### PR TITLE
Add omitempty tag for slices

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -83,5 +83,5 @@ type MetalLBConfig struct {
 
 	// +kubebuilder:validation:Optional
 	// LoadBalancerIPs, request given IPs from the pool if available. Using a list to allow dual stack (IPv4/IPv6) support
-	LoadBalancerIPs []string `json:"loadBalancerIPs"`
+	LoadBalancerIPs []string `json:"loadBalancerIPs,omitempty"`
 }

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -101,7 +101,7 @@ type ManilaSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
-	ExtraMounts []ManilaExtraVolMounts `json:"extraMounts"`
+	ExtraMounts []ManilaExtraVolMounts `json:"extraMounts,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service. Setting

--- a/api/v1beta1/manilaapi_types.go
+++ b/api/v1beta1/manilaapi_types.go
@@ -89,15 +89,15 @@ type ManilaAPISpec struct {
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
-	ExtraMounts []ManilaExtraVolMounts `json:"extraMounts"`
+	ExtraMounts []ManilaExtraVolMounts `json:"extraMounts,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExternalEndpoints, expose a VIP via MetalLB on the pre-created address pool
-	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints"`
+	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints,omitempty"`
 }
 
 // ManilaAPIStatus defines the observed state of ManilaAPI

--- a/api/v1beta1/manilascheduler_types.go
+++ b/api/v1beta1/manilascheduler_types.go
@@ -93,11 +93,11 @@ type ManilaSchedulerSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
-	ExtraMounts []ManilaExtraVolMounts `json:"extraMounts"`
+	ExtraMounts []ManilaExtraVolMounts `json:"extraMounts,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 }
 
 // ManilaSchedulerStatus defines the observed state of ManilaScheduler

--- a/api/v1beta1/manilashare_types.go
+++ b/api/v1beta1/manilashare_types.go
@@ -93,11 +93,11 @@ type ManilaShareSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
-	ExtraMounts []ManilaExtraVolMounts `json:"extraMounts"`
+	ExtraMounts []ManilaExtraVolMounts `json:"extraMounts,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 }
 
 // ManilaShareStatus defines the observed state of ManilaShare


### PR DESCRIPTION
When manila is added to the OpenstackControlPlane, we can observe the job failing with a similar error:

```
The OpenStackControlPlane "openstack" is invalid:

spec.manila.template.manilaScheduler.networkAttachments: Invalid value: "null": spec.manila.template.manilaScheduler.networkAttachments in body must be of type array: "null"
```

This patch adds the "omitempty" tag to the affected arrays specified in the API.