### PR TITLE
Show overall Manila status in CLI

### DIFF
--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -15,7 +15,16 @@ spec:
     singular: manila
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Manila is the Schema for the manilas API

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -125,6 +125,8 @@ type ManilaStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
+//+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 
 // Manila is the Schema for the manilas API
 type Manila struct {

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -15,7 +15,16 @@ spec:
     singular: manila
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Manila is the Schema for the manilas API


### PR DESCRIPTION
This patch adds the `Status` and `Message` columns so we can print the `status` of the services deployed by manila-operator.