### PR TITLE
Fix rbac, serviceaccount and kubebuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+DEFAULT_IMG ?= quay.io/openstack-k8s-operators/manila-operator:latest
+IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 

--- a/api/bases/manila.openstack.org_manilaapis.yaml
+++ b/api/bases/manila.openstack.org_manilaapis.yaml
@@ -1889,11 +1889,11 @@ spec:
                 type: object
               passwordSelectors:
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password from the Secret
                 properties:
                   admin:
                     default: ManilaPassword
-                    description: Database - Selector to get the manila service password
+                    description: Service - Selector to get the manila service password
                       from the Secret
                     type: string
                   database:

--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -3854,11 +3854,11 @@ spec:
                     type: object
                   passwordSelectors:
                     description: PasswordSelectors - Selectors to identify the DB
-                      and AdminUser password and TransportURL from the Secret
+                      and ServiceUser password from the Secret
                     properties:
                       admin:
                         default: ManilaPassword
-                        description: Database - Selector to get the manila service
+                        description: Service - Selector to get the manila service
                           password from the Secret
                         type: string
                       database:
@@ -5881,11 +5881,11 @@ spec:
                     type: object
                   passwordSelectors:
                     description: PasswordSelectors - Selectors to identify the DB
-                      and TransportURL from the Secret
+                      and ServiceUser password from the Secret
                     properties:
                       admin:
                         default: ManilaPassword
-                        description: Database - Selector to get the manila service
+                        description: Service - Selector to get the manila service
                           password from the Secret
                         type: string
                       database:
@@ -7956,11 +7956,11 @@ spec:
                       type: object
                     passwordSelectors:
                       description: PasswordSelectors - Selectors to identify the DB
-                        and TransportURL from the Secret
+                        and ServiceUser password from the Secret
                       properties:
                         admin:
                           default: ManilaPassword
-                          description: Database - Selector to get the manila service
+                          description: Service - Selector to get the manila service
                             password from the Secret
                           type: string
                         database:
@@ -8024,11 +8024,11 @@ spec:
                 type: object
               passwordSelectors:
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password from the Secret
                 properties:
                   admin:
                     default: ManilaPassword
-                    description: Database - Selector to get the manila service password
+                    description: Service - Selector to get the manila service password
                       from the Secret
                     type: string
                   database:

--- a/api/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/api/bases/manila.openstack.org_manilaschedulers.yaml
@@ -1889,11 +1889,11 @@ spec:
                 type: object
               passwordSelectors:
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password from the Secret
                 properties:
                   admin:
                     default: ManilaPassword
-                    description: Database - Selector to get the manila service password
+                    description: Service - Selector to get the manila service password
                       from the Secret
                     type: string
                   database:

--- a/api/bases/manila.openstack.org_manilashares.yaml
+++ b/api/bases/manila.openstack.org_manilashares.yaml
@@ -1889,11 +1889,11 @@ spec:
                 type: object
               passwordSelectors:
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password from the Secret
                 properties:
                   admin:
                     default: ManilaPassword
-                    description: Database - Selector to get the manila service password
+                    description: Service - Selector to get the manila service password
                       from the Secret
                     type: string
                   database:

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -25,7 +25,7 @@ type PasswordSelector struct {
 	Database string `json:"database,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="ManilaPassword"
-	// Database - Selector to get the manila service password from the Secret
+	// Service - Selector to get the manila service password from the Secret
 	Service string `json:"admin,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="TransportURL"

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -55,7 +55,7 @@ type ManilaSpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and AdminUser password and TransportURL from the Secret
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/manilaapi_types.go
+++ b/api/v1beta1/manilaapi_types.go
@@ -53,7 +53,7 @@ type ManilaAPISpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and AdminUser password and TransportURL from the Secret
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/manilascheduler_types.go
+++ b/api/v1beta1/manilascheduler_types.go
@@ -57,7 +57,7 @@ type ManilaSchedulerSpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and TransportURL from the Secret
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/manilashare_types.go
+++ b/api/v1beta1/manilashare_types.go
@@ -57,7 +57,7 @@ type ManilaShareSpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and TransportURL from the Secret
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/manila.openstack.org_manilaapis.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaapis.yaml
@@ -1889,11 +1889,11 @@ spec:
                 type: object
               passwordSelectors:
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password from the Secret
                 properties:
                   admin:
                     default: ManilaPassword
-                    description: Database - Selector to get the manila service password
+                    description: Service - Selector to get the manila service password
                       from the Secret
                     type: string
                   database:

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -3854,11 +3854,11 @@ spec:
                     type: object
                   passwordSelectors:
                     description: PasswordSelectors - Selectors to identify the DB
-                      and AdminUser password and TransportURL from the Secret
+                      and ServiceUser password from the Secret
                     properties:
                       admin:
                         default: ManilaPassword
-                        description: Database - Selector to get the manila service
+                        description: Service - Selector to get the manila service
                           password from the Secret
                         type: string
                       database:
@@ -5881,11 +5881,11 @@ spec:
                     type: object
                   passwordSelectors:
                     description: PasswordSelectors - Selectors to identify the DB
-                      and TransportURL from the Secret
+                      and ServiceUser password from the Secret
                     properties:
                       admin:
                         default: ManilaPassword
-                        description: Database - Selector to get the manila service
+                        description: Service - Selector to get the manila service
                           password from the Secret
                         type: string
                       database:
@@ -7956,11 +7956,11 @@ spec:
                       type: object
                     passwordSelectors:
                       description: PasswordSelectors - Selectors to identify the DB
-                        and TransportURL from the Secret
+                        and ServiceUser password from the Secret
                       properties:
                         admin:
                           default: ManilaPassword
-                          description: Database - Selector to get the manila service
+                          description: Service - Selector to get the manila service
                             password from the Secret
                           type: string
                         database:
@@ -8024,11 +8024,11 @@ spec:
                 type: object
               passwordSelectors:
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password from the Secret
                 properties:
                   admin:
                     default: ManilaPassword
-                    description: Database - Selector to get the manila service password
+                    description: Service - Selector to get the manila service password
                       from the Secret
                     type: string
                   database:

--- a/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
@@ -1889,11 +1889,11 @@ spec:
                 type: object
               passwordSelectors:
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password from the Secret
                 properties:
                   admin:
                     default: ManilaPassword
-                    description: Database - Selector to get the manila service password
+                    description: Service - Selector to get the manila service password
                       from the Secret
                     type: string
                   database:

--- a/config/crd/bases/manila.openstack.org_manilashares.yaml
+++ b/config/crd/bases/manila.openstack.org_manilashares.yaml
@@ -1889,11 +1889,11 @@ spec:
                 type: object
               passwordSelectors:
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password from the Secret
                 properties:
                   admin:
                     default: ManilaPassword
-                    description: Database - Selector to get the manila service password
+                    description: Service - Selector to get the manila service password
                       from the Secret
                     type: string
                   database:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: quay.io/openstack-k8s-operators/manila-operator
   newTag: latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,6 +56,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -138,32 +145,6 @@ rules:
 - apiGroups:
   - manila.openstack.org
   resources:
-  - manilabackups
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - manila.openstack.org
-  resources:
-  - manilabackups/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - manila.openstack.org
-  resources:
-  - manilabackups/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - manila.openstack.org
-  resources:
   - manilas
   verbs:
   - create
@@ -235,32 +216,6 @@ rules:
   - manila.openstack.org
   resources:
   - manilashares/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - manila.openstack.org
-  resources:
-  - manilavolumes
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - manila.openstack.org
-  resources:
-  - manilavolumes/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - manila.openstack.org
-  resources:
-  - manilavolumes/status
   verbs:
   - get
   - patch

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: controller-manager
-  namespace: openstack
+  namespace: system
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -77,21 +77,18 @@ type ManilaReconciler struct {
 	Scheme  *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=manila.openstack.org,resources=manilas,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=manila.openstack.org,resources=manilas/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=manila.openstack.org,resources=manilas/finalizers,verbs=update
+// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilas,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilas/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilas/finalizers,verbs=update
 // +kubebuilder:rbac:groups=manila.openstack.org,resources=manilaapis,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=manila.openstack.org,resources=manilaapis/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=manila.openstack.org,resources=manilaapis/finalizers,verbs=update
 // +kubebuilder:rbac:groups=manila.openstack.org,resources=manilaschedulers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=manila.openstack.org,resources=manilaschedulers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=manila.openstack.org,resources=manilaschedulers/finalizers,verbs=update
-// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilabackups,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilabackups/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilabackups/finalizers,verbs=update
-// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilavolumes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilavolumes/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilavolumes/finalizers,verbs=update
+// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilashares,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilashares/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=manila.openstack.org,resources=manilashares/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;create;update;patch;delete;watch

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -80,6 +80,7 @@ type ManilaSchedulerReconciler struct {
 //+kubebuilder:rbac:groups=manila.openstack.org,resources=manilaschedulers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=manila.openstack.org,resources=manilaschedulers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=manila.openstack.org,resources=manilaschedulers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;create;update;patch;delete;watch

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -81,6 +81,7 @@ type ManilaShareReconciler struct {
 //+kubebuilder:rbac:groups=manila.openstack.org,resources=manilashares/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=manila.openstack.org,resources=manilashares/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;create;update;patch;delete;watch
 //+kubebuilder:rbac:groups=security.openshift.io,namespace=openstack,resources=securitycontextconstraints,resourceNames=privileged,verbs=use


### PR DESCRIPTION
This patch fixes an issue seen when deploying manila operator using the OLM pattern. kubebuilder is updated to add permissions to the right resources.