### PR TITLE
Bump images to zed

### DIFF
--- a/config/samples/manila_v1beta1_manila.yaml
+++ b/config/samples/manila_v1beta1_manila.yaml
@@ -13,11 +13,11 @@ spec:
   databaseUser: manila
   manilaAPI:
     replicas: 1
-    containerImage: quay.io/tripleowallabycentos9/openstack-manila-api:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-manila-api:current-tripleo
   manilaScheduler:
     replicas: 1
-    containerImage: quay.io/tripleowallabycentos9/openstack-manila-scheduler:current-tripleo
+    containerImage: quay.io/tripleozedcentos9/openstack-manila-scheduler:current-tripleo
   manilaShares:
     share1:
-      containerImage: quay.io/tripleowallabycentos9/openstack-manila-share:current-tripleo
+      containerImage: quay.io/tripleozedcentos9/openstack-manila-share:current-tripleo
       replicas: 1


### PR DESCRIPTION
This change improves the sample/ files used to deploy a simple manila CR, bumping the containerImages to zed.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>