### PR TITLE
Remove description from Manila CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ VERIFY_TLS ?= true
 GOWORK ?= off
 export GOWORK := $(GOWORK)
 
+
+GOLINT_TIMEOUT = 100s
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests
 # To enable set flag to true
@@ -107,6 +109,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
+manifests: CRDDESC_OVERRIDE=:maxDescLen=0
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd$(CRDDESC_OVERRIDE) webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
 	rm -f api/bases/* && cp -a config/crd/bases api/
@@ -346,5 +349,5 @@ tidy: fmt
 
 .PHONY: golangci-lint
 golangci-lint:
-	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
-	$(LOCALBIN)/golangci-lint run --fix
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
+	$(LOCALBIN)/golangci-lint run --fix --timeout $(GOLINT_TIMEOUT)

--- a/api/bases/manila.openstack.org_manilaapis.yaml
+++ b/api/bases/manila.openstack.org_manilaapis.yaml
@@ -31,160 +31,85 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ManilaAPI is the Schema for the manilaapis API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ManilaAPISpec defines the desired state of ManilaAPI
             properties:
               containerImage:
-                description: ContainerImage - Manila API Container Image URL
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
-                description: CustomServiceConfig - customize the service config using
-                  this parameter to change service defaults, or overwrite rendered
-                  information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
                 type: string
               databaseHostname:
-                description: DatabaseHostname - Manila Database Hostname
                 type: string
               databaseUser:
                 default: manila
-                description: 'DatabaseUser - optional username used for manila DB,
-                  defaults to manila TODO: -> implement needs work in mariadb-operator,
-                  right now only manila'
                 type: string
               debug:
-                description: Debug - enable debug for different deploy stages. If
-                  an init container is used, it runs and the actual action pod gets
-                  started with sleep infinity
                 properties:
                   initContainer:
                     default: false
-                    description: initContainer enable debug (waits until /tmp/stop-init-container
-                      disappears)
                     type: boolean
                   service:
                     default: false
-                    description: service enable debug
                     type: boolean
                 type: object
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  .
                 type: object
               externalEndpoints:
-                description: ExternalEndpoints, expose a VIP via MetalLB on the pre-created
-                  address pool
                 items:
-                  description: MetalLBConfig to configure the MetalLB loadbalancer
-                    service
                   properties:
                     endpoint:
-                      description: Endpoint, OpenStack endpoint this service maps
-                        to
                       enum:
                       - internal
                       - public
                       type: string
                     ipAddressPool:
-                      description: IPAddressPool expose VIP via MetalLB on the IPAddressPool
                       minLength: 1
                       type: string
                     loadBalancerIPs:
-                      description: LoadBalancerIPs, request given IPs from the pool
-                        if available. Using a list to allow dual stack (IPv4/IPv6)
-                        support
                       items:
                         type: string
                       type: array
                     sharedIP:
                       default: true
-                      description: SharedIP if true, VIP/VIPs get shared with multiple
-                        services
                       type: boolean
                     sharedIPKey:
                       default: ""
-                      description: SharedIPKey specifies the sharing key which gets
-                        set as the annotation on the LoadBalancer service. Services
-                        which share the same VIP must have the same SharedIPKey. Defaults
-                        to the IPAddressPool if SharedIP is true, but no SharedIPKey
-                        specified.
                       type: string
                   required:
                   - ipAddressPool
                   type: object
                 type: array
               extraMounts:
-                description: ExtraMounts containing conf files and credentials
                 items:
-                  description: ManilaExtraVolMounts exposes additional parameters
-                    processed by the manila-operator and defines the common VolMounts
-                    structure provided by the main storage module
                   properties:
                     extraVol:
                       items:
-                        description: VolMounts is the data structure used to expose
-                          Volumes and Mounts that can be added to a pod according
-                          to the defined Propagation policy
                         properties:
                           extraVolType:
-                            description: Label associated to a given extraMount
                             type: string
                           mounts:
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -192,262 +117,110 @@ spec:
                               type: object
                             type: array
                           propagation:
-                            description: Propagation defines which pod should mount
-                              the volume
                             items:
-                              description: PropagationType identifies the Service,
-                                Group or instance (e.g. the backend) that receives
-                                an Extra Volume that can potentially be mounted
                               type: string
                             type: array
                           volumes:
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'awsElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly value true will force
-                                        the readOnly setting in VolumeMounts. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: boolean
                                     volumeID:
-                                      description: 'volumeID is unique ID of the persistent
-                                        disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'monitors is Required: Monitors
-                                        is a collection of Ceph monitors More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: boolean
                                     secretFile:
-                                      description: 'secretFile is Optional: SecretFile
-                                        is the path to key ring for User, default
-                                        is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                     secretRef:
-                                      description: 'secretRef is Optional: SecretRef
-                                        is reference to the authentication secret
-                                        for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is optional: User is the
-                                        rados user name, default is admin More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is optional: points
-                                        to a secret object containing parameters used
-                                        to connect to OpenStack.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: 'volumeID used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -455,159 +228,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
                                       type: string
                                     fsType:
-                                      description: fsType to mount. Ex. "ext4", "xfs",
-                                        "ntfs". If not provided, the empty value is
-                                        passed to the associated CSI driver which
-                                        will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: nodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: readOnly specifies a read-only
-                                        configuration for the volume. Defaults to
-                                        false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: volumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -619,136 +299,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of
-                                        storage medium should back this directory.
-                                        The default is "" which means to use the node''s
-                                        default medium. Must be an empty string (default)
-                                        or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'sizeLimit is the total amount
-                                        of local storage required for this EmptyDir
-                                        volume. The size limit is also applicable
-                                        for memory medium. The maximum usage on memory
-                                        medium EmptyDir would be the minimum value
-                                        between the SizeLimit specified here and the
-                                        sum of memory limits of all containers in
-                                        a pod. The default is nil which means that
-                                        the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "ephemeral represents a volume that
-                                    is handled by a cluster storage driver. The volume's
-                                    lifecycle is tied to the pod that defines it -
-                                    it will be created before the pod starts, and
-                                    deleted when the pod is removed. \n Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from
-                                    snapshot or capacity tracking are needed, c) the
-                                    storage driver is specified through a storage
-                                    class, and d) the storage driver supports dynamic
-                                    volume provisioning through a PersistentVolumeClaim
-                                    (see EphemeralVolumeSource for more information
-                                    on the connection between this volume type and
-                                    PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                    or one of the vendor-specific APIs for volumes
-                                    that persist for longer than the lifecycle of
-                                    an individual pod. \n Use CSI for light-weight
-                                    local ephemeral volumes if the CSI driver is meant
-                                    to be used that way - see the documentation of
-                                    the driver for more information. \n A pod can
-                                    use both types of ephemeral volumes and persistent
-                                    volumes at the same time."
                                   properties:
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations
-                                            that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
                                           type: object
                                         spec:
-                                          description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: 'accessModes contains the
-                                                desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'dataSource field can be
-                                                used to specify either: * An existing
-                                                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external
-                                                controller can support the specified
-                                                data source, it will create a new
-                                                volume based on the contents of the
-                                                specified data source. When the AnyVolumeDataSource
-                                                feature gate is enabled, dataSource
-                                                contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be
-                                                copied to dataSource when dataSourceRef.namespace
-                                                is not specified. If the namespace
-                                                is specified, then dataSourceRef will
-                                                not be copied to dataSource.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -756,113 +335,25 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: 'dataSourceRef specifies
-                                                the object from which to populate
-                                                the volume with data, if a non-empty
-                                                volume is desired. This may be any
-                                                object from a non-empty API group
-                                                (non core object) or a PersistentVolumeClaim
-                                                object. When this field is specified,
-                                                volume binding will only succeed if
-                                                the type of the specified object matches
-                                                some installed volume populator or
-                                                dynamic provisioner. This field will
-                                                replace the functionality of the dataSource
-                                                field and as such if both fields are
-                                                non-empty, they must have the same
-                                                value. For backwards compatibility,
-                                                when namespace isn''t specified in
-                                                dataSourceRef, both fields (dataSource
-                                                and dataSourceRef) will be set to
-                                                the same value automatically if one
-                                                of them is empty and the other is
-                                                non-empty. When namespace is specified
-                                                in dataSourceRef, dataSource isn''t
-                                                set to the same value and must be
-                                                empty. There are three important differences
-                                                between dataSource and dataSourceRef:
-                                                * While dataSource only allows two
-                                                specific types of objects, dataSourceRef
-                                                allows any non-core object, as well
-                                                as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed
-                                                values (dropping them), dataSourceRef
-                                                preserves all values, and generates
-                                                an error if a disallowed value is
-                                                specified. * While dataSource only
-                                                allows local objects, dataSourceRef
-                                                allows objects in any namespaces.
-                                                (Beta) Using this field requires the
-                                                AnyVolumeDataSource feature gate to
-                                                be enabled. (Alpha) Using the namespace
-                                                field of dataSourceRef requires the
-                                                CrossNamespaceVolumeDataSource feature
-                                                gate to be enabled.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: Namespace is the namespace
-                                                    of resource being referenced Note
-                                                    that when a namespace is specified,
-                                                    a gateway.networking.k8s.io/ReferenceGrant
-                                                    object is required in the referent
-                                                    namespace to allow that namespace's
-                                                    owner to accept the reference.
-                                                    See the ReferenceGrant documentation
-                                                    for details. (Alpha) This field
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'resources represents the
-                                                minimum resources the volume should
-                                                have. If RecoverVolumeExpansionFailure
-                                                feature is enabled users are allowed
-                                                to specify resource requirements that
-                                                are lower than previous value but
-                                                must still be higher than capacity
-                                                recorded in the status field of the
-                                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                               properties:
                                                 claims:
-                                                  description: "Claims lists the names
-                                                    of resources, defined in spec.resourceClaims,
-                                                    that are used by this container.
-                                                    \n This is an alpha field and
-                                                    requires enabling the DynamicResourceAllocation
-                                                    feature gate. \n This field is
-                                                    immutable."
                                                   items:
-                                                    description: ResourceClaim references
-                                                      one entry in PodSpec.ResourceClaims.
                                                     properties:
                                                       name:
-                                                        description: Name must match
-                                                          the name of one entry in
-                                                          pod.spec.resourceClaims
-                                                          of the Pod where this field
-                                                          is used. It makes that resource
-                                                          available inside a container.
                                                         type: string
                                                     required:
                                                     - name
@@ -878,9 +369,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the
-                                                    maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -889,54 +377,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
-                                                    the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -948,33 +400,14 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: 'storageClassName is the
-                                                name of the StorageClass required
-                                                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what
-                                                type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -982,84 +415,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. TODO: how do we prevent errors
-                                        in the filesystem from compromising the machine'
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'wwids Optional: FC volume world
-                                        wide identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: flexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". The default filesystem depends
-                                        on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: 'readOnly is Optional: defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is Optional: secretRef
-                                        is reference to the secret object containing
-                                        sensitive information to pass to the plugin
-                                        scripts. This may be empty if no secret object
-                                        is specified. If the secret object contains
-                                        more than one secret, all secrets are passed
-                                        to the plugin scripts.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -1067,205 +454,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: datasetName is Name of the dataset
-                                        stored as metadata -> name on the dataset
-                                        for Flocker should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'gcePersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   properties:
                                     fsType:
-                                      description: 'fsType is filesystem type of the
-                                        volume that you want to mount. Tip: Ensure
-                                        that the filesystem type is supported by the
-                                        host operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'pdName is unique name of the PD
-                                        resource in GCE. Used to identify the disk
-                                        in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'gitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
                                   properties:
                                     directory:
-                                      description: directory is the target directory
-                                        name. Must not contain or start with '..'.  If
-                                        '.' is supplied, the volume directory will
-                                        be the git repository.  Otherwise, if specified,
-                                        the volume will contain the git repository
-                                        in the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                   properties:
                                     endpoints:
-                                      description: 'endpoints is the endpoint name
-                                        that details Glusterfs topology. More info:
-                                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     path:
-                                      description: 'path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'iscsi represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     initiatorName:
-                                      description: initiatorName is the custom iSCSI
-                                        Initiator Name. If initiatorName is specified
-                                        with iscsiInterface simultaneously, new iSCSI
-                                        interface <target portal>:<volume name> will
-                                        be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iscsiInterface is the interface
-                                        Name that uses an iSCSI transport. Defaults
-                                        to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: portals is the iSCSI Target Portal
-                                        List. The portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: targetPortal is iSCSI Target Portal.
-                                        The Portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -1273,166 +543,67 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'name of the volume. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 nfs:
-                                  description: 'nfs represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   properties:
                                     path:
-                                      description: 'path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: boolean
                                     server:
-                                      description: 'server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly
-                                        setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used
-                                        to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777
-                                        or a decimal value between 0 and 511. YAML
-                                        accepts both octal and decimal values, JSON
-                                        requires decimal values for mode bits. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced ConfigMap
-                                                  will be projected into the volume
-                                                  as a file whose name is the key
-                                                  and content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1440,105 +611,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode
-                                                        bits used to set permissions
-                                                        on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -1550,58 +658,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced Secret will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1609,52 +675,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
                                                 type: string
                                             required:
                                             - path
@@ -1663,162 +696,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: group to map volume access to Default
-                                        is no group
                                       type: string
                                     readOnly:
-                                      description: readOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
                                       type: string
                                     tenant:
-                                      description: tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
                                       type: string
                                     user:
-                                      description: user to map volume access to Defaults
-                                        to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'rbd represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     image:
-                                      description: 'image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: 'keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     monitors:
-                                      description: 'monitors is a collection of Ceph
-                                        monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'pool is the rados pool name. Default
-                                        is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is the rados user name. Default
-                                        is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: storageMode indicates whether the
-                                        storage for a volume should be ThickProvisioned
-                                        or ThinProvisioned. Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the name of a volume
-                                        already created in the ScaleIO system that
-                                        is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -1826,63 +773,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -1890,85 +793,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the
-                                        secret in the pod''s namespace to use. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: volumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: volumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -1991,57 +845,35 @@ spec:
                   type: object
                 type: array
               networkAttachments:
-                description: NetworkAttachments is a list of NetworkAttachment resource
-                  names to expose the services to the given network
                 items:
                   type: string
                 type: array
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes running
-                  this service. Setting here overrides any global NodeSelector settings
-                  within the Manila CR.
                 type: object
               passwordSelectors:
                 default:
                   database: ManilaDatabasePassword
                   service: ManilaPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: ManilaDatabasePassword
-                    description: 'Database - Selector to get the manila database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: ManilaPassword
-                    description: Service - Selector to get the manila service password
-                      from the Secret
                     type: string
                 type: object
               replicas:
                 default: 1
-                description: Replicas - Manila API Replicas
                 format: int32
                 type: integer
               resources:
-                description: Resources - Compute Resources required by this service
-                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                 properties:
                   claims:
-                    description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable."
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: Name must match the name of one entry in pod.spec.resourceClaims
-                            of the Pod where this field is used. It makes that resource
-                            available inside a container.
                           type: string
                       required:
                       - name
@@ -2057,8 +889,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -2067,71 +897,39 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               secret:
-                description: Secret containing OpenStack password information for
-                  ManilaDatabasePassword, AdminPassword
                 type: string
               serviceUser:
                 default: manila
-                description: ServiceUser - optional username used for this service
-                  to register in manila
                 type: string
               transportURLSecret:
-                description: Secret containing RabbitMq transport URL
                 type: string
             type: object
           status:
-            description: ManilaAPIStatus defines the observed state of ManilaAPI
             properties:
               apiEndpoints:
                 additionalProperties:
                   additionalProperties:
                     type: string
                   type: object
-                description: API endpoints
                 type: object
               conditions:
-                description: Conditions
                 items:
-                  description: Condition defines an observation of a API resource
-                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase.
                       type: string
                     severity:
-                      description: Severity provides a classification of Reason code,
-                        so the current situation is immediately understandable and
-                        could act accordingly. It is meant for situations where Status=False
-                        and it should be indicated if it is just informational, warning
-                        (next reconciliation might fix it) or an error (e.g. DB create
-                        issue and no actions to automatically resolve the issue can/should
-                        be done). For conditions where Status=Unknown or Status=True
-                        the Severity should be SeverityNone.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase.
                       type: string
                   required:
                   - lastTransitionTime
@@ -2142,23 +940,19 @@ spec:
               hash:
                 additionalProperties:
                   type: string
-                description: Map of hashes to track e.g. job status
                 type: object
               networkAttachments:
                 additionalProperties:
                   items:
                     type: string
                   type: array
-                description: NetworkAttachments status of the deployment pods
                 type: object
               readyCount:
-                description: ReadyCount of Manila API instances
                 format: int32
                 type: integer
               serviceIDs:
                 additionalProperties:
                   type: string
-                description: ServiceIDs
                 type: object
             type: object
         type: object

--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -27,117 +27,58 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Manila is the Schema for the manilas API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ManilaSpec defines the desired state of Manila
             properties:
               customServiceConfig:
                 default: '# add your customization here'
-                description: CustomServiceConfig - customize the service config for
-                  all Manila services using this parameter to change service defaults,
-                  or overwrite rendered information using raw OpenStack config format.
-                  The content gets added to to /etc/<service>/<service>.conf.d directory
-                  as custom.conf file.
                 type: string
               databaseInstance:
-                description: MariaDB instance name Right now required by the maridb-operator
-                  to get the credentials from the instance to create the DB Might
-                  not be required in future
                 type: string
               databaseUser:
                 default: manila
-                description: 'DatabaseUser - optional username used for manila DB,
-                  defaults to manila TODO: -> implement needs work in mariadb-operator,
-                  right now only manila'
                 type: string
               debug:
-                description: Debug - enable debug for different deploy stages. If
-                  an init container is used, it runs and the actual action pod gets
-                  started with sleep infinity
                 properties:
                   dbInitContainer:
                     default: false
-                    description: dbInitContainer enable debug (waits until /tmp/stop-init-container
-                      disappears)
                     type: boolean
                   dbSync:
                     default: false
-                    description: dbSync enable debug
                     type: boolean
                 type: object
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: 'ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  . TODO: -> implement'
                 type: object
               extraMounts:
-                description: ExtraMounts containing conf files and credentials
                 items:
-                  description: ManilaExtraVolMounts exposes additional parameters
-                    processed by the manila-operator and defines the common VolMounts
-                    structure provided by the main storage module
                   properties:
                     extraVol:
                       items:
-                        description: VolMounts is the data structure used to expose
-                          Volumes and Mounts that can be added to a pod according
-                          to the defined Propagation policy
                         properties:
                           extraVolType:
-                            description: Label associated to a given extraMount
                             type: string
                           mounts:
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -145,262 +86,110 @@ spec:
                               type: object
                             type: array
                           propagation:
-                            description: Propagation defines which pod should mount
-                              the volume
                             items:
-                              description: PropagationType identifies the Service,
-                                Group or instance (e.g. the backend) that receives
-                                an Extra Volume that can potentially be mounted
                               type: string
                             type: array
                           volumes:
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'awsElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly value true will force
-                                        the readOnly setting in VolumeMounts. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: boolean
                                     volumeID:
-                                      description: 'volumeID is unique ID of the persistent
-                                        disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'monitors is Required: Monitors
-                                        is a collection of Ceph monitors More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: boolean
                                     secretFile:
-                                      description: 'secretFile is Optional: SecretFile
-                                        is the path to key ring for User, default
-                                        is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                     secretRef:
-                                      description: 'secretRef is Optional: SecretRef
-                                        is reference to the authentication secret
-                                        for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is optional: User is the
-                                        rados user name, default is admin More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is optional: points
-                                        to a secret object containing parameters used
-                                        to connect to OpenStack.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: 'volumeID used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -408,159 +197,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
                                       type: string
                                     fsType:
-                                      description: fsType to mount. Ex. "ext4", "xfs",
-                                        "ntfs". If not provided, the empty value is
-                                        passed to the associated CSI driver which
-                                        will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: nodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: readOnly specifies a read-only
-                                        configuration for the volume. Defaults to
-                                        false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: volumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -572,136 +268,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of
-                                        storage medium should back this directory.
-                                        The default is "" which means to use the node''s
-                                        default medium. Must be an empty string (default)
-                                        or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'sizeLimit is the total amount
-                                        of local storage required for this EmptyDir
-                                        volume. The size limit is also applicable
-                                        for memory medium. The maximum usage on memory
-                                        medium EmptyDir would be the minimum value
-                                        between the SizeLimit specified here and the
-                                        sum of memory limits of all containers in
-                                        a pod. The default is nil which means that
-                                        the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "ephemeral represents a volume that
-                                    is handled by a cluster storage driver. The volume's
-                                    lifecycle is tied to the pod that defines it -
-                                    it will be created before the pod starts, and
-                                    deleted when the pod is removed. \n Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from
-                                    snapshot or capacity tracking are needed, c) the
-                                    storage driver is specified through a storage
-                                    class, and d) the storage driver supports dynamic
-                                    volume provisioning through a PersistentVolumeClaim
-                                    (see EphemeralVolumeSource for more information
-                                    on the connection between this volume type and
-                                    PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                    or one of the vendor-specific APIs for volumes
-                                    that persist for longer than the lifecycle of
-                                    an individual pod. \n Use CSI for light-weight
-                                    local ephemeral volumes if the CSI driver is meant
-                                    to be used that way - see the documentation of
-                                    the driver for more information. \n A pod can
-                                    use both types of ephemeral volumes and persistent
-                                    volumes at the same time."
                                   properties:
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations
-                                            that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
                                           type: object
                                         spec:
-                                          description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: 'accessModes contains the
-                                                desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'dataSource field can be
-                                                used to specify either: * An existing
-                                                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external
-                                                controller can support the specified
-                                                data source, it will create a new
-                                                volume based on the contents of the
-                                                specified data source. When the AnyVolumeDataSource
-                                                feature gate is enabled, dataSource
-                                                contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be
-                                                copied to dataSource when dataSourceRef.namespace
-                                                is not specified. If the namespace
-                                                is specified, then dataSourceRef will
-                                                not be copied to dataSource.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -709,113 +304,25 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: 'dataSourceRef specifies
-                                                the object from which to populate
-                                                the volume with data, if a non-empty
-                                                volume is desired. This may be any
-                                                object from a non-empty API group
-                                                (non core object) or a PersistentVolumeClaim
-                                                object. When this field is specified,
-                                                volume binding will only succeed if
-                                                the type of the specified object matches
-                                                some installed volume populator or
-                                                dynamic provisioner. This field will
-                                                replace the functionality of the dataSource
-                                                field and as such if both fields are
-                                                non-empty, they must have the same
-                                                value. For backwards compatibility,
-                                                when namespace isn''t specified in
-                                                dataSourceRef, both fields (dataSource
-                                                and dataSourceRef) will be set to
-                                                the same value automatically if one
-                                                of them is empty and the other is
-                                                non-empty. When namespace is specified
-                                                in dataSourceRef, dataSource isn''t
-                                                set to the same value and must be
-                                                empty. There are three important differences
-                                                between dataSource and dataSourceRef:
-                                                * While dataSource only allows two
-                                                specific types of objects, dataSourceRef
-                                                allows any non-core object, as well
-                                                as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed
-                                                values (dropping them), dataSourceRef
-                                                preserves all values, and generates
-                                                an error if a disallowed value is
-                                                specified. * While dataSource only
-                                                allows local objects, dataSourceRef
-                                                allows objects in any namespaces.
-                                                (Beta) Using this field requires the
-                                                AnyVolumeDataSource feature gate to
-                                                be enabled. (Alpha) Using the namespace
-                                                field of dataSourceRef requires the
-                                                CrossNamespaceVolumeDataSource feature
-                                                gate to be enabled.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: Namespace is the namespace
-                                                    of resource being referenced Note
-                                                    that when a namespace is specified,
-                                                    a gateway.networking.k8s.io/ReferenceGrant
-                                                    object is required in the referent
-                                                    namespace to allow that namespace's
-                                                    owner to accept the reference.
-                                                    See the ReferenceGrant documentation
-                                                    for details. (Alpha) This field
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'resources represents the
-                                                minimum resources the volume should
-                                                have. If RecoverVolumeExpansionFailure
-                                                feature is enabled users are allowed
-                                                to specify resource requirements that
-                                                are lower than previous value but
-                                                must still be higher than capacity
-                                                recorded in the status field of the
-                                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                               properties:
                                                 claims:
-                                                  description: "Claims lists the names
-                                                    of resources, defined in spec.resourceClaims,
-                                                    that are used by this container.
-                                                    \n This is an alpha field and
-                                                    requires enabling the DynamicResourceAllocation
-                                                    feature gate. \n This field is
-                                                    immutable."
                                                   items:
-                                                    description: ResourceClaim references
-                                                      one entry in PodSpec.ResourceClaims.
                                                     properties:
                                                       name:
-                                                        description: Name must match
-                                                          the name of one entry in
-                                                          pod.spec.resourceClaims
-                                                          of the Pod where this field
-                                                          is used. It makes that resource
-                                                          available inside a container.
                                                         type: string
                                                     required:
                                                     - name
@@ -831,9 +338,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the
-                                                    maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -842,54 +346,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
-                                                    the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -901,33 +369,14 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: 'storageClassName is the
-                                                name of the StorageClass required
-                                                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what
-                                                type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -935,84 +384,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. TODO: how do we prevent errors
-                                        in the filesystem from compromising the machine'
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'wwids Optional: FC volume world
-                                        wide identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: flexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". The default filesystem depends
-                                        on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: 'readOnly is Optional: defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is Optional: secretRef
-                                        is reference to the secret object containing
-                                        sensitive information to pass to the plugin
-                                        scripts. This may be empty if no secret object
-                                        is specified. If the secret object contains
-                                        more than one secret, all secrets are passed
-                                        to the plugin scripts.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -1020,205 +423,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: datasetName is Name of the dataset
-                                        stored as metadata -> name on the dataset
-                                        for Flocker should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'gcePersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   properties:
                                     fsType:
-                                      description: 'fsType is filesystem type of the
-                                        volume that you want to mount. Tip: Ensure
-                                        that the filesystem type is supported by the
-                                        host operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'pdName is unique name of the PD
-                                        resource in GCE. Used to identify the disk
-                                        in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'gitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
                                   properties:
                                     directory:
-                                      description: directory is the target directory
-                                        name. Must not contain or start with '..'.  If
-                                        '.' is supplied, the volume directory will
-                                        be the git repository.  Otherwise, if specified,
-                                        the volume will contain the git repository
-                                        in the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                   properties:
                                     endpoints:
-                                      description: 'endpoints is the endpoint name
-                                        that details Glusterfs topology. More info:
-                                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     path:
-                                      description: 'path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'iscsi represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     initiatorName:
-                                      description: initiatorName is the custom iSCSI
-                                        Initiator Name. If initiatorName is specified
-                                        with iscsiInterface simultaneously, new iSCSI
-                                        interface <target portal>:<volume name> will
-                                        be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iscsiInterface is the interface
-                                        Name that uses an iSCSI transport. Defaults
-                                        to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: portals is the iSCSI Target Portal
-                                        List. The portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: targetPortal is iSCSI Target Portal.
-                                        The Portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -1226,166 +512,67 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'name of the volume. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 nfs:
-                                  description: 'nfs represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   properties:
                                     path:
-                                      description: 'path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: boolean
                                     server:
-                                      description: 'server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly
-                                        setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used
-                                        to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777
-                                        or a decimal value between 0 and 511. YAML
-                                        accepts both octal and decimal values, JSON
-                                        requires decimal values for mode bits. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced ConfigMap
-                                                  will be projected into the volume
-                                                  as a file whose name is the key
-                                                  and content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1393,105 +580,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode
-                                                        bits used to set permissions
-                                                        on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -1503,58 +627,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced Secret will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1562,52 +644,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
                                                 type: string
                                             required:
                                             - path
@@ -1616,162 +665,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: group to map volume access to Default
-                                        is no group
                                       type: string
                                     readOnly:
-                                      description: readOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
                                       type: string
                                     tenant:
-                                      description: tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
                                       type: string
                                     user:
-                                      description: user to map volume access to Defaults
-                                        to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'rbd represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     image:
-                                      description: 'image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: 'keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     monitors:
-                                      description: 'monitors is a collection of Ceph
-                                        monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'pool is the rados pool name. Default
-                                        is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is the rados user name. Default
-                                        is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: storageMode indicates whether the
-                                        storage for a volume should be ThickProvisioned
-                                        or ThinProvisioned. Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the name of a volume
-                                        already created in the ScaleIO system that
-                                        is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -1779,63 +742,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -1843,85 +762,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the
-                                        secret in the pod''s namespace to use. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: volumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: volumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -1944,148 +814,77 @@ spec:
                   type: object
                 type: array
               manilaAPI:
-                description: ManilaAPI - Spec definition for the API service of this
-                  Manila deployment
                 properties:
                   containerImage:
-                    description: ContainerImage - Manila API Container Image URL
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
-                    description: CustomServiceConfig - customize the service config
-                      using this parameter to change service defaults, or overwrite
-                      rendered information using raw OpenStack config format. The
-                      content gets added to to /etc/<service>/<service>.conf.d directory
-                      as custom.conf file.
                     type: string
                   databaseHostname:
-                    description: DatabaseHostname - Manila Database Hostname
                     type: string
                   databaseUser:
                     default: manila
-                    description: 'DatabaseUser - optional username used for manila
-                      DB, defaults to manila TODO: -> implement needs work in mariadb-operator,
-                      right now only manila'
                     type: string
                   debug:
-                    description: Debug - enable debug for different deploy stages.
-                      If an init container is used, it runs and the actual action
-                      pod gets started with sleep infinity
                     properties:
                       initContainer:
                         default: false
-                        description: initContainer enable debug (waits until /tmp/stop-init-container
-                          disappears)
                         type: boolean
                       service:
                         default: false
-                        description: service enable debug
                         type: boolean
                     type: object
                   defaultConfigOverwrite:
                     additionalProperties:
                       type: string
-                    description: ConfigOverwrite - interface to overwrite default
-                      config files like e.g. policy.json. But can also be used to
-                      add additional files. Those get added to the service config
-                      dir in /etc/<service> .
                     type: object
                   externalEndpoints:
-                    description: ExternalEndpoints, expose a VIP via MetalLB on the
-                      pre-created address pool
                     items:
-                      description: MetalLBConfig to configure the MetalLB loadbalancer
-                        service
                       properties:
                         endpoint:
-                          description: Endpoint, OpenStack endpoint this service maps
-                            to
                           enum:
                           - internal
                           - public
                           type: string
                         ipAddressPool:
-                          description: IPAddressPool expose VIP via MetalLB on the
-                            IPAddressPool
                           minLength: 1
                           type: string
                         loadBalancerIPs:
-                          description: LoadBalancerIPs, request given IPs from the
-                            pool if available. Using a list to allow dual stack (IPv4/IPv6)
-                            support
                           items:
                             type: string
                           type: array
                         sharedIP:
                           default: true
-                          description: SharedIP if true, VIP/VIPs get shared with
-                            multiple services
                           type: boolean
                         sharedIPKey:
                           default: ""
-                          description: SharedIPKey specifies the sharing key which
-                            gets set as the annotation on the LoadBalancer service.
-                            Services which share the same VIP must have the same SharedIPKey.
-                            Defaults to the IPAddressPool if SharedIP is true, but
-                            no SharedIPKey specified.
                           type: string
                       required:
                       - ipAddressPool
                       type: object
                     type: array
                   extraMounts:
-                    description: ExtraMounts containing conf files and credentials
                     items:
-                      description: ManilaExtraVolMounts exposes additional parameters
-                        processed by the manila-operator and defines the common VolMounts
-                        structure provided by the main storage module
                       properties:
                         extraVol:
                           items:
-                            description: VolMounts is the data structure used to expose
-                              Volumes and Mounts that can be added to a pod according
-                              to the defined Propagation policy
                             properties:
                               extraVolType:
-                                description: Label associated to a given extraMount
                                 type: string
                               mounts:
                                 items:
-                                  description: VolumeMount describes a mounting of
-                                    a Volume within a container.
                                   properties:
                                     mountPath:
-                                      description: Path within the container at which
-                                        the volume should be mounted.  Must not contain
-                                        ':'.
                                       type: string
                                     mountPropagation:
-                                      description: mountPropagation determines how
-                                        mounts are propagated from the host to container
-                                        and the other way around. When not set, MountPropagationNone
-                                        is used. This field is beta in 1.10.
                                       type: string
                                     name:
-                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
-                                      description: Mounted read-only if true, read-write
-                                        otherwise (false or unspecified). Defaults
-                                        to false.
                                       type: boolean
                                     subPath:
-                                      description: Path within the volume from which
-                                        the container's volume should be mounted.
-                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
-                                      description: Expanded path within the volume
-                                        from which the container's volume should be
-                                        mounted. Behaves similarly to SubPath but
-                                        environment variable references $(VAR_NAME)
-                                        are expanded using the container's environment.
-                                        Defaults to "" (volume's root). SubPathExpr
-                                        and SubPath are mutually exclusive.
                                       type: string
                                   required:
                                   - mountPath
@@ -2093,274 +892,110 @@ spec:
                                   type: object
                                 type: array
                               propagation:
-                                description: Propagation defines which pod should
-                                  mount the volume
                                 items:
-                                  description: PropagationType identifies the Service,
-                                    Group or instance (e.g. the backend) that receives
-                                    an Extra Volume that can potentially be mounted
                                   type: string
                                 type: array
                               volumes:
                                 items:
-                                  description: Volume represents a named volume in
-                                    a pod that may be accessed by any container in
-                                    the pod.
                                   properties:
                                     awsElasticBlockStore:
-                                      description: 'awsElasticBlockStore represents
-                                        an AWS Disk resource that is attached to a
-                                        kubelet''s host machine and then exposed to
-                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).'
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly value true will force
-                                            the readOnly setting in VolumeMounts.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                           type: boolean
                                         volumeID:
-                                          description: 'volumeID is unique ID of the
-                                            persistent disk resource in AWS (Amazon
-                                            EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     azureDisk:
-                                      description: azureDisk represents an Azure Data
-                                        Disk mount on the host and bind mount to the
-                                        pod.
                                       properties:
                                         cachingMode:
-                                          description: 'cachingMode is the Host Caching
-                                            mode: None, Read Only, Read Write.'
                                           type: string
                                         diskName:
-                                          description: diskName is the Name of the
-                                            data disk in the blob storage
                                           type: string
                                         diskURI:
-                                          description: diskURI is the URI of data
-                                            disk in the blob storage
                                           type: string
                                         fsType:
-                                          description: fsType is Filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         kind:
-                                          description: 'kind expected values are Shared:
-                                            multiple blob disks per storage account  Dedicated:
-                                            single blob disk per storage account  Managed:
-                                            azure managed data disk (only in managed
-                                            availability set). defaults to shared'
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                       required:
                                       - diskName
                                       - diskURI
                                       type: object
                                     azureFile:
-                                      description: azureFile represents an Azure File
-                                        Service mount on the host and bind mount to
-                                        the pod.
                                       properties:
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretName:
-                                          description: secretName is the  name of
-                                            secret that contains Azure Storage Account
-                                            Name and Key
                                           type: string
                                         shareName:
-                                          description: shareName is the azure share
-                                            Name
                                           type: string
                                       required:
                                       - secretName
                                       - shareName
                                       type: object
                                     cephfs:
-                                      description: cephFS represents a Ceph FS mount
-                                        on the host that shares a pod's lifetime
                                       properties:
                                         monitors:
-                                          description: 'monitors is Required: Monitors
-                                            is a collection of Ceph monitors More
-                                            info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           items:
                                             type: string
                                           type: array
                                         path:
-                                          description: 'path is Optional: Used as
-                                            the mounted root, rather than the full
-                                            Ceph tree, default is /'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: boolean
                                         secretFile:
-                                          description: 'secretFile is Optional: SecretFile
-                                            is the path to key ring for User, default
-                                            is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: string
                                         secretRef:
-                                          description: 'secretRef is Optional: SecretRef
-                                            is reference to the authentication secret
-                                            for User, default is empty. More info:
-                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is optional: User is
-                                            the rados user name, default is admin
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: string
                                       required:
                                       - monitors
                                       type: object
                                     cinder:
-                                      description: 'cinder represents a cinder volume
-                                        attached and mounted on kubelets host machine.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Examples:
-                                            "ext4", "xfs", "ntfs". Implicitly inferred
-                                            to be "ext4" if unspecified. More info:
-                                            https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is optional: points
-                                            to a secret object containing parameters
-                                            used to connect to OpenStack.'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeID:
-                                          description: 'volumeID used to identify
-                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     configMap:
-                                      description: configMap represents a configMap
-                                        that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced ConfigMap will be projected
-                                            into the volume as a file whose name is
-                                            the key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the ConfigMap,
-                                            the volume setup will error unless it
-                                            is marked optional. Paths must be relative
-                                            and may not contain the '..' path or start
-                                            with '..'.
                                           items:
-                                            description: Maps a string key to a path
-                                              within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
@@ -2368,168 +1003,66 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                         optional:
-                                          description: optional specify whether the
-                                            ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     csi:
-                                      description: csi (Container Storage Interface)
-                                        represents ephemeral storage that is handled
-                                        by certain external CSI drivers (Beta feature).
                                       properties:
                                         driver:
-                                          description: driver is the name of the CSI
-                                            driver that handles this volume. Consult
-                                            with your admin for the correct name as
-                                            registered in the cluster.
                                           type: string
                                         fsType:
-                                          description: fsType to mount. Ex. "ext4",
-                                            "xfs", "ntfs". If not provided, the empty
-                                            value is passed to the associated CSI
-                                            driver which will determine the default
-                                            filesystem to apply.
                                           type: string
                                         nodePublishSecretRef:
-                                          description: nodePublishSecretRef is a reference
-                                            to the secret object containing sensitive
-                                            information to pass to the CSI driver
-                                            to complete the CSI NodePublishVolume
-                                            and NodeUnpublishVolume calls. This field
-                                            is optional, and  may be empty if no secret
-                                            is required. If the secret object contains
-                                            more than one secret, all secret references
-                                            are passed.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         readOnly:
-                                          description: readOnly specifies a read-only
-                                            configuration for the volume. Defaults
-                                            to false (read/write).
                                           type: boolean
                                         volumeAttributes:
                                           additionalProperties:
                                             type: string
-                                          description: volumeAttributes stores driver-specific
-                                            properties that are passed to the CSI
-                                            driver. Consult your driver's documentation
-                                            for supported values.
                                           type: object
                                       required:
                                       - driver
                                       type: object
                                     downwardAPI:
-                                      description: downwardAPI represents downward
-                                        API about the pod that should populate this
-                                        volume
                                       properties:
                                         defaultMode:
-                                          description: 'Optional: mode bits to use
-                                            on created files by default. Must be a
-                                            Optional: mode bits used to set permissions
-                                            on created files by default. Must be an
-                                            octal value between 0000 and 0777 or a
-                                            decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. Defaults to 0644. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: Items is a list of downward
-                                            API volume file
                                           items:
-                                            description: DownwardAPIVolumeFile represents
-                                              information to create the file containing
-                                              the pod field
                                             properties:
                                               fieldRef:
-                                                description: 'Required: Selects a
-                                                  field of the pod: only annotations,
-                                                  labels, name and namespace are supported.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema
-                                                      the FieldPath is written in
-                                                      terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field
-                                                      to select in the specified API
-                                                      version.
                                                     type: string
                                                 required:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               mode:
-                                                description: 'Optional: mode bits
-                                                  used to set permissions on this
-                                                  file, must be an octal value between
-                                                  0000 and 0777 or a decimal value
-                                                  between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: 'Required: Path is  the
-                                                  relative path name of the file to
-                                                  be created. Must not be absolute
-                                                  or contain the ''..'' path. Must
-                                                  be utf-8 encoded. The first item
-                                                  of the relative path must not start
-                                                  with ''..'''
                                                 type: string
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  requests.cpu and requests.memory)
-                                                  are currently supported.'
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name:
-                                                      required for volumes, optional
-                                                      for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                     - type: integer
                                                     - type: string
-                                                    description: Specifies the output
-                                                      format of the exposed resources,
-                                                      defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource
-                                                      to select'
                                                     type: string
                                                 required:
                                                 - resource
@@ -2541,146 +1074,35 @@ spec:
                                           type: array
                                       type: object
                                     emptyDir:
-                                      description: 'emptyDir represents a temporary
-                                        directory that shares a pod''s lifetime. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       properties:
                                         medium:
-                                          description: 'medium represents what type
-                                            of storage medium should back this directory.
-                                            The default is "" which means to use the
-                                            node''s default medium. Must be an empty
-                                            string (default) or Memory. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: 'sizeLimit is the total amount
-                                            of local storage required for this EmptyDir
-                                            volume. The size limit is also applicable
-                                            for memory medium. The maximum usage on
-                                            memory medium EmptyDir would be the minimum
-                                            value between the SizeLimit specified
-                                            here and the sum of memory limits of all
-                                            containers in a pod. The default is nil
-                                            which means that the limit is undefined.
-                                            More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     ephemeral:
-                                      description: "ephemeral represents a volume
-                                        that is handled by a cluster storage driver.
-                                        The volume's lifecycle is tied to the pod
-                                        that defines it - it will be created before
-                                        the pod starts, and deleted when the pod is
-                                        removed. \n Use this if: a) the volume is
-                                        only needed while the pod runs, b) features
-                                        of normal volumes like restoring from snapshot
-                                        or capacity tracking are needed, c) the storage
-                                        driver is specified through a storage class,
-                                        and d) the storage driver supports dynamic
-                                        volume provisioning through a PersistentVolumeClaim
-                                        (see EphemeralVolumeSource for more information
-                                        on the connection between this volume type
-                                        and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                        or one of the vendor-specific APIs for volumes
-                                        that persist for longer than the lifecycle
-                                        of an individual pod. \n Use CSI for light-weight
-                                        local ephemeral volumes if the CSI driver
-                                        is meant to be used that way - see the documentation
-                                        of the driver for more information. \n A pod
-                                        can use both types of ephemeral volumes and
-                                        persistent volumes at the same time."
                                       properties:
                                         volumeClaimTemplate:
-                                          description: "Will be used to create a stand-alone
-                                            PVC to provision the volume. The pod in
-                                            which this EphemeralVolumeSource is embedded
-                                            will be the owner of the PVC, i.e. the
-                                            PVC will be deleted together with the
-                                            pod.  The name of the PVC will be `<pod
-                                            name>-<volume name>` where `<volume name>`
-                                            is the name from the `PodSpec.Volumes`
-                                            array entry. Pod validation will reject
-                                            the pod if the concatenated name is not
-                                            valid for a PVC (for example, too long).
-                                            \n An existing PVC with that name that
-                                            is not owned by the pod will *not* be
-                                            used for the pod to avoid using an unrelated
-                                            volume by mistake. Starting the pod is
-                                            then blocked until the unrelated PVC is
-                                            removed. If such a pre-created PVC is
-                                            meant to be used by the pod, the PVC has
-                                            to updated with an owner reference to
-                                            the pod once the pod exists. Normally
-                                            this should not be necessary, but it may
-                                            be useful when manually reconstructing
-                                            a broken cluster. \n This field is read-only
-                                            and no changes will be made by Kubernetes
-                                            to the PVC after it has been created.
-                                            \n Required, must not be nil."
                                           properties:
                                             metadata:
-                                              description: May contain labels and
-                                                annotations that will be copied into
-                                                the PVC when creating it. No other
-                                                fields are allowed and will be rejected
-                                                during validation.
                                               type: object
                                             spec:
-                                              description: The specification for the
-                                                PersistentVolumeClaim. The entire
-                                                content is copied unchanged into the
-                                                PVC that gets created from this template.
-                                                The same fields as in a PersistentVolumeClaim
-                                                are also valid here.
                                               properties:
                                                 accessModes:
-                                                  description: 'accessModes contains
-                                                    the desired access modes the volume
-                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                   items:
                                                     type: string
                                                   type: array
                                                 dataSource:
-                                                  description: 'dataSource field can
-                                                    be used to specify either: * An
-                                                    existing VolumeSnapshot object
-                                                    (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                    * An existing PVC (PersistentVolumeClaim)
-                                                    If the provisioner or an external
-                                                    controller can support the specified
-                                                    data source, it will create a
-                                                    new volume based on the contents
-                                                    of the specified data source.
-                                                    When the AnyVolumeDataSource feature
-                                                    gate is enabled, dataSource contents
-                                                    will be copied to dataSourceRef,
-                                                    and dataSourceRef contents will
-                                                    be copied to dataSource when dataSourceRef.namespace
-                                                    is not specified. If the namespace
-                                                    is specified, then dataSourceRef
-                                                    will not be copied to dataSource.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -2688,122 +1110,25 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 dataSourceRef:
-                                                  description: 'dataSourceRef specifies
-                                                    the object from which to populate
-                                                    the volume with data, if a non-empty
-                                                    volume is desired. This may be
-                                                    any object from a non-empty API
-                                                    group (non core object) or a PersistentVolumeClaim
-                                                    object. When this field is specified,
-                                                    volume binding will only succeed
-                                                    if the type of the specified object
-                                                    matches some installed volume
-                                                    populator or dynamic provisioner.
-                                                    This field will replace the functionality
-                                                    of the dataSource field and as
-                                                    such if both fields are non-empty,
-                                                    they must have the same value.
-                                                    For backwards compatibility, when
-                                                    namespace isn''t specified in
-                                                    dataSourceRef, both fields (dataSource
-                                                    and dataSourceRef) will be set
-                                                    to the same value automatically
-                                                    if one of them is empty and the
-                                                    other is non-empty. When namespace
-                                                    is specified in dataSourceRef,
-                                                    dataSource isn''t set to the same
-                                                    value and must be empty. There
-                                                    are three important differences
-                                                    between dataSource and dataSourceRef:
-                                                    * While dataSource only allows
-                                                    two specific types of objects,
-                                                    dataSourceRef allows any non-core
-                                                    object, as well as PersistentVolumeClaim
-                                                    objects. * While dataSource ignores
-                                                    disallowed values (dropping them),
-                                                    dataSourceRef preserves all values,
-                                                    and generates an error if a disallowed
-                                                    value is specified. * While dataSource
-                                                    only allows local objects, dataSourceRef
-                                                    allows objects in any namespaces.
-                                                    (Beta) Using this field requires
-                                                    the AnyVolumeDataSource feature
-                                                    gate to be enabled. (Alpha) Using
-                                                    the namespace field of dataSourceRef
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                     namespace:
-                                                      description: Namespace is the
-                                                        namespace of resource being
-                                                        referenced Note that when
-                                                        a namespace is specified,
-                                                        a gateway.networking.k8s.io/ReferenceGrant
-                                                        object is required in the
-                                                        referent namespace to allow
-                                                        that namespace's owner to
-                                                        accept the reference. See
-                                                        the ReferenceGrant documentation
-                                                        for details. (Alpha) This
-                                                        field requires the CrossNamespaceVolumeDataSource
-                                                        feature gate to be enabled.
                                                       type: string
                                                   required:
                                                   - kind
                                                   - name
                                                   type: object
                                                 resources:
-                                                  description: 'resources represents
-                                                    the minimum resources the volume
-                                                    should have. If RecoverVolumeExpansionFailure
-                                                    feature is enabled users are allowed
-                                                    to specify resource requirements
-                                                    that are lower than previous value
-                                                    but must still be higher than
-                                                    capacity recorded in the status
-                                                    field of the claim. More info:
-                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                   properties:
                                                     claims:
-                                                      description: "Claims lists the
-                                                        names of resources, defined
-                                                        in spec.resourceClaims, that
-                                                        are used by this container.
-                                                        \n This is an alpha field
-                                                        and requires enabling the
-                                                        DynamicResourceAllocation
-                                                        feature gate. \n This field
-                                                        is immutable."
                                                       items:
-                                                        description: ResourceClaim
-                                                          references one entry in
-                                                          PodSpec.ResourceClaims.
                                                         properties:
                                                           name:
-                                                            description: Name must
-                                                              match the name of one
-                                                              entry in pod.spec.resourceClaims
-                                                              of the Pod where this
-                                                              field is used. It makes
-                                                              that resource available
-                                                              inside a container.
                                                             type: string
                                                         required:
                                                         - name
@@ -2819,10 +1144,6 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Limits describes
-                                                        the maximum amount of compute
-                                                        resources allowed. More info:
-                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -2831,58 +1152,18 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Requests describes
-                                                        the minimum amount of compute
-                                                        resources required. If Requests
-                                                        is omitted for a container,
-                                                        it defaults to Limits if that
-                                                        is explicitly specified, otherwise
-                                                        to an implementation-defined
-                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                   type: object
                                                 selector:
-                                                  description: selector is a label
-                                                    query over volumes to consider
-                                                    for binding.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
-                                                          relates the key and values.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              label key that the selector
-                                                              applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
-                                                              merge patch.
                                                             items:
                                                               type: string
                                                             type: array
@@ -2894,35 +1175,14 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 storageClassName:
-                                                  description: 'storageClassName is
-                                                    the name of the StorageClass required
-                                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                   type: string
                                                 volumeMode:
-                                                  description: volumeMode defines
-                                                    what type of volume is required
-                                                    by the claim. Value of Filesystem
-                                                    is implied when not included in
-                                                    claim spec.
                                                   type: string
                                                 volumeName:
-                                                  description: volumeName is the binding
-                                                    reference to the PersistentVolume
-                                                    backing this claim.
                                                   type: string
                                               type: object
                                           required:
@@ -2930,85 +1190,38 @@ spec:
                                           type: object
                                       type: object
                                     fc:
-                                      description: fc represents a Fibre Channel resource
-                                        that is attached to a kubelet's host machine
-                                        and then exposed to the pod.
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. TODO: how do
-                                            we prevent errors in the filesystem from
-                                            compromising the machine'
                                           type: string
                                         lun:
-                                          description: 'lun is Optional: FC target
-                                            lun number'
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
                                           type: boolean
                                         targetWWNs:
-                                          description: 'targetWWNs is Optional: FC
-                                            target worldwide names (WWNs)'
                                           items:
                                             type: string
                                           type: array
                                         wwids:
-                                          description: 'wwids Optional: FC volume
-                                            world wide identifiers (wwids) Either
-                                            wwids or combination of targetWWNs and
-                                            lun must be set, but not both simultaneously.'
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     flexVolume:
-                                      description: flexVolume represents a generic
-                                        volume resource that is provisioned/attached
-                                        using an exec based plugin.
                                       properties:
                                         driver:
-                                          description: driver is the name of the driver
-                                            to use for this volume.
                                           type: string
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". The default filesystem
-                                            depends on FlexVolume script.
                                           type: string
                                         options:
                                           additionalProperties:
                                             type: string
-                                          description: 'options is Optional: this
-                                            field holds extra command options if any.'
                                           type: object
                                         readOnly:
-                                          description: 'readOnly is Optional: defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is Optional: secretRef
-                                            is reference to the secret object containing
-                                            sensitive information to pass to the plugin
-                                            scripts. This may be empty if no secret
-                                            object is specified. If the secret object
-                                            contains more than one secret, all secrets
-                                            are passed to the plugin scripts.'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -3016,216 +1229,88 @@ spec:
                                       - driver
                                       type: object
                                     flocker:
-                                      description: flocker represents a Flocker volume
-                                        attached to a kubelet's host machine. This
-                                        depends on the Flocker control service being
-                                        running
                                       properties:
                                         datasetName:
-                                          description: datasetName is Name of the
-                                            dataset stored as metadata -> name on
-                                            the dataset for Flocker should be considered
-                                            as deprecated
                                           type: string
                                         datasetUUID:
-                                          description: datasetUUID is the UUID of
-                                            the dataset. This is unique identifier
-                                            of a Flocker dataset
                                           type: string
                                       type: object
                                     gcePersistentDisk:
-                                      description: 'gcePersistentDisk represents a
-                                        GCE Disk resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       properties:
                                         fsType:
-                                          description: 'fsType is filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           format: int32
                                           type: integer
                                         pdName:
-                                          description: 'pdName is unique name of the
-                                            PD resource in GCE. Used to identify the
-                                            disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           type: boolean
                                       required:
                                       - pdName
                                       type: object
                                     gitRepo:
-                                      description: 'gitRepo represents a git repository
-                                        at a particular revision. DEPRECATED: GitRepo
-                                        is deprecated. To provision a container with
-                                        a git repo, mount an EmptyDir into an InitContainer
-                                        that clones the repo using git, then mount
-                                        the EmptyDir into the Pod''s container.'
                                       properties:
                                         directory:
-                                          description: directory is the target directory
-                                            name. Must not contain or start with '..'.  If
-                                            '.' is supplied, the volume directory
-                                            will be the git repository.  Otherwise,
-                                            if specified, the volume will contain
-                                            the git repository in the subdirectory
-                                            with the given name.
                                           type: string
                                         repository:
-                                          description: repository is the URL
                                           type: string
                                         revision:
-                                          description: revision is the commit hash
-                                            for the specified revision.
                                           type: string
                                       required:
                                       - repository
                                       type: object
                                     glusterfs:
-                                      description: 'glusterfs represents a Glusterfs
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                       properties:
                                         endpoints:
-                                          description: 'endpoints is the endpoint
-                                            name that details Glusterfs topology.
-                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: string
                                         path:
-                                          description: 'path is the Glusterfs volume
-                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            Glusterfs volume to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: boolean
                                       required:
                                       - endpoints
                                       - path
                                       type: object
                                     hostPath:
-                                      description: 'hostPath represents a pre-existing
-                                        file or directory on the host machine that
-                                        is directly exposed to the container. This
-                                        is generally used for system agents or other
-                                        privileged things that are allowed to see
-                                        the host machine. Most containers will NOT
-                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                        --- TODO(jonesdl) We need to restrict who
-                                        can use host directory mounts and who can/can
-                                        not mount host directories as read/write.'
                                       properties:
                                         path:
-                                          description: 'path of the directory on the
-                                            host. If the path is a symlink, it will
-                                            follow the link to the real path. More
-                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults
-                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                           type: string
                                       required:
                                       - path
                                       type: object
                                     iscsi:
-                                      description: 'iscsi represents an ISCSI Disk
-                                        resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                       properties:
                                         chapAuthDiscovery:
-                                          description: chapAuthDiscovery defines whether
-                                            support iSCSI Discovery CHAP authentication
                                           type: boolean
                                         chapAuthSession:
-                                          description: chapAuthSession defines whether
-                                            support iSCSI Session CHAP authentication
                                           type: boolean
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         initiatorName:
-                                          description: initiatorName is the custom
-                                            iSCSI Initiator Name. If initiatorName
-                                            is specified with iscsiInterface simultaneously,
-                                            new iSCSI interface <target portal>:<volume
-                                            name> will be created for the connection.
                                           type: string
                                         iqn:
-                                          description: iqn is the target iSCSI Qualified
-                                            Name.
                                           type: string
                                         iscsiInterface:
-                                          description: iscsiInterface is the interface
-                                            Name that uses an iSCSI transport. Defaults
-                                            to 'default' (tcp).
                                           type: string
                                         lun:
-                                          description: lun represents iSCSI Target
-                                            Lun number.
                                           format: int32
                                           type: integer
                                         portals:
-                                          description: portals is the iSCSI Target
-                                            Portal List. The portal is either an IP
-                                            or ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
                                           items:
                                             type: string
                                           type: array
                                         readOnly:
-                                          description: readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef is the CHAP Secret
-                                            for iSCSI target and initiator authentication
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         targetPortal:
-                                          description: targetPortal is iSCSI Target
-                                            Portal. The Portal is either an IP or
-                                            ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
                                           type: string
                                       required:
                                       - iqn
@@ -3233,182 +1318,67 @@ spec:
                                       - targetPortal
                                       type: object
                                     name:
-                                      description: 'name of the volume. Must be a
-                                        DNS_LABEL and unique within the pod. More
-                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                       type: string
                                     nfs:
-                                      description: 'nfs represents an NFS mount on
-                                        the host that shares a pod''s lifetime More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       properties:
                                         path:
-                                          description: 'path that is exported by the
-                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            NFS export to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: boolean
                                         server:
-                                          description: 'server is the hostname or
-                                            IP address of the NFS server. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: string
                                       required:
                                       - path
                                       - server
                                       type: object
                                     persistentVolumeClaim:
-                                      description: 'persistentVolumeClaimVolumeSource
-                                        represents a reference to a PersistentVolumeClaim
-                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       properties:
                                         claimName:
-                                          description: 'claimName is the name of a
-                                            PersistentVolumeClaim in the same namespace
-                                            as the pod using this volume. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                           type: string
                                         readOnly:
-                                          description: readOnly Will force the ReadOnly
-                                            setting in VolumeMounts. Default false.
                                           type: boolean
                                       required:
                                       - claimName
                                       type: object
                                     photonPersistentDisk:
-                                      description: photonPersistentDisk represents
-                                        a PhotonController persistent disk attached
-                                        and mounted on kubelets host machine
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         pdID:
-                                          description: pdID is the ID that identifies
-                                            Photon Controller persistent disk
                                           type: string
                                       required:
                                       - pdID
                                       type: object
                                     portworxVolume:
-                                      description: portworxVolume represents a portworx
-                                        volume attached and mounted on kubelets host
-                                        machine
                                       properties:
                                         fsType:
-                                          description: fSType represents the filesystem
-                                            type to mount Must be a filesystem type
-                                            supported by the host operating system.
-                                            Ex. "ext4", "xfs". Implicitly inferred
-                                            to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         volumeID:
-                                          description: volumeID uniquely identifies
-                                            a Portworx volume
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     projected:
-                                      description: projected items for all in one
-                                        resources secrets, configmaps, and downward
-                                        API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits
-                                            used to set permissions on created files
-                                            by default. Must be an octal value between
-                                            0000 and 0777 or a decimal value between
-                                            0 and 511. YAML accepts both octal and
-                                            decimal values, JSON requires decimal
-                                            values for mode bits. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.
                                           format: int32
                                           type: integer
                                         sources:
-                                          description: sources is the list of volume
-                                            projections
                                           items:
-                                            description: Projection that may be projected
-                                              along with other supported volume types
                                             properties:
                                               configMap:
-                                                description: configMap information
-                                                  about the configMap data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced ConfigMap
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the ConfigMap, the volume
-                                                      setup will error unless it is
-                                                      marked optional. Paths must
-                                                      be relative and may not contain
-                                                      the '..' path or start with
-                                                      '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -3416,116 +1386,42 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
                                                     type: string
                                                   optional:
-                                                    description: optional specify
-                                                      whether the ConfigMap or its
-                                                      keys must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               downwardAPI:
-                                                description: downwardAPI information
-                                                  about the downwardAPI data to project
                                                 properties:
                                                   items:
-                                                    description: Items is a list of
-                                                      DownwardAPIVolume file
                                                     items:
-                                                      description: DownwardAPIVolumeFile
-                                                        represents information to
-                                                        create the file containing
-                                                        the pod field
                                                       properties:
                                                         fieldRef:
-                                                          description: 'Required:
-                                                            Selects a field of the
-                                                            pod: only annotations,
-                                                            labels, name and namespace
-                                                            are supported.'
                                                           properties:
                                                             apiVersion:
-                                                              description: Version
-                                                                of the schema the
-                                                                FieldPath is written
-                                                                in terms of, defaults
-                                                                to "v1".
                                                               type: string
                                                             fieldPath:
-                                                              description: Path of
-                                                                the field to select
-                                                                in the specified API
-                                                                version.
                                                               type: string
                                                           required:
                                                           - fieldPath
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file,
-                                                            must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: 'Required:
-                                                            Path is  the relative
-                                                            path name of the file
-                                                            to be created. Must not
-                                                            be absolute or contain
-                                                            the ''..'' path. Must
-                                                            be utf-8 encoded. The
-                                                            first item of the relative
-                                                            path must not start with
-                                                            ''..'''
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a
-                                                            resource of the container:
-                                                            only resources limits
-                                                            and requests (limits.cpu,
-                                                            limits.memory, requests.cpu
-                                                            and requests.memory) are
-                                                            currently supported.'
                                                           properties:
                                                             containerName:
-                                                              description: 'Container
-                                                                name: required for
-                                                                volumes, optional
-                                                                for env vars'
                                                               type: string
                                                             divisor:
                                                               anyOf:
                                                               - type: integer
                                                               - type: string
-                                                              description: Specifies
-                                                                the output format
-                                                                of the exposed resources,
-                                                                defaults to "1"
                                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                               x-kubernetes-int-or-string: true
                                                             resource:
-                                                              description: 'Required:
-                                                                resource to select'
                                                               type: string
                                                           required:
                                                           - resource
@@ -3537,64 +1433,16 @@ spec:
                                                     type: array
                                                 type: object
                                               secret:
-                                                description: secret information about
-                                                  the secret data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced Secret
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the Secret, the volume setup
-                                                      will error unless it is marked
-                                                      optional. Paths must be relative
-                                                      and may not contain the '..'
-                                                      path or start with '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -3602,55 +1450,19 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
                                                     type: string
                                                   optional:
-                                                    description: optional field specify
-                                                      whether the Secret or its key
-                                                      must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               serviceAccountToken:
-                                                description: serviceAccountToken is
-                                                  information about the serviceAccountToken
-                                                  data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended
-                                                      audience of the token. A recipient
-                                                      of a token must identify itself
-                                                      with an identifier specified
-                                                      in the audience of the token,
-                                                      and otherwise should reject
-                                                      the token. The audience defaults
-                                                      to the identifier of the apiserver.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: expirationSeconds
-                                                      is the requested duration of
-                                                      validity of the service account
-                                                      token. As the token approaches
-                                                      expiration, the kubelet volume
-                                                      plugin will proactively rotate
-                                                      the service account token. The
-                                                      kubelet will start trying to
-                                                      rotate the token if the token
-                                                      is older than 80 percent of
-                                                      its time to live or if the token
-                                                      is older than 24 hours.Defaults
-                                                      to 1 hour and must be at least
-                                                      10 minutes.
                                                     format: int64
                                                     type: integer
                                                   path:
-                                                    description: path is the path
-                                                      relative to the mount point
-                                                      of the file to project the token
-                                                      into.
                                                     type: string
                                                 required:
                                                 - path
@@ -3659,168 +1471,76 @@ spec:
                                           type: array
                                       type: object
                                     quobyte:
-                                      description: quobyte represents a Quobyte mount
-                                        on the host that shares a pod's lifetime
                                       properties:
                                         group:
-                                          description: group to map volume access
-                                            to Default is no group
                                           type: string
                                         readOnly:
-                                          description: readOnly here will force the
-                                            Quobyte volume to be mounted with read-only
-                                            permissions. Defaults to false.
                                           type: boolean
                                         registry:
-                                          description: registry represents a single
-                                            or multiple Quobyte Registry services
-                                            specified as a string as host:port pair
-                                            (multiple entries are separated with commas)
-                                            which acts as the central registry for
-                                            volumes
                                           type: string
                                         tenant:
-                                          description: tenant owning the given Quobyte
-                                            volume in the Backend Used with dynamically
-                                            provisioned Quobyte volumes, value is
-                                            set by the plugin
                                           type: string
                                         user:
-                                          description: user to map volume access to
-                                            Defaults to serivceaccount user
                                           type: string
                                         volume:
-                                          description: volume is a string that references
-                                            an already created Quobyte volume by name.
                                           type: string
                                       required:
                                       - registry
                                       - volume
                                       type: object
                                     rbd:
-                                      description: 'rbd represents a Rados Block Device
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         image:
-                                          description: 'image is the rados image name.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         keyring:
-                                          description: 'keyring is the path to key
-                                            ring for RBDUser. Default is /etc/ceph/keyring.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         monitors:
-                                          description: 'monitors is a collection of
-                                            Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           items:
                                             type: string
                                           type: array
                                         pool:
-                                          description: 'pool is the rados pool name.
-                                            Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is name of the authentication
-                                            secret for RBDUser. If provided overrides
-                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is the rados user name.
-                                            Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                       required:
                                       - image
                                       - monitors
                                       type: object
                                     scaleIO:
-                                      description: scaleIO represents a ScaleIO persistent
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Default is "xfs".
                                           type: string
                                         gateway:
-                                          description: gateway is the host address
-                                            of the ScaleIO API Gateway.
                                           type: string
                                         protectionDomain:
-                                          description: protectionDomain is the name
-                                            of the ScaleIO Protection Domain for the
-                                            configured storage.
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef references to the
-                                            secret for ScaleIO user and other sensitive
-                                            information. If this is not provided,
-                                            Login operation will fail.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         sslEnabled:
-                                          description: sslEnabled Flag enable/disable
-                                            SSL communication with Gateway, default
-                                            false
                                           type: boolean
                                         storageMode:
-                                          description: storageMode indicates whether
-                                            the storage for a volume should be ThickProvisioned
-                                            or ThinProvisioned. Default is ThinProvisioned.
                                           type: string
                                         storagePool:
-                                          description: storagePool is the ScaleIO
-                                            Storage Pool associated with the protection
-                                            domain.
                                           type: string
                                         system:
-                                          description: system is the name of the storage
-                                            system as configured in ScaleIO.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the name of a
-                                            volume already created in the ScaleIO
-                                            system that is associated with this volume
-                                            source.
                                           type: string
                                       required:
                                       - gateway
@@ -3828,68 +1548,19 @@ spec:
                                       - system
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that
-                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced Secret will be projected into
-                                            the volume as a file whose name is the
-                                            key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the Secret, the
-                                            volume setup will error unless it is marked
-                                            optional. Paths must be relative and may
-                                            not contain the '..' path or start with
-                                            '..'.
                                           items:
-                                            description: Maps a string key to a path
-                                              within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
@@ -3897,90 +1568,36 @@ spec:
                                             type: object
                                           type: array
                                         optional:
-                                          description: optional field specify whether
-                                            the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of
-                                            the secret in the pod''s namespace to
-                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                           type: string
                                       type: object
                                     storageos:
-                                      description: storageOS represents a StorageOS
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef specifies the secret
-                                            to use for obtaining the StorageOS API
-                                            credentials.  If not specified, default
-                                            values will be attempted.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeName:
-                                          description: volumeName is the human-readable
-                                            name of the StorageOS volume.  Volume
-                                            names are only unique within a namespace.
                                           type: string
                                         volumeNamespace:
-                                          description: volumeNamespace specifies the
-                                            scope of the volume within StorageOS.  If
-                                            no namespace is specified then the Pod's
-                                            namespace will be used.  This allows the
-                                            Kubernetes name scoping to be mirrored
-                                            within StorageOS for tighter integration.
-                                            Set VolumeName to any name to override
-                                            the default behaviour. Set to "default"
-                                            if you are not using namespaces within
-                                            StorageOS. Namespaces that do not pre-exist
-                                            within StorageOS will be created.
                                           type: string
                                       type: object
                                     vsphereVolume:
-                                      description: vsphereVolume represents a vSphere
-                                        volume attached and mounted on kubelets host
-                                        machine
                                       properties:
                                         fsType:
-                                          description: fsType is filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         storagePolicyID:
-                                          description: storagePolicyID is the storage
-                                            Policy Based Management (SPBM) profile
-                                            ID associated with the StoragePolicyName.
                                           type: string
                                         storagePolicyName:
-                                          description: storagePolicyName is the storage
-                                            Policy Based Management (SPBM) profile
-                                            name.
                                           type: string
                                         volumePath:
-                                          description: volumePath is the path that
-                                            identifies vSphere volume vmdk
                                           type: string
                                       required:
                                       - volumePath
@@ -4003,59 +1620,35 @@ spec:
                       type: object
                     type: array
                   networkAttachments:
-                    description: NetworkAttachments is a list of NetworkAttachment
-                      resource names to expose the services to the given network
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes running
-                      this service. Setting here overrides any global NodeSelector
-                      settings within the Manila CR.
                     type: object
                   passwordSelectors:
                     default:
                       database: ManilaDatabasePassword
                       service: ManilaPassword
-                    description: PasswordSelectors - Selectors to identify the DB
-                      and ServiceUser password from the Secret
                     properties:
                       database:
                         default: ManilaDatabasePassword
-                        description: 'Database - Selector to get the manila database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
                         type: string
                       service:
                         default: ManilaPassword
-                        description: Service - Selector to get the manila service
-                          password from the Secret
                         type: string
                     type: object
                   replicas:
                     default: 1
-                    description: Replicas - Manila API Replicas
                     format: int32
                     type: integer
                   resources:
-                    description: Resources - Compute Resources required by this service
-                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     properties:
                       claims:
-                        description: "Claims lists the names of resources, defined
-                          in spec.resourceClaims, that are used by this container.
-                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable."
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: Name must match the name of one entry in
-                                pod.spec.resourceClaims of the Pod where this field
-                                is used. It makes that resource available inside a
-                                container.
                               type: string
                           required:
                           - name
@@ -4071,8 +1664,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                       requests:
                         additionalProperties:
@@ -4081,126 +1672,63 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   secret:
-                    description: Secret containing OpenStack password information
-                      for ManilaDatabasePassword, AdminPassword
                     type: string
                   serviceUser:
                     default: manila
-                    description: ServiceUser - optional username used for this service
-                      to register in manila
                     type: string
                   transportURLSecret:
-                    description: Secret containing RabbitMq transport URL
                     type: string
                 type: object
               manilaScheduler:
-                description: ManilaScheduler - Spec definition for the Scheduler service
-                  of this Manila deployment
                 properties:
                   containerImage:
-                    description: ContainerImage - manila Scheduler Container Image
-                      URL
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
-                    description: CustomServiceConfig - customize the service config
-                      using this parameter to change service defaults, or overwrite
-                      rendered information using raw OpenStack config format. The
-                      content gets added to to /etc/<service>/<service>.conf.d directory
-                      as custom.conf file.
                     type: string
                   databaseHostname:
-                    description: DatabaseHostname - manila Database Hostname
                     type: string
                   databaseUser:
                     default: manila
-                    description: 'DatabaseUser - optional username used for manila
-                      DB, defaults to manila TODO: -> implement needs work in mariadb-operator,
-                      right now only manila'
                     type: string
                   debug:
-                    description: Debug - enable debug for different deploy stages.
-                      If an init container is used, it runs and the actual action
-                      pod gets started with sleep infinity
                     properties:
                       initContainer:
                         default: false
-                        description: initContainer enable debug (waits until /tmp/stop-init-container
-                          disappears)
                         type: boolean
                       service:
                         default: false
-                        description: service enable debug
                         type: boolean
                     type: object
                   defaultConfigOverwrite:
                     additionalProperties:
                       type: string
-                    description: ConfigOverwrite - interface to overwrite default
-                      config files like e.g. policy.json. But can also be used to
-                      add additional files. Those get added to the service config
-                      dir in /etc/<service> .
                     type: object
                   extraMounts:
-                    description: ExtraMounts containing conf files and credentials
                     items:
-                      description: ManilaExtraVolMounts exposes additional parameters
-                        processed by the manila-operator and defines the common VolMounts
-                        structure provided by the main storage module
                       properties:
                         extraVol:
                           items:
-                            description: VolMounts is the data structure used to expose
-                              Volumes and Mounts that can be added to a pod according
-                              to the defined Propagation policy
                             properties:
                               extraVolType:
-                                description: Label associated to a given extraMount
                                 type: string
                               mounts:
                                 items:
-                                  description: VolumeMount describes a mounting of
-                                    a Volume within a container.
                                   properties:
                                     mountPath:
-                                      description: Path within the container at which
-                                        the volume should be mounted.  Must not contain
-                                        ':'.
                                       type: string
                                     mountPropagation:
-                                      description: mountPropagation determines how
-                                        mounts are propagated from the host to container
-                                        and the other way around. When not set, MountPropagationNone
-                                        is used. This field is beta in 1.10.
                                       type: string
                                     name:
-                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
-                                      description: Mounted read-only if true, read-write
-                                        otherwise (false or unspecified). Defaults
-                                        to false.
                                       type: boolean
                                     subPath:
-                                      description: Path within the volume from which
-                                        the container's volume should be mounted.
-                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
-                                      description: Expanded path within the volume
-                                        from which the container's volume should be
-                                        mounted. Behaves similarly to SubPath but
-                                        environment variable references $(VAR_NAME)
-                                        are expanded using the container's environment.
-                                        Defaults to "" (volume's root). SubPathExpr
-                                        and SubPath are mutually exclusive.
                                       type: string
                                   required:
                                   - mountPath
@@ -4208,274 +1736,110 @@ spec:
                                   type: object
                                 type: array
                               propagation:
-                                description: Propagation defines which pod should
-                                  mount the volume
                                 items:
-                                  description: PropagationType identifies the Service,
-                                    Group or instance (e.g. the backend) that receives
-                                    an Extra Volume that can potentially be mounted
                                   type: string
                                 type: array
                               volumes:
                                 items:
-                                  description: Volume represents a named volume in
-                                    a pod that may be accessed by any container in
-                                    the pod.
                                   properties:
                                     awsElasticBlockStore:
-                                      description: 'awsElasticBlockStore represents
-                                        an AWS Disk resource that is attached to a
-                                        kubelet''s host machine and then exposed to
-                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).'
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly value true will force
-                                            the readOnly setting in VolumeMounts.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                           type: boolean
                                         volumeID:
-                                          description: 'volumeID is unique ID of the
-                                            persistent disk resource in AWS (Amazon
-                                            EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     azureDisk:
-                                      description: azureDisk represents an Azure Data
-                                        Disk mount on the host and bind mount to the
-                                        pod.
                                       properties:
                                         cachingMode:
-                                          description: 'cachingMode is the Host Caching
-                                            mode: None, Read Only, Read Write.'
                                           type: string
                                         diskName:
-                                          description: diskName is the Name of the
-                                            data disk in the blob storage
                                           type: string
                                         diskURI:
-                                          description: diskURI is the URI of data
-                                            disk in the blob storage
                                           type: string
                                         fsType:
-                                          description: fsType is Filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         kind:
-                                          description: 'kind expected values are Shared:
-                                            multiple blob disks per storage account  Dedicated:
-                                            single blob disk per storage account  Managed:
-                                            azure managed data disk (only in managed
-                                            availability set). defaults to shared'
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                       required:
                                       - diskName
                                       - diskURI
                                       type: object
                                     azureFile:
-                                      description: azureFile represents an Azure File
-                                        Service mount on the host and bind mount to
-                                        the pod.
                                       properties:
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretName:
-                                          description: secretName is the  name of
-                                            secret that contains Azure Storage Account
-                                            Name and Key
                                           type: string
                                         shareName:
-                                          description: shareName is the azure share
-                                            Name
                                           type: string
                                       required:
                                       - secretName
                                       - shareName
                                       type: object
                                     cephfs:
-                                      description: cephFS represents a Ceph FS mount
-                                        on the host that shares a pod's lifetime
                                       properties:
                                         monitors:
-                                          description: 'monitors is Required: Monitors
-                                            is a collection of Ceph monitors More
-                                            info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           items:
                                             type: string
                                           type: array
                                         path:
-                                          description: 'path is Optional: Used as
-                                            the mounted root, rather than the full
-                                            Ceph tree, default is /'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: boolean
                                         secretFile:
-                                          description: 'secretFile is Optional: SecretFile
-                                            is the path to key ring for User, default
-                                            is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: string
                                         secretRef:
-                                          description: 'secretRef is Optional: SecretRef
-                                            is reference to the authentication secret
-                                            for User, default is empty. More info:
-                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is optional: User is
-                                            the rados user name, default is admin
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: string
                                       required:
                                       - monitors
                                       type: object
                                     cinder:
-                                      description: 'cinder represents a cinder volume
-                                        attached and mounted on kubelets host machine.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Examples:
-                                            "ext4", "xfs", "ntfs". Implicitly inferred
-                                            to be "ext4" if unspecified. More info:
-                                            https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is optional: points
-                                            to a secret object containing parameters
-                                            used to connect to OpenStack.'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeID:
-                                          description: 'volumeID used to identify
-                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     configMap:
-                                      description: configMap represents a configMap
-                                        that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced ConfigMap will be projected
-                                            into the volume as a file whose name is
-                                            the key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the ConfigMap,
-                                            the volume setup will error unless it
-                                            is marked optional. Paths must be relative
-                                            and may not contain the '..' path or start
-                                            with '..'.
                                           items:
-                                            description: Maps a string key to a path
-                                              within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
@@ -4483,168 +1847,66 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                         optional:
-                                          description: optional specify whether the
-                                            ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     csi:
-                                      description: csi (Container Storage Interface)
-                                        represents ephemeral storage that is handled
-                                        by certain external CSI drivers (Beta feature).
                                       properties:
                                         driver:
-                                          description: driver is the name of the CSI
-                                            driver that handles this volume. Consult
-                                            with your admin for the correct name as
-                                            registered in the cluster.
                                           type: string
                                         fsType:
-                                          description: fsType to mount. Ex. "ext4",
-                                            "xfs", "ntfs". If not provided, the empty
-                                            value is passed to the associated CSI
-                                            driver which will determine the default
-                                            filesystem to apply.
                                           type: string
                                         nodePublishSecretRef:
-                                          description: nodePublishSecretRef is a reference
-                                            to the secret object containing sensitive
-                                            information to pass to the CSI driver
-                                            to complete the CSI NodePublishVolume
-                                            and NodeUnpublishVolume calls. This field
-                                            is optional, and  may be empty if no secret
-                                            is required. If the secret object contains
-                                            more than one secret, all secret references
-                                            are passed.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         readOnly:
-                                          description: readOnly specifies a read-only
-                                            configuration for the volume. Defaults
-                                            to false (read/write).
                                           type: boolean
                                         volumeAttributes:
                                           additionalProperties:
                                             type: string
-                                          description: volumeAttributes stores driver-specific
-                                            properties that are passed to the CSI
-                                            driver. Consult your driver's documentation
-                                            for supported values.
                                           type: object
                                       required:
                                       - driver
                                       type: object
                                     downwardAPI:
-                                      description: downwardAPI represents downward
-                                        API about the pod that should populate this
-                                        volume
                                       properties:
                                         defaultMode:
-                                          description: 'Optional: mode bits to use
-                                            on created files by default. Must be a
-                                            Optional: mode bits used to set permissions
-                                            on created files by default. Must be an
-                                            octal value between 0000 and 0777 or a
-                                            decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. Defaults to 0644. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: Items is a list of downward
-                                            API volume file
                                           items:
-                                            description: DownwardAPIVolumeFile represents
-                                              information to create the file containing
-                                              the pod field
                                             properties:
                                               fieldRef:
-                                                description: 'Required: Selects a
-                                                  field of the pod: only annotations,
-                                                  labels, name and namespace are supported.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema
-                                                      the FieldPath is written in
-                                                      terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field
-                                                      to select in the specified API
-                                                      version.
                                                     type: string
                                                 required:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               mode:
-                                                description: 'Optional: mode bits
-                                                  used to set permissions on this
-                                                  file, must be an octal value between
-                                                  0000 and 0777 or a decimal value
-                                                  between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: 'Required: Path is  the
-                                                  relative path name of the file to
-                                                  be created. Must not be absolute
-                                                  or contain the ''..'' path. Must
-                                                  be utf-8 encoded. The first item
-                                                  of the relative path must not start
-                                                  with ''..'''
                                                 type: string
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  requests.cpu and requests.memory)
-                                                  are currently supported.'
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name:
-                                                      required for volumes, optional
-                                                      for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                     - type: integer
                                                     - type: string
-                                                    description: Specifies the output
-                                                      format of the exposed resources,
-                                                      defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource
-                                                      to select'
                                                     type: string
                                                 required:
                                                 - resource
@@ -4656,146 +1918,35 @@ spec:
                                           type: array
                                       type: object
                                     emptyDir:
-                                      description: 'emptyDir represents a temporary
-                                        directory that shares a pod''s lifetime. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       properties:
                                         medium:
-                                          description: 'medium represents what type
-                                            of storage medium should back this directory.
-                                            The default is "" which means to use the
-                                            node''s default medium. Must be an empty
-                                            string (default) or Memory. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: 'sizeLimit is the total amount
-                                            of local storage required for this EmptyDir
-                                            volume. The size limit is also applicable
-                                            for memory medium. The maximum usage on
-                                            memory medium EmptyDir would be the minimum
-                                            value between the SizeLimit specified
-                                            here and the sum of memory limits of all
-                                            containers in a pod. The default is nil
-                                            which means that the limit is undefined.
-                                            More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     ephemeral:
-                                      description: "ephemeral represents a volume
-                                        that is handled by a cluster storage driver.
-                                        The volume's lifecycle is tied to the pod
-                                        that defines it - it will be created before
-                                        the pod starts, and deleted when the pod is
-                                        removed. \n Use this if: a) the volume is
-                                        only needed while the pod runs, b) features
-                                        of normal volumes like restoring from snapshot
-                                        or capacity tracking are needed, c) the storage
-                                        driver is specified through a storage class,
-                                        and d) the storage driver supports dynamic
-                                        volume provisioning through a PersistentVolumeClaim
-                                        (see EphemeralVolumeSource for more information
-                                        on the connection between this volume type
-                                        and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                        or one of the vendor-specific APIs for volumes
-                                        that persist for longer than the lifecycle
-                                        of an individual pod. \n Use CSI for light-weight
-                                        local ephemeral volumes if the CSI driver
-                                        is meant to be used that way - see the documentation
-                                        of the driver for more information. \n A pod
-                                        can use both types of ephemeral volumes and
-                                        persistent volumes at the same time."
                                       properties:
                                         volumeClaimTemplate:
-                                          description: "Will be used to create a stand-alone
-                                            PVC to provision the volume. The pod in
-                                            which this EphemeralVolumeSource is embedded
-                                            will be the owner of the PVC, i.e. the
-                                            PVC will be deleted together with the
-                                            pod.  The name of the PVC will be `<pod
-                                            name>-<volume name>` where `<volume name>`
-                                            is the name from the `PodSpec.Volumes`
-                                            array entry. Pod validation will reject
-                                            the pod if the concatenated name is not
-                                            valid for a PVC (for example, too long).
-                                            \n An existing PVC with that name that
-                                            is not owned by the pod will *not* be
-                                            used for the pod to avoid using an unrelated
-                                            volume by mistake. Starting the pod is
-                                            then blocked until the unrelated PVC is
-                                            removed. If such a pre-created PVC is
-                                            meant to be used by the pod, the PVC has
-                                            to updated with an owner reference to
-                                            the pod once the pod exists. Normally
-                                            this should not be necessary, but it may
-                                            be useful when manually reconstructing
-                                            a broken cluster. \n This field is read-only
-                                            and no changes will be made by Kubernetes
-                                            to the PVC after it has been created.
-                                            \n Required, must not be nil."
                                           properties:
                                             metadata:
-                                              description: May contain labels and
-                                                annotations that will be copied into
-                                                the PVC when creating it. No other
-                                                fields are allowed and will be rejected
-                                                during validation.
                                               type: object
                                             spec:
-                                              description: The specification for the
-                                                PersistentVolumeClaim. The entire
-                                                content is copied unchanged into the
-                                                PVC that gets created from this template.
-                                                The same fields as in a PersistentVolumeClaim
-                                                are also valid here.
                                               properties:
                                                 accessModes:
-                                                  description: 'accessModes contains
-                                                    the desired access modes the volume
-                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                   items:
                                                     type: string
                                                   type: array
                                                 dataSource:
-                                                  description: 'dataSource field can
-                                                    be used to specify either: * An
-                                                    existing VolumeSnapshot object
-                                                    (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                    * An existing PVC (PersistentVolumeClaim)
-                                                    If the provisioner or an external
-                                                    controller can support the specified
-                                                    data source, it will create a
-                                                    new volume based on the contents
-                                                    of the specified data source.
-                                                    When the AnyVolumeDataSource feature
-                                                    gate is enabled, dataSource contents
-                                                    will be copied to dataSourceRef,
-                                                    and dataSourceRef contents will
-                                                    be copied to dataSource when dataSourceRef.namespace
-                                                    is not specified. If the namespace
-                                                    is specified, then dataSourceRef
-                                                    will not be copied to dataSource.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -4803,122 +1954,25 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 dataSourceRef:
-                                                  description: 'dataSourceRef specifies
-                                                    the object from which to populate
-                                                    the volume with data, if a non-empty
-                                                    volume is desired. This may be
-                                                    any object from a non-empty API
-                                                    group (non core object) or a PersistentVolumeClaim
-                                                    object. When this field is specified,
-                                                    volume binding will only succeed
-                                                    if the type of the specified object
-                                                    matches some installed volume
-                                                    populator or dynamic provisioner.
-                                                    This field will replace the functionality
-                                                    of the dataSource field and as
-                                                    such if both fields are non-empty,
-                                                    they must have the same value.
-                                                    For backwards compatibility, when
-                                                    namespace isn''t specified in
-                                                    dataSourceRef, both fields (dataSource
-                                                    and dataSourceRef) will be set
-                                                    to the same value automatically
-                                                    if one of them is empty and the
-                                                    other is non-empty. When namespace
-                                                    is specified in dataSourceRef,
-                                                    dataSource isn''t set to the same
-                                                    value and must be empty. There
-                                                    are three important differences
-                                                    between dataSource and dataSourceRef:
-                                                    * While dataSource only allows
-                                                    two specific types of objects,
-                                                    dataSourceRef allows any non-core
-                                                    object, as well as PersistentVolumeClaim
-                                                    objects. * While dataSource ignores
-                                                    disallowed values (dropping them),
-                                                    dataSourceRef preserves all values,
-                                                    and generates an error if a disallowed
-                                                    value is specified. * While dataSource
-                                                    only allows local objects, dataSourceRef
-                                                    allows objects in any namespaces.
-                                                    (Beta) Using this field requires
-                                                    the AnyVolumeDataSource feature
-                                                    gate to be enabled. (Alpha) Using
-                                                    the namespace field of dataSourceRef
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                     namespace:
-                                                      description: Namespace is the
-                                                        namespace of resource being
-                                                        referenced Note that when
-                                                        a namespace is specified,
-                                                        a gateway.networking.k8s.io/ReferenceGrant
-                                                        object is required in the
-                                                        referent namespace to allow
-                                                        that namespace's owner to
-                                                        accept the reference. See
-                                                        the ReferenceGrant documentation
-                                                        for details. (Alpha) This
-                                                        field requires the CrossNamespaceVolumeDataSource
-                                                        feature gate to be enabled.
                                                       type: string
                                                   required:
                                                   - kind
                                                   - name
                                                   type: object
                                                 resources:
-                                                  description: 'resources represents
-                                                    the minimum resources the volume
-                                                    should have. If RecoverVolumeExpansionFailure
-                                                    feature is enabled users are allowed
-                                                    to specify resource requirements
-                                                    that are lower than previous value
-                                                    but must still be higher than
-                                                    capacity recorded in the status
-                                                    field of the claim. More info:
-                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                   properties:
                                                     claims:
-                                                      description: "Claims lists the
-                                                        names of resources, defined
-                                                        in spec.resourceClaims, that
-                                                        are used by this container.
-                                                        \n This is an alpha field
-                                                        and requires enabling the
-                                                        DynamicResourceAllocation
-                                                        feature gate. \n This field
-                                                        is immutable."
                                                       items:
-                                                        description: ResourceClaim
-                                                          references one entry in
-                                                          PodSpec.ResourceClaims.
                                                         properties:
                                                           name:
-                                                            description: Name must
-                                                              match the name of one
-                                                              entry in pod.spec.resourceClaims
-                                                              of the Pod where this
-                                                              field is used. It makes
-                                                              that resource available
-                                                              inside a container.
                                                             type: string
                                                         required:
                                                         - name
@@ -4934,10 +1988,6 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Limits describes
-                                                        the maximum amount of compute
-                                                        resources allowed. More info:
-                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -4946,58 +1996,18 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Requests describes
-                                                        the minimum amount of compute
-                                                        resources required. If Requests
-                                                        is omitted for a container,
-                                                        it defaults to Limits if that
-                                                        is explicitly specified, otherwise
-                                                        to an implementation-defined
-                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                   type: object
                                                 selector:
-                                                  description: selector is a label
-                                                    query over volumes to consider
-                                                    for binding.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
-                                                          relates the key and values.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              label key that the selector
-                                                              applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
-                                                              merge patch.
                                                             items:
                                                               type: string
                                                             type: array
@@ -5009,35 +2019,14 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 storageClassName:
-                                                  description: 'storageClassName is
-                                                    the name of the StorageClass required
-                                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                   type: string
                                                 volumeMode:
-                                                  description: volumeMode defines
-                                                    what type of volume is required
-                                                    by the claim. Value of Filesystem
-                                                    is implied when not included in
-                                                    claim spec.
                                                   type: string
                                                 volumeName:
-                                                  description: volumeName is the binding
-                                                    reference to the PersistentVolume
-                                                    backing this claim.
                                                   type: string
                                               type: object
                                           required:
@@ -5045,85 +2034,38 @@ spec:
                                           type: object
                                       type: object
                                     fc:
-                                      description: fc represents a Fibre Channel resource
-                                        that is attached to a kubelet's host machine
-                                        and then exposed to the pod.
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. TODO: how do
-                                            we prevent errors in the filesystem from
-                                            compromising the machine'
                                           type: string
                                         lun:
-                                          description: 'lun is Optional: FC target
-                                            lun number'
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
                                           type: boolean
                                         targetWWNs:
-                                          description: 'targetWWNs is Optional: FC
-                                            target worldwide names (WWNs)'
                                           items:
                                             type: string
                                           type: array
                                         wwids:
-                                          description: 'wwids Optional: FC volume
-                                            world wide identifiers (wwids) Either
-                                            wwids or combination of targetWWNs and
-                                            lun must be set, but not both simultaneously.'
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     flexVolume:
-                                      description: flexVolume represents a generic
-                                        volume resource that is provisioned/attached
-                                        using an exec based plugin.
                                       properties:
                                         driver:
-                                          description: driver is the name of the driver
-                                            to use for this volume.
                                           type: string
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". The default filesystem
-                                            depends on FlexVolume script.
                                           type: string
                                         options:
                                           additionalProperties:
                                             type: string
-                                          description: 'options is Optional: this
-                                            field holds extra command options if any.'
                                           type: object
                                         readOnly:
-                                          description: 'readOnly is Optional: defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is Optional: secretRef
-                                            is reference to the secret object containing
-                                            sensitive information to pass to the plugin
-                                            scripts. This may be empty if no secret
-                                            object is specified. If the secret object
-                                            contains more than one secret, all secrets
-                                            are passed to the plugin scripts.'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -5131,216 +2073,88 @@ spec:
                                       - driver
                                       type: object
                                     flocker:
-                                      description: flocker represents a Flocker volume
-                                        attached to a kubelet's host machine. This
-                                        depends on the Flocker control service being
-                                        running
                                       properties:
                                         datasetName:
-                                          description: datasetName is Name of the
-                                            dataset stored as metadata -> name on
-                                            the dataset for Flocker should be considered
-                                            as deprecated
                                           type: string
                                         datasetUUID:
-                                          description: datasetUUID is the UUID of
-                                            the dataset. This is unique identifier
-                                            of a Flocker dataset
                                           type: string
                                       type: object
                                     gcePersistentDisk:
-                                      description: 'gcePersistentDisk represents a
-                                        GCE Disk resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       properties:
                                         fsType:
-                                          description: 'fsType is filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           format: int32
                                           type: integer
                                         pdName:
-                                          description: 'pdName is unique name of the
-                                            PD resource in GCE. Used to identify the
-                                            disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           type: boolean
                                       required:
                                       - pdName
                                       type: object
                                     gitRepo:
-                                      description: 'gitRepo represents a git repository
-                                        at a particular revision. DEPRECATED: GitRepo
-                                        is deprecated. To provision a container with
-                                        a git repo, mount an EmptyDir into an InitContainer
-                                        that clones the repo using git, then mount
-                                        the EmptyDir into the Pod''s container.'
                                       properties:
                                         directory:
-                                          description: directory is the target directory
-                                            name. Must not contain or start with '..'.  If
-                                            '.' is supplied, the volume directory
-                                            will be the git repository.  Otherwise,
-                                            if specified, the volume will contain
-                                            the git repository in the subdirectory
-                                            with the given name.
                                           type: string
                                         repository:
-                                          description: repository is the URL
                                           type: string
                                         revision:
-                                          description: revision is the commit hash
-                                            for the specified revision.
                                           type: string
                                       required:
                                       - repository
                                       type: object
                                     glusterfs:
-                                      description: 'glusterfs represents a Glusterfs
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                       properties:
                                         endpoints:
-                                          description: 'endpoints is the endpoint
-                                            name that details Glusterfs topology.
-                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: string
                                         path:
-                                          description: 'path is the Glusterfs volume
-                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            Glusterfs volume to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: boolean
                                       required:
                                       - endpoints
                                       - path
                                       type: object
                                     hostPath:
-                                      description: 'hostPath represents a pre-existing
-                                        file or directory on the host machine that
-                                        is directly exposed to the container. This
-                                        is generally used for system agents or other
-                                        privileged things that are allowed to see
-                                        the host machine. Most containers will NOT
-                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                        --- TODO(jonesdl) We need to restrict who
-                                        can use host directory mounts and who can/can
-                                        not mount host directories as read/write.'
                                       properties:
                                         path:
-                                          description: 'path of the directory on the
-                                            host. If the path is a symlink, it will
-                                            follow the link to the real path. More
-                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults
-                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                           type: string
                                       required:
                                       - path
                                       type: object
                                     iscsi:
-                                      description: 'iscsi represents an ISCSI Disk
-                                        resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                       properties:
                                         chapAuthDiscovery:
-                                          description: chapAuthDiscovery defines whether
-                                            support iSCSI Discovery CHAP authentication
                                           type: boolean
                                         chapAuthSession:
-                                          description: chapAuthSession defines whether
-                                            support iSCSI Session CHAP authentication
                                           type: boolean
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         initiatorName:
-                                          description: initiatorName is the custom
-                                            iSCSI Initiator Name. If initiatorName
-                                            is specified with iscsiInterface simultaneously,
-                                            new iSCSI interface <target portal>:<volume
-                                            name> will be created for the connection.
                                           type: string
                                         iqn:
-                                          description: iqn is the target iSCSI Qualified
-                                            Name.
                                           type: string
                                         iscsiInterface:
-                                          description: iscsiInterface is the interface
-                                            Name that uses an iSCSI transport. Defaults
-                                            to 'default' (tcp).
                                           type: string
                                         lun:
-                                          description: lun represents iSCSI Target
-                                            Lun number.
                                           format: int32
                                           type: integer
                                         portals:
-                                          description: portals is the iSCSI Target
-                                            Portal List. The portal is either an IP
-                                            or ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
                                           items:
                                             type: string
                                           type: array
                                         readOnly:
-                                          description: readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef is the CHAP Secret
-                                            for iSCSI target and initiator authentication
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         targetPortal:
-                                          description: targetPortal is iSCSI Target
-                                            Portal. The Portal is either an IP or
-                                            ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
                                           type: string
                                       required:
                                       - iqn
@@ -5348,182 +2162,67 @@ spec:
                                       - targetPortal
                                       type: object
                                     name:
-                                      description: 'name of the volume. Must be a
-                                        DNS_LABEL and unique within the pod. More
-                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                       type: string
                                     nfs:
-                                      description: 'nfs represents an NFS mount on
-                                        the host that shares a pod''s lifetime More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       properties:
                                         path:
-                                          description: 'path that is exported by the
-                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            NFS export to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: boolean
                                         server:
-                                          description: 'server is the hostname or
-                                            IP address of the NFS server. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: string
                                       required:
                                       - path
                                       - server
                                       type: object
                                     persistentVolumeClaim:
-                                      description: 'persistentVolumeClaimVolumeSource
-                                        represents a reference to a PersistentVolumeClaim
-                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       properties:
                                         claimName:
-                                          description: 'claimName is the name of a
-                                            PersistentVolumeClaim in the same namespace
-                                            as the pod using this volume. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                           type: string
                                         readOnly:
-                                          description: readOnly Will force the ReadOnly
-                                            setting in VolumeMounts. Default false.
                                           type: boolean
                                       required:
                                       - claimName
                                       type: object
                                     photonPersistentDisk:
-                                      description: photonPersistentDisk represents
-                                        a PhotonController persistent disk attached
-                                        and mounted on kubelets host machine
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         pdID:
-                                          description: pdID is the ID that identifies
-                                            Photon Controller persistent disk
                                           type: string
                                       required:
                                       - pdID
                                       type: object
                                     portworxVolume:
-                                      description: portworxVolume represents a portworx
-                                        volume attached and mounted on kubelets host
-                                        machine
                                       properties:
                                         fsType:
-                                          description: fSType represents the filesystem
-                                            type to mount Must be a filesystem type
-                                            supported by the host operating system.
-                                            Ex. "ext4", "xfs". Implicitly inferred
-                                            to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         volumeID:
-                                          description: volumeID uniquely identifies
-                                            a Portworx volume
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     projected:
-                                      description: projected items for all in one
-                                        resources secrets, configmaps, and downward
-                                        API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits
-                                            used to set permissions on created files
-                                            by default. Must be an octal value between
-                                            0000 and 0777 or a decimal value between
-                                            0 and 511. YAML accepts both octal and
-                                            decimal values, JSON requires decimal
-                                            values for mode bits. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.
                                           format: int32
                                           type: integer
                                         sources:
-                                          description: sources is the list of volume
-                                            projections
                                           items:
-                                            description: Projection that may be projected
-                                              along with other supported volume types
                                             properties:
                                               configMap:
-                                                description: configMap information
-                                                  about the configMap data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced ConfigMap
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the ConfigMap, the volume
-                                                      setup will error unless it is
-                                                      marked optional. Paths must
-                                                      be relative and may not contain
-                                                      the '..' path or start with
-                                                      '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -5531,116 +2230,42 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
                                                     type: string
                                                   optional:
-                                                    description: optional specify
-                                                      whether the ConfigMap or its
-                                                      keys must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               downwardAPI:
-                                                description: downwardAPI information
-                                                  about the downwardAPI data to project
                                                 properties:
                                                   items:
-                                                    description: Items is a list of
-                                                      DownwardAPIVolume file
                                                     items:
-                                                      description: DownwardAPIVolumeFile
-                                                        represents information to
-                                                        create the file containing
-                                                        the pod field
                                                       properties:
                                                         fieldRef:
-                                                          description: 'Required:
-                                                            Selects a field of the
-                                                            pod: only annotations,
-                                                            labels, name and namespace
-                                                            are supported.'
                                                           properties:
                                                             apiVersion:
-                                                              description: Version
-                                                                of the schema the
-                                                                FieldPath is written
-                                                                in terms of, defaults
-                                                                to "v1".
                                                               type: string
                                                             fieldPath:
-                                                              description: Path of
-                                                                the field to select
-                                                                in the specified API
-                                                                version.
                                                               type: string
                                                           required:
                                                           - fieldPath
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file,
-                                                            must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: 'Required:
-                                                            Path is  the relative
-                                                            path name of the file
-                                                            to be created. Must not
-                                                            be absolute or contain
-                                                            the ''..'' path. Must
-                                                            be utf-8 encoded. The
-                                                            first item of the relative
-                                                            path must not start with
-                                                            ''..'''
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a
-                                                            resource of the container:
-                                                            only resources limits
-                                                            and requests (limits.cpu,
-                                                            limits.memory, requests.cpu
-                                                            and requests.memory) are
-                                                            currently supported.'
                                                           properties:
                                                             containerName:
-                                                              description: 'Container
-                                                                name: required for
-                                                                volumes, optional
-                                                                for env vars'
                                                               type: string
                                                             divisor:
                                                               anyOf:
                                                               - type: integer
                                                               - type: string
-                                                              description: Specifies
-                                                                the output format
-                                                                of the exposed resources,
-                                                                defaults to "1"
                                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                               x-kubernetes-int-or-string: true
                                                             resource:
-                                                              description: 'Required:
-                                                                resource to select'
                                                               type: string
                                                           required:
                                                           - resource
@@ -5652,64 +2277,16 @@ spec:
                                                     type: array
                                                 type: object
                                               secret:
-                                                description: secret information about
-                                                  the secret data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced Secret
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the Secret, the volume setup
-                                                      will error unless it is marked
-                                                      optional. Paths must be relative
-                                                      and may not contain the '..'
-                                                      path or start with '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -5717,55 +2294,19 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
                                                     type: string
                                                   optional:
-                                                    description: optional field specify
-                                                      whether the Secret or its key
-                                                      must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               serviceAccountToken:
-                                                description: serviceAccountToken is
-                                                  information about the serviceAccountToken
-                                                  data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended
-                                                      audience of the token. A recipient
-                                                      of a token must identify itself
-                                                      with an identifier specified
-                                                      in the audience of the token,
-                                                      and otherwise should reject
-                                                      the token. The audience defaults
-                                                      to the identifier of the apiserver.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: expirationSeconds
-                                                      is the requested duration of
-                                                      validity of the service account
-                                                      token. As the token approaches
-                                                      expiration, the kubelet volume
-                                                      plugin will proactively rotate
-                                                      the service account token. The
-                                                      kubelet will start trying to
-                                                      rotate the token if the token
-                                                      is older than 80 percent of
-                                                      its time to live or if the token
-                                                      is older than 24 hours.Defaults
-                                                      to 1 hour and must be at least
-                                                      10 minutes.
                                                     format: int64
                                                     type: integer
                                                   path:
-                                                    description: path is the path
-                                                      relative to the mount point
-                                                      of the file to project the token
-                                                      into.
                                                     type: string
                                                 required:
                                                 - path
@@ -5774,168 +2315,76 @@ spec:
                                           type: array
                                       type: object
                                     quobyte:
-                                      description: quobyte represents a Quobyte mount
-                                        on the host that shares a pod's lifetime
                                       properties:
                                         group:
-                                          description: group to map volume access
-                                            to Default is no group
                                           type: string
                                         readOnly:
-                                          description: readOnly here will force the
-                                            Quobyte volume to be mounted with read-only
-                                            permissions. Defaults to false.
                                           type: boolean
                                         registry:
-                                          description: registry represents a single
-                                            or multiple Quobyte Registry services
-                                            specified as a string as host:port pair
-                                            (multiple entries are separated with commas)
-                                            which acts as the central registry for
-                                            volumes
                                           type: string
                                         tenant:
-                                          description: tenant owning the given Quobyte
-                                            volume in the Backend Used with dynamically
-                                            provisioned Quobyte volumes, value is
-                                            set by the plugin
                                           type: string
                                         user:
-                                          description: user to map volume access to
-                                            Defaults to serivceaccount user
                                           type: string
                                         volume:
-                                          description: volume is a string that references
-                                            an already created Quobyte volume by name.
                                           type: string
                                       required:
                                       - registry
                                       - volume
                                       type: object
                                     rbd:
-                                      description: 'rbd represents a Rados Block Device
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         image:
-                                          description: 'image is the rados image name.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         keyring:
-                                          description: 'keyring is the path to key
-                                            ring for RBDUser. Default is /etc/ceph/keyring.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         monitors:
-                                          description: 'monitors is a collection of
-                                            Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           items:
                                             type: string
                                           type: array
                                         pool:
-                                          description: 'pool is the rados pool name.
-                                            Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is name of the authentication
-                                            secret for RBDUser. If provided overrides
-                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is the rados user name.
-                                            Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                       required:
                                       - image
                                       - monitors
                                       type: object
                                     scaleIO:
-                                      description: scaleIO represents a ScaleIO persistent
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Default is "xfs".
                                           type: string
                                         gateway:
-                                          description: gateway is the host address
-                                            of the ScaleIO API Gateway.
                                           type: string
                                         protectionDomain:
-                                          description: protectionDomain is the name
-                                            of the ScaleIO Protection Domain for the
-                                            configured storage.
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef references to the
-                                            secret for ScaleIO user and other sensitive
-                                            information. If this is not provided,
-                                            Login operation will fail.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         sslEnabled:
-                                          description: sslEnabled Flag enable/disable
-                                            SSL communication with Gateway, default
-                                            false
                                           type: boolean
                                         storageMode:
-                                          description: storageMode indicates whether
-                                            the storage for a volume should be ThickProvisioned
-                                            or ThinProvisioned. Default is ThinProvisioned.
                                           type: string
                                         storagePool:
-                                          description: storagePool is the ScaleIO
-                                            Storage Pool associated with the protection
-                                            domain.
                                           type: string
                                         system:
-                                          description: system is the name of the storage
-                                            system as configured in ScaleIO.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the name of a
-                                            volume already created in the ScaleIO
-                                            system that is associated with this volume
-                                            source.
                                           type: string
                                       required:
                                       - gateway
@@ -5943,68 +2392,19 @@ spec:
                                       - system
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that
-                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced Secret will be projected into
-                                            the volume as a file whose name is the
-                                            key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the Secret, the
-                                            volume setup will error unless it is marked
-                                            optional. Paths must be relative and may
-                                            not contain the '..' path or start with
-                                            '..'.
                                           items:
-                                            description: Maps a string key to a path
-                                              within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
@@ -6012,90 +2412,36 @@ spec:
                                             type: object
                                           type: array
                                         optional:
-                                          description: optional field specify whether
-                                            the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of
-                                            the secret in the pod''s namespace to
-                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                           type: string
                                       type: object
                                     storageos:
-                                      description: storageOS represents a StorageOS
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef specifies the secret
-                                            to use for obtaining the StorageOS API
-                                            credentials.  If not specified, default
-                                            values will be attempted.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeName:
-                                          description: volumeName is the human-readable
-                                            name of the StorageOS volume.  Volume
-                                            names are only unique within a namespace.
                                           type: string
                                         volumeNamespace:
-                                          description: volumeNamespace specifies the
-                                            scope of the volume within StorageOS.  If
-                                            no namespace is specified then the Pod's
-                                            namespace will be used.  This allows the
-                                            Kubernetes name scoping to be mirrored
-                                            within StorageOS for tighter integration.
-                                            Set VolumeName to any name to override
-                                            the default behaviour. Set to "default"
-                                            if you are not using namespaces within
-                                            StorageOS. Namespaces that do not pre-exist
-                                            within StorageOS will be created.
                                           type: string
                                       type: object
                                     vsphereVolume:
-                                      description: vsphereVolume represents a vSphere
-                                        volume attached and mounted on kubelets host
-                                        machine
                                       properties:
                                         fsType:
-                                          description: fsType is filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         storagePolicyID:
-                                          description: storagePolicyID is the storage
-                                            Policy Based Management (SPBM) profile
-                                            ID associated with the StoragePolicyName.
                                           type: string
                                         storagePolicyName:
-                                          description: storagePolicyName is the storage
-                                            Policy Based Management (SPBM) profile
-                                            name.
                                           type: string
                                         volumePath:
-                                          description: volumePath is the path that
-                                            identifies vSphere volume vmdk
                                           type: string
                                       required:
                                       - volumePath
@@ -6118,59 +2464,35 @@ spec:
                       type: object
                     type: array
                   networkAttachments:
-                    description: NetworkAttachments is a list of NetworkAttachment
-                      resource names to expose the services to the given network
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes running
-                      this service. Setting here overrides any global NodeSelector
-                      settings within the Manila CR.
                     type: object
                   passwordSelectors:
                     default:
                       database: ManilaDatabasePassword
                       service: ManilaPassword
-                    description: PasswordSelectors - Selectors to identify the DB
-                      and ServiceUser password from the Secret
                     properties:
                       database:
                         default: ManilaDatabasePassword
-                        description: 'Database - Selector to get the manila database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
                         type: string
                       service:
                         default: ManilaPassword
-                        description: Service - Selector to get the manila service
-                          password from the Secret
                         type: string
                     type: object
                   replicas:
                     default: 1
-                    description: Replicas - manila Scheduler Replicas
                     format: int32
                     type: integer
                   resources:
-                    description: Resources - Compute Resources required by this service
-                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     properties:
                       claims:
-                        description: "Claims lists the names of resources, defined
-                          in spec.resourceClaims, that are used by this container.
-                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable."
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: Name must match the name of one entry in
-                                pod.spec.resourceClaims of the Pod where this field
-                                is used. It makes that resource available inside a
-                                container.
                               type: string
                           required:
                           - name
@@ -6186,8 +2508,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                       requests:
                         additionalProperties:
@@ -6196,128 +2516,64 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   secret:
-                    description: Secret containing OpenStack password information
-                      for manilaDatabasePassword
                     type: string
                   serviceUser:
                     default: manila
-                    description: ServiceUser - optional username used for this service
-                      to register in manila
                     type: string
                   transportURLSecret:
-                    description: Secret containing RabbitMq transport URL
                     type: string
                 type: object
               manilaShares:
                 additionalProperties:
-                  description: ManilaShareSpec defines the desired state of ManilaShare
                   properties:
                     containerImage:
-                      description: ContainerImage - manila Volume Container Image
-                        URL
                       type: string
                     customServiceConfig:
                       default: '# add your customization here'
-                      description: CustomServiceConfig - customize the service config
-                        using this parameter to change service defaults, or overwrite
-                        rendered information using raw OpenStack config format. The
-                        content gets added to to /etc/<service>/<service>.conf.d directory
-                        as custom.conf file.
                       type: string
                     databaseHostname:
-                      description: DatabaseHostname - manila Database Hostname
                       type: string
                     databaseUser:
                       default: manila
-                      description: 'DatabaseUser - optional username used for manila
-                        DB, defaults to manila TODO: -> implement needs work in mariadb-operator,
-                        right now only manila'
                       type: string
                     debug:
-                      description: Debug - enable debug for different deploy stages.
-                        If an init container is used, it runs and the actual action
-                        pod gets started with sleep infinity
                       properties:
                         initContainer:
                           default: false
-                          description: initContainer enable debug (waits until /tmp/stop-init-container
-                            disappears)
                           type: boolean
                         service:
                           default: false
-                          description: service enable debug
                           type: boolean
                       type: object
                     defaultConfigOverwrite:
                       additionalProperties:
                         type: string
-                      description: ConfigOverwrite - interface to overwrite default
-                        config files like e.g. policy.json. But can also be used to
-                        add additional files. Those get added to the service config
-                        dir in /etc/<service> .
                       type: object
                     extraMounts:
-                      description: ExtraMounts containing conf files and credentials
                       items:
-                        description: ManilaExtraVolMounts exposes additional parameters
-                          processed by the manila-operator and defines the common
-                          VolMounts structure provided by the main storage module
                         properties:
                           extraVol:
                             items:
-                              description: VolMounts is the data structure used to
-                                expose Volumes and Mounts that can be added to a pod
-                                according to the defined Propagation policy
                               properties:
                                 extraVolType:
-                                  description: Label associated to a given extraMount
                                   type: string
                                 mounts:
                                   items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: Path within the container at
-                                          which the volume should be mounted.  Must
-                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: mountPropagation determines how
-                                          mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
                                         type: string
                                       name:
-                                        description: This must match the Name of a
-                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: Mounted read-only if true, read-write
-                                          otherwise (false or unspecified). Defaults
-                                          to false.
                                         type: boolean
                                       subPath:
-                                        description: Path within the volume from which
-                                          the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: Expanded path within the volume
-                                          from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -6325,280 +2581,110 @@ spec:
                                     type: object
                                   type: array
                                 propagation:
-                                  description: Propagation defines which pod should
-                                    mount the volume
                                   items:
-                                    description: PropagationType identifies the Service,
-                                      Group or instance (e.g. the backend) that receives
-                                      an Extra Volume that can potentially be mounted
                                     type: string
                                   type: array
                                 volumes:
                                   items:
-                                    description: Volume represents a named volume
-                                      in a pod that may be accessed by any container
-                                      in the pod.
                                     properties:
                                       awsElasticBlockStore:
-                                        description: 'awsElasticBlockStore represents
-                                          an AWS Disk resource that is attached to
-                                          a kubelet''s host machine and then exposed
-                                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         properties:
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type of the volume that you want to
-                                              mount. Tip: Ensure that the filesystem
-                                              type is supported by the host operating
-                                              system. Examples: "ext4", "xfs", "ntfs".
-                                              Implicitly inferred to be "ext4" if
-                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           partition:
-                                            description: 'partition is the partition
-                                              in the volume that you want to mount.
-                                              If omitted, the default is to mount
-                                              by volume name. Examples: For volume
-                                              /dev/sda1, you specify the partition
-                                              as "1". Similarly, the volume partition
-                                              for /dev/sda is "0" (or you can leave
-                                              the property empty).'
                                             format: int32
                                             type: integer
                                           readOnly:
-                                            description: 'readOnly value true will
-                                              force the readOnly setting in VolumeMounts.
-                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                             type: boolean
                                           volumeID:
-                                            description: 'volumeID is unique ID of
-                                              the persistent disk resource in AWS
-                                              (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                             type: string
                                         required:
                                         - volumeID
                                         type: object
                                       azureDisk:
-                                        description: azureDisk represents an Azure
-                                          Data Disk mount on the host and bind mount
-                                          to the pod.
                                         properties:
                                           cachingMode:
-                                            description: 'cachingMode is the Host
-                                              Caching mode: None, Read Only, Read
-                                              Write.'
                                             type: string
                                           diskName:
-                                            description: diskName is the Name of the
-                                              data disk in the blob storage
                                             type: string
                                           diskURI:
-                                            description: diskURI is the URI of data
-                                              disk in the blob storage
                                             type: string
                                           fsType:
-                                            description: fsType is Filesystem type
-                                              to mount. Must be a filesystem type
-                                              supported by the host operating system.
-                                              Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           kind:
-                                            description: 'kind expected values are
-                                              Shared: multiple blob disks per storage
-                                              account  Dedicated: single blob disk
-                                              per storage account  Managed: azure
-                                              managed data disk (only in managed availability
-                                              set). defaults to shared'
                                             type: string
                                           readOnly:
-                                            description: readOnly Defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                         required:
                                         - diskName
                                         - diskURI
                                         type: object
                                       azureFile:
-                                        description: azureFile represents an Azure
-                                          File Service mount on the host and bind
-                                          mount to the pod.
                                         properties:
                                           readOnly:
-                                            description: readOnly defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           secretName:
-                                            description: secretName is the  name of
-                                              secret that contains Azure Storage Account
-                                              Name and Key
                                             type: string
                                           shareName:
-                                            description: shareName is the azure share
-                                              Name
                                             type: string
                                         required:
                                         - secretName
                                         - shareName
                                         type: object
                                       cephfs:
-                                        description: cephFS represents a Ceph FS mount
-                                          on the host that shares a pod's lifetime
                                         properties:
                                           monitors:
-                                            description: 'monitors is Required: Monitors
-                                              is a collection of Ceph monitors More
-                                              info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             items:
                                               type: string
                                             type: array
                                           path:
-                                            description: 'path is Optional: Used as
-                                              the mounted root, rather than the full
-                                              Ceph tree, default is /'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly is Optional: Defaults
-                                              to false (read/write). ReadOnly here
-                                              will force the ReadOnly setting in VolumeMounts.
-                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             type: boolean
                                           secretFile:
-                                            description: 'secretFile is Optional:
-                                              SecretFile is the path to key ring for
-                                              User, default is /etc/ceph/user.secret
-                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             type: string
                                           secretRef:
-                                            description: 'secretRef is Optional: SecretRef
-                                              is reference to the authentication secret
-                                              for User, default is empty. More info:
-                                              https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           user:
-                                            description: 'user is optional: User is
-                                              the rados user name, default is admin
-                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             type: string
                                         required:
                                         - monitors
                                         type: object
                                       cinder:
-                                        description: 'cinder represents a cinder volume
-                                          attached and mounted on kubelets host machine.
-                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         properties:
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Examples: "ext4", "xfs", "ntfs".
-                                              Implicitly inferred to be "ext4" if
-                                              unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
-                                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                             type: boolean
                                           secretRef:
-                                            description: 'secretRef is optional: points
-                                              to a secret object containing parameters
-                                              used to connect to OpenStack.'
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           volumeID:
-                                            description: 'volumeID used to identify
-                                              the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                             type: string
                                         required:
                                         - volumeID
                                         type: object
                                       configMap:
-                                        description: configMap represents a configMap
-                                          that should populate this volume
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is optional:
-                                              mode bits used to set permissions on
-                                              created files by default. Must be an
-                                              octal value between 0000 and 0777 or
-                                              a decimal value between 0 and 511. YAML
-                                              accepts both octal and decimal values,
-                                              JSON requires decimal values for mode
-                                              bits. Defaults to 0644. Directories
-                                              within the path are not affected by
-                                              this setting. This might be in conflict
-                                              with other options that affect the file
-                                              mode, like fsGroup, and the result can
-                                              be other mode bits set.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced ConfigMap will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the ConfigMap, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
                                                   type: string
                                               required:
                                               - key
@@ -6606,171 +2692,66 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       csi:
-                                        description: csi (Container Storage Interface)
-                                          represents ephemeral storage that is handled
-                                          by certain external CSI drivers (Beta feature).
                                         properties:
                                           driver:
-                                            description: driver is the name of the
-                                              CSI driver that handles this volume.
-                                              Consult with your admin for the correct
-                                              name as registered in the cluster.
                                             type: string
                                           fsType:
-                                            description: fsType to mount. Ex. "ext4",
-                                              "xfs", "ntfs". If not provided, the
-                                              empty value is passed to the associated
-                                              CSI driver which will determine the
-                                              default filesystem to apply.
                                             type: string
                                           nodePublishSecretRef:
-                                            description: nodePublishSecretRef is a
-                                              reference to the secret object containing
-                                              sensitive information to pass to the
-                                              CSI driver to complete the CSI NodePublishVolume
-                                              and NodeUnpublishVolume calls. This
-                                              field is optional, and  may be empty
-                                              if no secret is required. If the secret
-                                              object contains more than one secret,
-                                              all secret references are passed.
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           readOnly:
-                                            description: readOnly specifies a read-only
-                                              configuration for the volume. Defaults
-                                              to false (read/write).
                                             type: boolean
                                           volumeAttributes:
                                             additionalProperties:
                                               type: string
-                                            description: volumeAttributes stores driver-specific
-                                              properties that are passed to the CSI
-                                              driver. Consult your driver's documentation
-                                              for supported values.
                                             type: object
                                         required:
                                         - driver
                                         type: object
                                       downwardAPI:
-                                        description: downwardAPI represents downward
-                                          API about the pod that should populate this
-                                          volume
                                         properties:
                                           defaultMode:
-                                            description: 'Optional: mode bits to use
-                                              on created files by default. Must be
-                                              a Optional: mode bits used to set permissions
-                                              on created files by default. Must be
-                                              an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. Defaults to 0644. Directories
-                                              within the path are not affected by
-                                              this setting. This might be in conflict
-                                              with other options that affect the file
-                                              mode, like fsGroup, and the result can
-                                              be other mode bits set.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: Items is a list of downward
-                                              API volume file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file, must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: 'Selects a resource
-                                                    of the container: only resources
-                                                    limits and requests (limits.cpu,
-                                                    limits.memory, requests.cpu and
-                                                    requests.memory) are currently
-                                                    supported.'
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -6782,150 +2763,35 @@ spec:
                                             type: array
                                         type: object
                                       emptyDir:
-                                        description: 'emptyDir represents a temporary
-                                          directory that shares a pod''s lifetime.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         properties:
                                           medium:
-                                            description: 'medium represents what type
-                                              of storage medium should back this directory.
-                                              The default is "" which means to use
-                                              the node''s default medium. Must be
-                                              an empty string (default) or Memory.
-                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                             type: string
                                           sizeLimit:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: 'sizeLimit is the total amount
-                                              of local storage required for this EmptyDir
-                                              volume. The size limit is also applicable
-                                              for memory medium. The maximum usage
-                                              on memory medium EmptyDir would be the
-                                              minimum value between the SizeLimit
-                                              specified here and the sum of memory
-                                              limits of all containers in a pod. The
-                                              default is nil which means that the
-                                              limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       ephemeral:
-                                        description: "ephemeral represents a volume
-                                          that is handled by a cluster storage driver.
-                                          The volume's lifecycle is tied to the pod
-                                          that defines it - it will be created before
-                                          the pod starts, and deleted when the pod
-                                          is removed. \n Use this if: a) the volume
-                                          is only needed while the pod runs, b) features
-                                          of normal volumes like restoring from snapshot
-                                          or capacity tracking are needed, c) the
-                                          storage driver is specified through a storage
-                                          class, and d) the storage driver supports
-                                          dynamic volume provisioning through a PersistentVolumeClaim
-                                          (see EphemeralVolumeSource for more information
-                                          on the connection between this volume type
-                                          and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                          or one of the vendor-specific APIs for volumes
-                                          that persist for longer than the lifecycle
-                                          of an individual pod. \n Use CSI for light-weight
-                                          local ephemeral volumes if the CSI driver
-                                          is meant to be used that way - see the documentation
-                                          of the driver for more information. \n A
-                                          pod can use both types of ephemeral volumes
-                                          and persistent volumes at the same time."
                                         properties:
                                           volumeClaimTemplate:
-                                            description: "Will be used to create a
-                                              stand-alone PVC to provision the volume.
-                                              The pod in which this EphemeralVolumeSource
-                                              is embedded will be the owner of the
-                                              PVC, i.e. the PVC will be deleted together
-                                              with the pod.  The name of the PVC will
-                                              be `<pod name>-<volume name>` where
-                                              `<volume name>` is the name from the
-                                              `PodSpec.Volumes` array entry. Pod validation
-                                              will reject the pod if the concatenated
-                                              name is not valid for a PVC (for example,
-                                              too long). \n An existing PVC with that
-                                              name that is not owned by the pod will
-                                              *not* be used for the pod to avoid using
-                                              an unrelated volume by mistake. Starting
-                                              the pod is then blocked until the unrelated
-                                              PVC is removed. If such a pre-created
-                                              PVC is meant to be used by the pod,
-                                              the PVC has to updated with an owner
-                                              reference to the pod once the pod exists.
-                                              Normally this should not be necessary,
-                                              but it may be useful when manually reconstructing
-                                              a broken cluster. \n This field is read-only
-                                              and no changes will be made by Kubernetes
-                                              to the PVC after it has been created.
-                                              \n Required, must not be nil."
                                             properties:
                                               metadata:
-                                                description: May contain labels and
-                                                  annotations that will be copied
-                                                  into the PVC when creating it. No
-                                                  other fields are allowed and will
-                                                  be rejected during validation.
                                                 type: object
                                               spec:
-                                                description: The specification for
-                                                  the PersistentVolumeClaim. The entire
-                                                  content is copied unchanged into
-                                                  the PVC that gets created from this
-                                                  template. The same fields as in
-                                                  a PersistentVolumeClaim are also
-                                                  valid here.
                                                 properties:
                                                   accessModes:
-                                                    description: 'accessModes contains
-                                                      the desired access modes the
-                                                      volume should have. More info:
-                                                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                     items:
                                                       type: string
                                                     type: array
                                                   dataSource:
-                                                    description: 'dataSource field
-                                                      can be used to specify either:
-                                                      * An existing VolumeSnapshot
-                                                      object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                      * An existing PVC (PersistentVolumeClaim)
-                                                      If the provisioner or an external
-                                                      controller can support the specified
-                                                      data source, it will create
-                                                      a new volume based on the contents
-                                                      of the specified data source.
-                                                      When the AnyVolumeDataSource
-                                                      feature gate is enabled, dataSource
-                                                      contents will be copied to dataSourceRef,
-                                                      and dataSourceRef contents will
-                                                      be copied to dataSource when
-                                                      dataSourceRef.namespace is not
-                                                      specified. If the namespace
-                                                      is specified, then dataSourceRef
-                                                      will not be copied to dataSource.'
                                                     properties:
                                                       apiGroup:
-                                                        description: APIGroup is the
-                                                          group for the resource being
-                                                          referenced. If APIGroup
-                                                          is not specified, the specified
-                                                          Kind must be in the core
-                                                          API group. For any other
-                                                          third-party types, APIGroup
-                                                          is required.
                                                         type: string
                                                       kind:
-                                                        description: Kind is the type
-                                                          of resource being referenced
                                                         type: string
                                                       name:
-                                                        description: Name is the name
-                                                          of resource being referenced
                                                         type: string
                                                     required:
                                                     - kind
@@ -6933,128 +2799,25 @@ spec:
                                                     type: object
                                                     x-kubernetes-map-type: atomic
                                                   dataSourceRef:
-                                                    description: 'dataSourceRef specifies
-                                                      the object from which to populate
-                                                      the volume with data, if a non-empty
-                                                      volume is desired. This may
-                                                      be any object from a non-empty
-                                                      API group (non core object)
-                                                      or a PersistentVolumeClaim object.
-                                                      When this field is specified,
-                                                      volume binding will only succeed
-                                                      if the type of the specified
-                                                      object matches some installed
-                                                      volume populator or dynamic
-                                                      provisioner. This field will
-                                                      replace the functionality of
-                                                      the dataSource field and as
-                                                      such if both fields are non-empty,
-                                                      they must have the same value.
-                                                      For backwards compatibility,
-                                                      when namespace isn''t specified
-                                                      in dataSourceRef, both fields
-                                                      (dataSource and dataSourceRef)
-                                                      will be set to the same value
-                                                      automatically if one of them
-                                                      is empty and the other is non-empty.
-                                                      When namespace is specified
-                                                      in dataSourceRef, dataSource
-                                                      isn''t set to the same value
-                                                      and must be empty. There are
-                                                      three important differences
-                                                      between dataSource and dataSourceRef:
-                                                      * While dataSource only allows
-                                                      two specific types of objects,
-                                                      dataSourceRef allows any non-core
-                                                      object, as well as PersistentVolumeClaim
-                                                      objects. * While dataSource
-                                                      ignores disallowed values (dropping
-                                                      them), dataSourceRef preserves
-                                                      all values, and generates an
-                                                      error if a disallowed value
-                                                      is specified. * While dataSource
-                                                      only allows local objects, dataSourceRef
-                                                      allows objects in any namespaces.
-                                                      (Beta) Using this field requires
-                                                      the AnyVolumeDataSource feature
-                                                      gate to be enabled. (Alpha)
-                                                      Using the namespace field of
-                                                      dataSourceRef requires the CrossNamespaceVolumeDataSource
-                                                      feature gate to be enabled.'
                                                     properties:
                                                       apiGroup:
-                                                        description: APIGroup is the
-                                                          group for the resource being
-                                                          referenced. If APIGroup
-                                                          is not specified, the specified
-                                                          Kind must be in the core
-                                                          API group. For any other
-                                                          third-party types, APIGroup
-                                                          is required.
                                                         type: string
                                                       kind:
-                                                        description: Kind is the type
-                                                          of resource being referenced
                                                         type: string
                                                       name:
-                                                        description: Name is the name
-                                                          of resource being referenced
                                                         type: string
                                                       namespace:
-                                                        description: Namespace is
-                                                          the namespace of resource
-                                                          being referenced Note that
-                                                          when a namespace is specified,
-                                                          a gateway.networking.k8s.io/ReferenceGrant
-                                                          object is required in the
-                                                          referent namespace to allow
-                                                          that namespace's owner to
-                                                          accept the reference. See
-                                                          the ReferenceGrant documentation
-                                                          for details. (Alpha) This
-                                                          field requires the CrossNamespaceVolumeDataSource
-                                                          feature gate to be enabled.
                                                         type: string
                                                     required:
                                                     - kind
                                                     - name
                                                     type: object
                                                   resources:
-                                                    description: 'resources represents
-                                                      the minimum resources the volume
-                                                      should have. If RecoverVolumeExpansionFailure
-                                                      feature is enabled users are
-                                                      allowed to specify resource
-                                                      requirements that are lower
-                                                      than previous value but must
-                                                      still be higher than capacity
-                                                      recorded in the status field
-                                                      of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                     properties:
                                                       claims:
-                                                        description: "Claims lists
-                                                          the names of resources,
-                                                          defined in spec.resourceClaims,
-                                                          that are used by this container.
-                                                          \n This is an alpha field
-                                                          and requires enabling the
-                                                          DynamicResourceAllocation
-                                                          feature gate. \n This field
-                                                          is immutable."
                                                         items:
-                                                          description: ResourceClaim
-                                                            references one entry in
-                                                            PodSpec.ResourceClaims.
                                                           properties:
                                                             name:
-                                                              description: Name must
-                                                                match the name of
-                                                                one entry in pod.spec.resourceClaims
-                                                                of the Pod where this
-                                                                field is used. It
-                                                                makes that resource
-                                                                available inside a
-                                                                container.
                                                               type: string
                                                           required:
                                                           - name
@@ -7070,10 +2833,6 @@ spec:
                                                           - type: string
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
-                                                        description: 'Limits describes
-                                                          the maximum amount of compute
-                                                          resources allowed. More
-                                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                         type: object
                                                       requests:
                                                         additionalProperties:
@@ -7082,63 +2841,18 @@ spec:
                                                           - type: string
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
-                                                        description: 'Requests describes
-                                                          the minimum amount of compute
-                                                          resources required. If Requests
-                                                          is omitted for a container,
-                                                          it defaults to Limits if
-                                                          that is explicitly specified,
-                                                          otherwise to an implementation-defined
-                                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                         type: object
                                                     type: object
                                                   selector:
-                                                    description: selector is a label
-                                                      query over volumes to consider
-                                                      for binding.
                                                     properties:
                                                       matchExpressions:
-                                                        description: matchExpressions
-                                                          is a list of label selector
-                                                          requirements. The requirements
-                                                          are ANDed.
                                                         items:
-                                                          description: A label selector
-                                                            requirement is a selector
-                                                            that contains values,
-                                                            a key, and an operator
-                                                            that relates the key and
-                                                            values.
                                                           properties:
                                                             key:
-                                                              description: key is
-                                                                the label key that
-                                                                the selector applies
-                                                                to.
                                                               type: string
                                                             operator:
-                                                              description: operator
-                                                                represents a key's
-                                                                relationship to a
-                                                                set of values. Valid
-                                                                operators are In,
-                                                                NotIn, Exists and
-                                                                DoesNotExist.
                                                               type: string
                                                             values:
-                                                              description: values
-                                                                is an array of string
-                                                                values. If the operator
-                                                                is In or NotIn, the
-                                                                values array must
-                                                                be non-empty. If the
-                                                                operator is Exists
-                                                                or DoesNotExist, the
-                                                                values array must
-                                                                be empty. This array
-                                                                is replaced during
-                                                                a strategic merge
-                                                                patch.
                                                               items:
                                                                 type: string
                                                               type: array
@@ -7150,36 +2864,14 @@ spec:
                                                       matchLabels:
                                                         additionalProperties:
                                                           type: string
-                                                        description: matchLabels is
-                                                          a map of {key,value} pairs.
-                                                          A single {key,value} in
-                                                          the matchLabels map is equivalent
-                                                          to an element of matchExpressions,
-                                                          whose key field is "key",
-                                                          the operator is "In", and
-                                                          the values array contains
-                                                          only "value". The requirements
-                                                          are ANDed.
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
                                                   storageClassName:
-                                                    description: 'storageClassName
-                                                      is the name of the StorageClass
-                                                      required by the claim. More
-                                                      info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                     type: string
                                                   volumeMode:
-                                                    description: volumeMode defines
-                                                      what type of volume is required
-                                                      by the claim. Value of Filesystem
-                                                      is implied when not included
-                                                      in claim spec.
                                                     type: string
                                                   volumeName:
-                                                    description: volumeName is the
-                                                      binding reference to the PersistentVolume
-                                                      backing this claim.
                                                     type: string
                                                 type: object
                                             required:
@@ -7187,88 +2879,38 @@ spec:
                                             type: object
                                         type: object
                                       fc:
-                                        description: fc represents a Fibre Channel
-                                          resource that is attached to a kubelet's
-                                          host machine and then exposed to the pod.
                                         properties:
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           lun:
-                                            description: 'lun is Optional: FC target
-                                              lun number'
                                             format: int32
                                             type: integer
                                           readOnly:
-                                            description: 'readOnly is Optional: Defaults
-                                              to false (read/write). ReadOnly here
-                                              will force the ReadOnly setting in VolumeMounts.'
                                             type: boolean
                                           targetWWNs:
-                                            description: 'targetWWNs is Optional:
-                                              FC target worldwide names (WWNs)'
                                             items:
                                               type: string
                                             type: array
                                           wwids:
-                                            description: 'wwids Optional: FC volume
-                                              world wide identifiers (wwids) Either
-                                              wwids or combination of targetWWNs and
-                                              lun must be set, but not both simultaneously.'
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       flexVolume:
-                                        description: flexVolume represents a generic
-                                          volume resource that is provisioned/attached
-                                          using an exec based plugin.
                                         properties:
                                           driver:
-                                            description: driver is the name of the
-                                              driver to use for this volume.
                                             type: string
                                           fsType:
-                                            description: fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". The
-                                              default filesystem depends on FlexVolume
-                                              script.
                                             type: string
                                           options:
                                             additionalProperties:
                                               type: string
-                                            description: 'options is Optional: this
-                                              field holds extra command options if
-                                              any.'
                                             type: object
                                           readOnly:
-                                            description: 'readOnly is Optional: defaults
-                                              to false (read/write). ReadOnly here
-                                              will force the ReadOnly setting in VolumeMounts.'
                                             type: boolean
                                           secretRef:
-                                            description: 'secretRef is Optional: secretRef
-                                              is reference to the secret object containing
-                                              sensitive information to pass to the
-                                              plugin scripts. This may be empty if
-                                              no secret object is specified. If the
-                                              secret object contains more than one
-                                              secret, all secrets are passed to the
-                                              plugin scripts.'
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
@@ -7276,220 +2918,88 @@ spec:
                                         - driver
                                         type: object
                                       flocker:
-                                        description: flocker represents a Flocker
-                                          volume attached to a kubelet's host machine.
-                                          This depends on the Flocker control service
-                                          being running
                                         properties:
                                           datasetName:
-                                            description: datasetName is Name of the
-                                              dataset stored as metadata -> name on
-                                              the dataset for Flocker should be considered
-                                              as deprecated
                                             type: string
                                           datasetUUID:
-                                            description: datasetUUID is the UUID of
-                                              the dataset. This is unique identifier
-                                              of a Flocker dataset
                                             type: string
                                         type: object
                                       gcePersistentDisk:
-                                        description: 'gcePersistentDisk represents
-                                          a GCE Disk resource that is attached to
-                                          a kubelet''s host machine and then exposed
-                                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         properties:
                                           fsType:
-                                            description: 'fsType is filesystem type
-                                              of the volume that you want to mount.
-                                              Tip: Ensure that the filesystem type
-                                              is supported by the host operating system.
-                                              Examples: "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
-                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           partition:
-                                            description: 'partition is the partition
-                                              in the volume that you want to mount.
-                                              If omitted, the default is to mount
-                                              by volume name. Examples: For volume
-                                              /dev/sda1, you specify the partition
-                                              as "1". Similarly, the volume partition
-                                              for /dev/sda is "0" (or you can leave
-                                              the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                             format: int32
                                             type: integer
                                           pdName:
-                                            description: 'pdName is unique name of
-                                              the PD resource in GCE. Used to identify
-                                              the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
-                                              Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                             type: boolean
                                         required:
                                         - pdName
                                         type: object
                                       gitRepo:
-                                        description: 'gitRepo represents a git repository
-                                          at a particular revision. DEPRECATED: GitRepo
-                                          is deprecated. To provision a container
-                                          with a git repo, mount an EmptyDir into
-                                          an InitContainer that clones the repo using
-                                          git, then mount the EmptyDir into the Pod''s
-                                          container.'
                                         properties:
                                           directory:
-                                            description: directory is the target directory
-                                              name. Must not contain or start with
-                                              '..'.  If '.' is supplied, the volume
-                                              directory will be the git repository.  Otherwise,
-                                              if specified, the volume will contain
-                                              the git repository in the subdirectory
-                                              with the given name.
                                             type: string
                                           repository:
-                                            description: repository is the URL
                                             type: string
                                           revision:
-                                            description: revision is the commit hash
-                                              for the specified revision.
                                             type: string
                                         required:
                                         - repository
                                         type: object
                                       glusterfs:
-                                        description: 'glusterfs represents a Glusterfs
-                                          mount on the host that shares a pod''s lifetime.
-                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                         properties:
                                           endpoints:
-                                            description: 'endpoints is the endpoint
-                                              name that details Glusterfs topology.
-                                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                             type: string
                                           path:
-                                            description: 'path is the Glusterfs volume
-                                              path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly here will force
-                                              the Glusterfs volume to be mounted with
-                                              read-only permissions. Defaults to false.
-                                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                             type: boolean
                                         required:
                                         - endpoints
                                         - path
                                         type: object
                                       hostPath:
-                                        description: 'hostPath represents a pre-existing
-                                          file or directory on the host machine that
-                                          is directly exposed to the container. This
-                                          is generally used for system agents or other
-                                          privileged things that are allowed to see
-                                          the host machine. Most containers will NOT
-                                          need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                          --- TODO(jonesdl) We need to restrict who
-                                          can use host directory mounts and who can/can
-                                          not mount host directories as read/write.'
                                         properties:
                                           path:
-                                            description: 'path of the directory on
-                                              the host. If the path is a symlink,
-                                              it will follow the link to the real
-                                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                             type: string
                                           type:
-                                            description: 'type for HostPath Volume
-                                              Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       iscsi:
-                                        description: 'iscsi represents an ISCSI Disk
-                                          resource that is attached to a kubelet''s
-                                          host machine and then exposed to the pod.
-                                          More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                         properties:
                                           chapAuthDiscovery:
-                                            description: chapAuthDiscovery defines
-                                              whether support iSCSI Discovery CHAP
-                                              authentication
                                             type: boolean
                                           chapAuthSession:
-                                            description: chapAuthSession defines whether
-                                              support iSCSI Session CHAP authentication
                                             type: boolean
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type of the volume that you want to
-                                              mount. Tip: Ensure that the filesystem
-                                              type is supported by the host operating
-                                              system. Examples: "ext4", "xfs", "ntfs".
-                                              Implicitly inferred to be "ext4" if
-                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           initiatorName:
-                                            description: initiatorName is the custom
-                                              iSCSI Initiator Name. If initiatorName
-                                              is specified with iscsiInterface simultaneously,
-                                              new iSCSI interface <target portal>:<volume
-                                              name> will be created for the connection.
                                             type: string
                                           iqn:
-                                            description: iqn is the target iSCSI Qualified
-                                              Name.
                                             type: string
                                           iscsiInterface:
-                                            description: iscsiInterface is the interface
-                                              Name that uses an iSCSI transport. Defaults
-                                              to 'default' (tcp).
                                             type: string
                                           lun:
-                                            description: lun represents iSCSI Target
-                                              Lun number.
                                             format: int32
                                             type: integer
                                           portals:
-                                            description: portals is the iSCSI Target
-                                              Portal List. The portal is either an
-                                              IP or ip_addr:port if the port is other
-                                              than default (typically TCP ports 860
-                                              and 3260).
                                             items:
                                               type: string
                                             type: array
                                           readOnly:
-                                            description: readOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
-                                              Defaults to false.
                                             type: boolean
                                           secretRef:
-                                            description: secretRef is the CHAP Secret
-                                              for iSCSI target and initiator authentication
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           targetPortal:
-                                            description: targetPortal is iSCSI Target
-                                              Portal. The Portal is either an IP or
-                                              ip_addr:port if the port is other than
-                                              default (typically TCP ports 860 and
-                                              3260).
                                             type: string
                                         required:
                                         - iqn
@@ -7497,185 +3007,67 @@ spec:
                                         - targetPortal
                                         type: object
                                       name:
-                                        description: 'name of the volume. Must be
-                                          a DNS_LABEL and unique within the pod. More
-                                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                       nfs:
-                                        description: 'nfs represents an NFS mount
-                                          on the host that shares a pod''s lifetime
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         properties:
                                           path:
-                                            description: 'path that is exported by
-                                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly here will force
-                                              the NFS export to be mounted with read-only
-                                              permissions. Defaults to false. More
-                                              info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                             type: boolean
                                           server:
-                                            description: 'server is the hostname or
-                                              IP address of the NFS server. More info:
-                                              https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                             type: string
                                         required:
                                         - path
                                         - server
                                         type: object
                                       persistentVolumeClaim:
-                                        description: 'persistentVolumeClaimVolumeSource
-                                          represents a reference to a PersistentVolumeClaim
-                                          in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         properties:
                                           claimName:
-                                            description: 'claimName is the name of
-                                              a PersistentVolumeClaim in the same
-                                              namespace as the pod using this volume.
-                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                             type: string
                                           readOnly:
-                                            description: readOnly Will force the ReadOnly
-                                              setting in VolumeMounts. Default false.
                                             type: boolean
                                         required:
                                         - claimName
                                         type: object
                                       photonPersistentDisk:
-                                        description: photonPersistentDisk represents
-                                          a PhotonController persistent disk attached
-                                          and mounted on kubelets host machine
                                         properties:
                                           fsType:
-                                            description: fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           pdID:
-                                            description: pdID is the ID that identifies
-                                              Photon Controller persistent disk
                                             type: string
                                         required:
                                         - pdID
                                         type: object
                                       portworxVolume:
-                                        description: portworxVolume represents a portworx
-                                          volume attached and mounted on kubelets
-                                          host machine
                                         properties:
                                           fsType:
-                                            description: fSType represents the filesystem
-                                              type to mount Must be a filesystem type
-                                              supported by the host operating system.
-                                              Ex. "ext4", "xfs". Implicitly inferred
-                                              to be "ext4" if unspecified.
                                             type: string
                                           readOnly:
-                                            description: readOnly defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           volumeID:
-                                            description: volumeID uniquely identifies
-                                              a Portworx volume
                                             type: string
                                         required:
                                         - volumeID
                                         type: object
                                       projected:
-                                        description: projected items for all in one
-                                          resources secrets, configmaps, and downward
-                                          API
                                         properties:
                                           defaultMode:
-                                            description: defaultMode are the mode
-                                              bits used to set permissions on created
-                                              files by default. Must be an octal value
-                                              between 0000 and 0777 or a decimal value
-                                              between 0 and 511. YAML accepts both
-                                              octal and decimal values, JSON requires
-                                              decimal values for mode bits. Directories
-                                              within the path are not affected by
-                                              this setting. This might be in conflict
-                                              with other options that affect the file
-                                              mode, like fsGroup, and the result can
-                                              be other mode bits set.
                                             format: int32
                                             type: integer
                                           sources:
-                                            description: sources is the list of volume
-                                              projections
                                             items:
-                                              description: Projection that may be
-                                                projected along with other supported
-                                                volume types
                                               properties:
                                                 configMap:
-                                                  description: configMap information
-                                                    about the configMap data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified,
-                                                        each key-value pair in the
-                                                        Data field of the referenced
-                                                        ConfigMap will be projected
-                                                        into the volume as a file
-                                                        whose name is the key and
-                                                        content is the value. If specified,
-                                                        the listed keys will be projected
-                                                        into the specified paths,
-                                                        and unlisted keys will not
-                                                        be present. If a key is specified
-                                                        which is not present in the
-                                                        ConfigMap, the volume setup
-                                                        will error unless it is marked
-                                                        optional. Paths must be relative
-                                                        and may not contain the '..'
-                                                        path or start with '..'.
                                                       items:
-                                                        description: Maps a string
-                                                          key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is
-                                                              Optional: mode bits
-                                                              used to set permissions
-                                                              on this file. Must be
-                                                              an octal value between
-                                                              0000 and 0777 or a decimal
-                                                              value between 0 and
-                                                              511. YAML accepts both
-                                                              octal and decimal values,
-                                                              JSON requires decimal
-                                                              values for mode bits.
-                                                              If not specified, the
-                                                              volume defaultMode will
-                                                              be used. This might
-                                                              be in conflict with
-                                                              other options that affect
-                                                              the file mode, like
-                                                              fsGroup, and the result
-                                                              can be other mode bits
-                                                              set.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the
-                                                              relative path of the
-                                                              file to map the key
-                                                              to. May not be an absolute
-                                                              path. May not contain
-                                                              the path element '..'.
-                                                              May not start with the
-                                                              string '..'.
                                                             type: string
                                                         required:
                                                         - key
@@ -7683,119 +3075,42 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent.
-                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Add other useful fields.
-                                                        apiVersion, kind, uid?'
                                                       type: string
                                                     optional:
-                                                      description: optional specify
-                                                        whether the ConfigMap or its
-                                                        keys must be defined
                                                       type: boolean
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 downwardAPI:
-                                                  description: downwardAPI information
-                                                    about the downwardAPI data to
-                                                    project
                                                   properties:
                                                     items:
-                                                      description: Items is a list
-                                                        of DownwardAPIVolume file
                                                       items:
-                                                        description: DownwardAPIVolumeFile
-                                                          represents information to
-                                                          create the file containing
-                                                          the pod field
                                                         properties:
                                                           fieldRef:
-                                                            description: 'Required:
-                                                              Selects a field of the
-                                                              pod: only annotations,
-                                                              labels, name and namespace
-                                                              are supported.'
                                                             properties:
                                                               apiVersion:
-                                                                description: Version
-                                                                  of the schema the
-                                                                  FieldPath is written
-                                                                  in terms of, defaults
-                                                                  to "v1".
                                                                 type: string
                                                               fieldPath:
-                                                                description: Path
-                                                                  of the field to
-                                                                  select in the specified
-                                                                  API version.
                                                                 type: string
                                                             required:
                                                             - fieldPath
                                                             type: object
                                                             x-kubernetes-map-type: atomic
                                                           mode:
-                                                            description: 'Optional:
-                                                              mode bits used to set
-                                                              permissions on this
-                                                              file, must be an octal
-                                                              value between 0000 and
-                                                              0777 or a decimal value
-                                                              between 0 and 511. YAML
-                                                              accepts both octal and
-                                                              decimal values, JSON
-                                                              requires decimal values
-                                                              for mode bits. If not
-                                                              specified, the volume
-                                                              defaultMode will be
-                                                              used. This might be
-                                                              in conflict with other
-                                                              options that affect
-                                                              the file mode, like
-                                                              fsGroup, and the result
-                                                              can be other mode bits
-                                                              set.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: 'Required:
-                                                              Path is  the relative
-                                                              path name of the file
-                                                              to be created. Must
-                                                              not be absolute or contain
-                                                              the ''..'' path. Must
-                                                              be utf-8 encoded. The
-                                                              first item of the relative
-                                                              path must not start
-                                                              with ''..'''
                                                             type: string
                                                           resourceFieldRef:
-                                                            description: 'Selects
-                                                              a resource of the container:
-                                                              only resources limits
-                                                              and requests (limits.cpu,
-                                                              limits.memory, requests.cpu
-                                                              and requests.memory)
-                                                              are currently supported.'
                                                             properties:
                                                               containerName:
-                                                                description: 'Container
-                                                                  name: required for
-                                                                  volumes, optional
-                                                                  for env vars'
                                                                 type: string
                                                               divisor:
                                                                 anyOf:
                                                                 - type: integer
                                                                 - type: string
-                                                                description: Specifies
-                                                                  the output format
-                                                                  of the exposed resources,
-                                                                  defaults to "1"
                                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                                 x-kubernetes-int-or-string: true
                                                               resource:
-                                                                description: 'Required:
-                                                                  resource to select'
                                                                 type: string
                                                             required:
                                                             - resource
@@ -7807,67 +3122,16 @@ spec:
                                                       type: array
                                                   type: object
                                                 secret:
-                                                  description: secret information
-                                                    about the secret data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified,
-                                                        each key-value pair in the
-                                                        Data field of the referenced
-                                                        Secret will be projected into
-                                                        the volume as a file whose
-                                                        name is the key and content
-                                                        is the value. If specified,
-                                                        the listed keys will be projected
-                                                        into the specified paths,
-                                                        and unlisted keys will not
-                                                        be present. If a key is specified
-                                                        which is not present in the
-                                                        Secret, the volume setup will
-                                                        error unless it is marked
-                                                        optional. Paths must be relative
-                                                        and may not contain the '..'
-                                                        path or start with '..'.
                                                       items:
-                                                        description: Maps a string
-                                                          key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is
-                                                              Optional: mode bits
-                                                              used to set permissions
-                                                              on this file. Must be
-                                                              an octal value between
-                                                              0000 and 0777 or a decimal
-                                                              value between 0 and
-                                                              511. YAML accepts both
-                                                              octal and decimal values,
-                                                              JSON requires decimal
-                                                              values for mode bits.
-                                                              If not specified, the
-                                                              volume defaultMode will
-                                                              be used. This might
-                                                              be in conflict with
-                                                              other options that affect
-                                                              the file mode, like
-                                                              fsGroup, and the result
-                                                              can be other mode bits
-                                                              set.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the
-                                                              relative path of the
-                                                              file to map the key
-                                                              to. May not be an absolute
-                                                              path. May not contain
-                                                              the path element '..'.
-                                                              May not start with the
-                                                              string '..'.
                                                             type: string
                                                         required:
                                                         - key
@@ -7875,57 +3139,19 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent.
-                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Add other useful fields.
-                                                        apiVersion, kind, uid?'
                                                       type: string
                                                     optional:
-                                                      description: optional field
-                                                        specify whether the Secret
-                                                        or its key must be defined
                                                       type: boolean
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 serviceAccountToken:
-                                                  description: serviceAccountToken
-                                                    is information about the serviceAccountToken
-                                                    data to project
                                                   properties:
                                                     audience:
-                                                      description: audience is the
-                                                        intended audience of the token.
-                                                        A recipient of a token must
-                                                        identify itself with an identifier
-                                                        specified in the audience
-                                                        of the token, and otherwise
-                                                        should reject the token. The
-                                                        audience defaults to the identifier
-                                                        of the apiserver.
                                                       type: string
                                                     expirationSeconds:
-                                                      description: expirationSeconds
-                                                        is the requested duration
-                                                        of validity of the service
-                                                        account token. As the token
-                                                        approaches expiration, the
-                                                        kubelet volume plugin will
-                                                        proactively rotate the service
-                                                        account token. The kubelet
-                                                        will start trying to rotate
-                                                        the token if the token is
-                                                        older than 80 percent of its
-                                                        time to live or if the token
-                                                        is older than 24 hours.Defaults
-                                                        to 1 hour and must be at least
-                                                        10 minutes.
                                                       format: int64
                                                       type: integer
                                                     path:
-                                                      description: path is the path
-                                                        relative to the mount point
-                                                        of the file to project the
-                                                        token into.
                                                       type: string
                                                   required:
                                                   - path
@@ -7934,171 +3160,76 @@ spec:
                                             type: array
                                         type: object
                                       quobyte:
-                                        description: quobyte represents a Quobyte
-                                          mount on the host that shares a pod's lifetime
                                         properties:
                                           group:
-                                            description: group to map volume access
-                                              to Default is no group
                                             type: string
                                           readOnly:
-                                            description: readOnly here will force
-                                              the Quobyte volume to be mounted with
-                                              read-only permissions. Defaults to false.
                                             type: boolean
                                           registry:
-                                            description: registry represents a single
-                                              or multiple Quobyte Registry services
-                                              specified as a string as host:port pair
-                                              (multiple entries are separated with
-                                              commas) which acts as the central registry
-                                              for volumes
                                             type: string
                                           tenant:
-                                            description: tenant owning the given Quobyte
-                                              volume in the Backend Used with dynamically
-                                              provisioned Quobyte volumes, value is
-                                              set by the plugin
                                             type: string
                                           user:
-                                            description: user to map volume access
-                                              to Defaults to serivceaccount user
                                             type: string
                                           volume:
-                                            description: volume is a string that references
-                                              an already created Quobyte volume by
-                                              name.
                                             type: string
                                         required:
                                         - registry
                                         - volume
                                         type: object
                                       rbd:
-                                        description: 'rbd represents a Rados Block
-                                          Device mount on the host that shares a pod''s
-                                          lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                         properties:
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type of the volume that you want to
-                                              mount. Tip: Ensure that the filesystem
-                                              type is supported by the host operating
-                                              system. Examples: "ext4", "xfs", "ntfs".
-                                              Implicitly inferred to be "ext4" if
-                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           image:
-                                            description: 'image is the rados image
-                                              name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                           keyring:
-                                            description: 'keyring is the path to key
-                                              ring for RBDUser. Default is /etc/ceph/keyring.
-                                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                           monitors:
-                                            description: 'monitors is a collection
-                                              of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             items:
                                               type: string
                                             type: array
                                           pool:
-                                            description: 'pool is the rados pool name.
-                                              Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
-                                              Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: boolean
                                           secretRef:
-                                            description: 'secretRef is name of the
-                                              authentication secret for RBDUser. If
-                                              provided overrides keyring. Default
-                                              is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           user:
-                                            description: 'user is the rados user name.
-                                              Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                         required:
                                         - image
                                         - monitors
                                         type: object
                                       scaleIO:
-                                        description: scaleIO represents a ScaleIO
-                                          persistent volume attached and mounted on
-                                          Kubernetes nodes.
                                         properties:
                                           fsType:
-                                            description: fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". Default
-                                              is "xfs".
                                             type: string
                                           gateway:
-                                            description: gateway is the host address
-                                              of the ScaleIO API Gateway.
                                             type: string
                                           protectionDomain:
-                                            description: protectionDomain is the name
-                                              of the ScaleIO Protection Domain for
-                                              the configured storage.
                                             type: string
                                           readOnly:
-                                            description: readOnly Defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           secretRef:
-                                            description: secretRef references to the
-                                              secret for ScaleIO user and other sensitive
-                                              information. If this is not provided,
-                                              Login operation will fail.
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           sslEnabled:
-                                            description: sslEnabled Flag enable/disable
-                                              SSL communication with Gateway, default
-                                              false
                                             type: boolean
                                           storageMode:
-                                            description: storageMode indicates whether
-                                              the storage for a volume should be ThickProvisioned
-                                              or ThinProvisioned. Default is ThinProvisioned.
                                             type: string
                                           storagePool:
-                                            description: storagePool is the ScaleIO
-                                              Storage Pool associated with the protection
-                                              domain.
                                             type: string
                                           system:
-                                            description: system is the name of the
-                                              storage system as configured in ScaleIO.
                                             type: string
                                           volumeName:
-                                            description: volumeName is the name of
-                                              a volume already created in the ScaleIO
-                                              system that is associated with this
-                                              volume source.
                                             type: string
                                         required:
                                         - gateway
@@ -8106,71 +3237,19 @@ spec:
                                         - system
                                         type: object
                                       secret:
-                                        description: 'secret represents a secret that
-                                          should populate this volume. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is Optional:
-                                              mode bits used to set permissions on
-                                              created files by default. Must be an
-                                              octal value between 0000 and 0777 or
-                                              a decimal value between 0 and 511. YAML
-                                              accepts both octal and decimal values,
-                                              JSON requires decimal values for mode
-                                              bits. Defaults to 0644. Directories
-                                              within the path are not affected by
-                                              this setting. This might be in conflict
-                                              with other options that affect the file
-                                              mode, like fsGroup, and the result can
-                                              be other mode bits set.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items If unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced Secret will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the Secret, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8178,90 +3257,36 @@ spec:
                                               type: object
                                             type: array
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its keys must be defined
                                             type: boolean
                                           secretName:
-                                            description: 'secretName is the name of
-                                              the secret in the pod''s namespace to
-                                              use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                             type: string
                                         type: object
                                       storageos:
-                                        description: storageOS represents a StorageOS
-                                          volume attached and mounted on Kubernetes
-                                          nodes.
                                         properties:
                                           fsType:
-                                            description: fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           readOnly:
-                                            description: readOnly defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           secretRef:
-                                            description: secretRef specifies the secret
-                                              to use for obtaining the StorageOS API
-                                              credentials.  If not specified, default
-                                              values will be attempted.
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           volumeName:
-                                            description: volumeName is the human-readable
-                                              name of the StorageOS volume.  Volume
-                                              names are only unique within a namespace.
                                             type: string
                                           volumeNamespace:
-                                            description: volumeNamespace specifies
-                                              the scope of the volume within StorageOS.  If
-                                              no namespace is specified then the Pod's
-                                              namespace will be used.  This allows
-                                              the Kubernetes name scoping to be mirrored
-                                              within StorageOS for tighter integration.
-                                              Set VolumeName to any name to override
-                                              the default behaviour. Set to "default"
-                                              if you are not using namespaces within
-                                              StorageOS. Namespaces that do not pre-exist
-                                              within StorageOS will be created.
                                             type: string
                                         type: object
                                       vsphereVolume:
-                                        description: vsphereVolume represents a vSphere
-                                          volume attached and mounted on kubelets
-                                          host machine
                                         properties:
                                           fsType:
-                                            description: fsType is filesystem type
-                                              to mount. Must be a filesystem type
-                                              supported by the host operating system.
-                                              Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           storagePolicyID:
-                                            description: storagePolicyID is the storage
-                                              Policy Based Management (SPBM) profile
-                                              ID associated with the StoragePolicyName.
                                             type: string
                                           storagePolicyName:
-                                            description: storagePolicyName is the
-                                              storage Policy Based Management (SPBM)
-                                              profile name.
                                             type: string
                                           volumePath:
-                                            description: volumePath is the path that
-                                              identifies vSphere volume vmdk
                                             type: string
                                         required:
                                         - volumePath
@@ -8284,60 +3309,36 @@ spec:
                         type: object
                       type: array
                     networkAttachments:
-                      description: NetworkAttachments is a list of NetworkAttachment
-                        resource names to expose the services to the given network
                       items:
                         type: string
                       type: array
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: NodeSelector to target subset of worker nodes running
-                        this service. Setting here overrides any global NodeSelector
-                        settings within the Manila CR.
                       type: object
                     passwordSelectors:
                       default:
                         database: ManilaDatabasePassword
                         service: ManilaPassword
-                      description: PasswordSelectors - Selectors to identify the DB
-                        and ServiceUser password from the Secret
                       properties:
                         database:
                           default: ManilaDatabasePassword
-                          description: 'Database - Selector to get the manila database
-                            user password from the Secret TODO: not used, need change
-                            in mariadb-operator'
                           type: string
                         service:
                           default: ManilaPassword
-                          description: Service - Selector to get the manila service
-                            password from the Secret
                           type: string
                       type: object
                     replicas:
                       default: 1
-                      description: Replicas - manila Volume Replicas
                       format: int32
                       maximum: 1
                       type: integer
                     resources:
-                      description: Resources - Compute Resources required by this
-                        service (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable."
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry
-                                  in pod.spec.resourceClaims of the Pod where this
-                                  field is used. It makes that resource available
-                                  inside a container.
                                 type: string
                             required:
                             - name
@@ -8353,8 +3354,6 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -8363,72 +3362,43 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     secret:
-                      description: Secret containing OpenStack password information
-                        for manilaDatabasePassword
                       type: string
                     serviceUser:
                       default: manila
-                      description: ServiceUser - optional username used for this service
-                        to register in manila
                       type: string
                     transportURLSecret:
-                      description: Secret containing RabbitMq transport URL
                       type: string
                   type: object
-                description: ManilaShares - Map of chosen names to spec definitions
-                  for the Share(s) service(s) of this Manila deployment
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes running
-                  this service. Setting NodeSelector here acts as a default value
-                  and can be overridden by service specific NodeSelector Settings.
                 type: object
               passwordSelectors:
                 default:
                   database: ManilaDatabasePassword
                   service: ManilaPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: ManilaDatabasePassword
-                    description: 'Database - Selector to get the manila database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: ManilaPassword
-                    description: Service - Selector to get the manila service password
-                      from the Secret
                     type: string
                 type: object
               preserveJobs:
                 default: false
-                description: PreserveJobs - do not delete jobs after they finished
-                  e.g. to check logs
                 type: boolean
               rabbitMqClusterName:
                 default: rabbitmq
-                description: RabbitMQ instance name Needed to request a transportURL
-                  that is created and used in Manila
                 type: string
               secret:
-                description: Secret containing OpenStack password information for
-                  ManilaDatabasePassword, ManilaPassword
                 type: string
               serviceUser:
                 default: manila
-                description: ServiceUser - optional username used for this service
-                  to register in manila
                 type: string
             required:
             - manilaAPI
@@ -8436,51 +3406,28 @@ spec:
             - rabbitMqClusterName
             type: object
           status:
-            description: ManilaStatus defines the observed state of Manila
             properties:
               apiEndpoints:
                 additionalProperties:
                   additionalProperties:
                     type: string
                   type: object
-                description: API endpoints
                 type: object
               conditions:
-                description: Conditions
                 items:
-                  description: Condition defines an observation of a API resource
-                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase.
                       type: string
                     severity:
-                      description: Severity provides a classification of Reason code,
-                        so the current situation is immediately understandable and
-                        could act accordingly. It is meant for situations where Status=False
-                        and it should be indicated if it is just informational, warning
-                        (next reconciliation might fix it) or an error (e.g. DB create
-                        issue and no actions to automatically resolve the issue can/should
-                        be done). For conditions where Status=Unknown or Status=True
-                        the Severity should be SeverityNone.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase.
                       type: string
                   required:
                   - lastTransitionTime
@@ -8489,34 +3436,27 @@ spec:
                   type: object
                 type: array
               databaseHostname:
-                description: Manila Database Hostname
                 type: string
               hash:
                 additionalProperties:
                   type: string
-                description: Map of hashes to track e.g. job status
                 type: object
               manilaAPIReadyCount:
-                description: ReadyCount of Manila API instance
                 format: int32
                 type: integer
               manilaSchedulerReadyCount:
-                description: ReadyCount of Manila Scheduler instance
                 format: int32
                 type: integer
               manilaSharesReadyCounts:
                 additionalProperties:
                   format: int32
                   type: integer
-                description: ReadyCounts of Manila Share instances
                 type: object
               serviceIDs:
                 additionalProperties:
                   type: string
-                description: ServiceIDs
                 type: object
               transportURLSecret:
-                description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string
             type: object
         type: object

--- a/api/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/api/bases/manila.openstack.org_manilaschedulers.yaml
@@ -31,118 +31,60 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ManilaScheduler is the Schema for the manilaschedulers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ManilaSchedulerSpec defines the desired state of ManilaScheduler
             properties:
               containerImage:
-                description: ContainerImage - manila Scheduler Container Image URL
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
-                description: CustomServiceConfig - customize the service config using
-                  this parameter to change service defaults, or overwrite rendered
-                  information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
                 type: string
               databaseHostname:
-                description: DatabaseHostname - manila Database Hostname
                 type: string
               databaseUser:
                 default: manila
-                description: 'DatabaseUser - optional username used for manila DB,
-                  defaults to manila TODO: -> implement needs work in mariadb-operator,
-                  right now only manila'
                 type: string
               debug:
-                description: Debug - enable debug for different deploy stages. If
-                  an init container is used, it runs and the actual action pod gets
-                  started with sleep infinity
                 properties:
                   initContainer:
                     default: false
-                    description: initContainer enable debug (waits until /tmp/stop-init-container
-                      disappears)
                     type: boolean
                   service:
                     default: false
-                    description: service enable debug
                     type: boolean
                 type: object
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  .
                 type: object
               extraMounts:
-                description: ExtraMounts containing conf files and credentials
                 items:
-                  description: ManilaExtraVolMounts exposes additional parameters
-                    processed by the manila-operator and defines the common VolMounts
-                    structure provided by the main storage module
                   properties:
                     extraVol:
                       items:
-                        description: VolMounts is the data structure used to expose
-                          Volumes and Mounts that can be added to a pod according
-                          to the defined Propagation policy
                         properties:
                           extraVolType:
-                            description: Label associated to a given extraMount
                             type: string
                           mounts:
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -150,262 +92,110 @@ spec:
                               type: object
                             type: array
                           propagation:
-                            description: Propagation defines which pod should mount
-                              the volume
                             items:
-                              description: PropagationType identifies the Service,
-                                Group or instance (e.g. the backend) that receives
-                                an Extra Volume that can potentially be mounted
                               type: string
                             type: array
                           volumes:
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'awsElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly value true will force
-                                        the readOnly setting in VolumeMounts. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: boolean
                                     volumeID:
-                                      description: 'volumeID is unique ID of the persistent
-                                        disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'monitors is Required: Monitors
-                                        is a collection of Ceph monitors More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: boolean
                                     secretFile:
-                                      description: 'secretFile is Optional: SecretFile
-                                        is the path to key ring for User, default
-                                        is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                     secretRef:
-                                      description: 'secretRef is Optional: SecretRef
-                                        is reference to the authentication secret
-                                        for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is optional: User is the
-                                        rados user name, default is admin More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is optional: points
-                                        to a secret object containing parameters used
-                                        to connect to OpenStack.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: 'volumeID used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -413,159 +203,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
                                       type: string
                                     fsType:
-                                      description: fsType to mount. Ex. "ext4", "xfs",
-                                        "ntfs". If not provided, the empty value is
-                                        passed to the associated CSI driver which
-                                        will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: nodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: readOnly specifies a read-only
-                                        configuration for the volume. Defaults to
-                                        false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: volumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -577,136 +274,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of
-                                        storage medium should back this directory.
-                                        The default is "" which means to use the node''s
-                                        default medium. Must be an empty string (default)
-                                        or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'sizeLimit is the total amount
-                                        of local storage required for this EmptyDir
-                                        volume. The size limit is also applicable
-                                        for memory medium. The maximum usage on memory
-                                        medium EmptyDir would be the minimum value
-                                        between the SizeLimit specified here and the
-                                        sum of memory limits of all containers in
-                                        a pod. The default is nil which means that
-                                        the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "ephemeral represents a volume that
-                                    is handled by a cluster storage driver. The volume's
-                                    lifecycle is tied to the pod that defines it -
-                                    it will be created before the pod starts, and
-                                    deleted when the pod is removed. \n Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from
-                                    snapshot or capacity tracking are needed, c) the
-                                    storage driver is specified through a storage
-                                    class, and d) the storage driver supports dynamic
-                                    volume provisioning through a PersistentVolumeClaim
-                                    (see EphemeralVolumeSource for more information
-                                    on the connection between this volume type and
-                                    PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                    or one of the vendor-specific APIs for volumes
-                                    that persist for longer than the lifecycle of
-                                    an individual pod. \n Use CSI for light-weight
-                                    local ephemeral volumes if the CSI driver is meant
-                                    to be used that way - see the documentation of
-                                    the driver for more information. \n A pod can
-                                    use both types of ephemeral volumes and persistent
-                                    volumes at the same time."
                                   properties:
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations
-                                            that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
                                           type: object
                                         spec:
-                                          description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: 'accessModes contains the
-                                                desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'dataSource field can be
-                                                used to specify either: * An existing
-                                                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external
-                                                controller can support the specified
-                                                data source, it will create a new
-                                                volume based on the contents of the
-                                                specified data source. When the AnyVolumeDataSource
-                                                feature gate is enabled, dataSource
-                                                contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be
-                                                copied to dataSource when dataSourceRef.namespace
-                                                is not specified. If the namespace
-                                                is specified, then dataSourceRef will
-                                                not be copied to dataSource.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -714,113 +310,25 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: 'dataSourceRef specifies
-                                                the object from which to populate
-                                                the volume with data, if a non-empty
-                                                volume is desired. This may be any
-                                                object from a non-empty API group
-                                                (non core object) or a PersistentVolumeClaim
-                                                object. When this field is specified,
-                                                volume binding will only succeed if
-                                                the type of the specified object matches
-                                                some installed volume populator or
-                                                dynamic provisioner. This field will
-                                                replace the functionality of the dataSource
-                                                field and as such if both fields are
-                                                non-empty, they must have the same
-                                                value. For backwards compatibility,
-                                                when namespace isn''t specified in
-                                                dataSourceRef, both fields (dataSource
-                                                and dataSourceRef) will be set to
-                                                the same value automatically if one
-                                                of them is empty and the other is
-                                                non-empty. When namespace is specified
-                                                in dataSourceRef, dataSource isn''t
-                                                set to the same value and must be
-                                                empty. There are three important differences
-                                                between dataSource and dataSourceRef:
-                                                * While dataSource only allows two
-                                                specific types of objects, dataSourceRef
-                                                allows any non-core object, as well
-                                                as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed
-                                                values (dropping them), dataSourceRef
-                                                preserves all values, and generates
-                                                an error if a disallowed value is
-                                                specified. * While dataSource only
-                                                allows local objects, dataSourceRef
-                                                allows objects in any namespaces.
-                                                (Beta) Using this field requires the
-                                                AnyVolumeDataSource feature gate to
-                                                be enabled. (Alpha) Using the namespace
-                                                field of dataSourceRef requires the
-                                                CrossNamespaceVolumeDataSource feature
-                                                gate to be enabled.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: Namespace is the namespace
-                                                    of resource being referenced Note
-                                                    that when a namespace is specified,
-                                                    a gateway.networking.k8s.io/ReferenceGrant
-                                                    object is required in the referent
-                                                    namespace to allow that namespace's
-                                                    owner to accept the reference.
-                                                    See the ReferenceGrant documentation
-                                                    for details. (Alpha) This field
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'resources represents the
-                                                minimum resources the volume should
-                                                have. If RecoverVolumeExpansionFailure
-                                                feature is enabled users are allowed
-                                                to specify resource requirements that
-                                                are lower than previous value but
-                                                must still be higher than capacity
-                                                recorded in the status field of the
-                                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                               properties:
                                                 claims:
-                                                  description: "Claims lists the names
-                                                    of resources, defined in spec.resourceClaims,
-                                                    that are used by this container.
-                                                    \n This is an alpha field and
-                                                    requires enabling the DynamicResourceAllocation
-                                                    feature gate. \n This field is
-                                                    immutable."
                                                   items:
-                                                    description: ResourceClaim references
-                                                      one entry in PodSpec.ResourceClaims.
                                                     properties:
                                                       name:
-                                                        description: Name must match
-                                                          the name of one entry in
-                                                          pod.spec.resourceClaims
-                                                          of the Pod where this field
-                                                          is used. It makes that resource
-                                                          available inside a container.
                                                         type: string
                                                     required:
                                                     - name
@@ -836,9 +344,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the
-                                                    maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -847,54 +352,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
-                                                    the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -906,33 +375,14 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: 'storageClassName is the
-                                                name of the StorageClass required
-                                                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what
-                                                type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -940,84 +390,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. TODO: how do we prevent errors
-                                        in the filesystem from compromising the machine'
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'wwids Optional: FC volume world
-                                        wide identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: flexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". The default filesystem depends
-                                        on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: 'readOnly is Optional: defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is Optional: secretRef
-                                        is reference to the secret object containing
-                                        sensitive information to pass to the plugin
-                                        scripts. This may be empty if no secret object
-                                        is specified. If the secret object contains
-                                        more than one secret, all secrets are passed
-                                        to the plugin scripts.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -1025,205 +429,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: datasetName is Name of the dataset
-                                        stored as metadata -> name on the dataset
-                                        for Flocker should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'gcePersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   properties:
                                     fsType:
-                                      description: 'fsType is filesystem type of the
-                                        volume that you want to mount. Tip: Ensure
-                                        that the filesystem type is supported by the
-                                        host operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'pdName is unique name of the PD
-                                        resource in GCE. Used to identify the disk
-                                        in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'gitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
                                   properties:
                                     directory:
-                                      description: directory is the target directory
-                                        name. Must not contain or start with '..'.  If
-                                        '.' is supplied, the volume directory will
-                                        be the git repository.  Otherwise, if specified,
-                                        the volume will contain the git repository
-                                        in the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                   properties:
                                     endpoints:
-                                      description: 'endpoints is the endpoint name
-                                        that details Glusterfs topology. More info:
-                                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     path:
-                                      description: 'path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'iscsi represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     initiatorName:
-                                      description: initiatorName is the custom iSCSI
-                                        Initiator Name. If initiatorName is specified
-                                        with iscsiInterface simultaneously, new iSCSI
-                                        interface <target portal>:<volume name> will
-                                        be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iscsiInterface is the interface
-                                        Name that uses an iSCSI transport. Defaults
-                                        to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: portals is the iSCSI Target Portal
-                                        List. The portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: targetPortal is iSCSI Target Portal.
-                                        The Portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -1231,166 +518,67 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'name of the volume. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 nfs:
-                                  description: 'nfs represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   properties:
                                     path:
-                                      description: 'path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: boolean
                                     server:
-                                      description: 'server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly
-                                        setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used
-                                        to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777
-                                        or a decimal value between 0 and 511. YAML
-                                        accepts both octal and decimal values, JSON
-                                        requires decimal values for mode bits. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced ConfigMap
-                                                  will be projected into the volume
-                                                  as a file whose name is the key
-                                                  and content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1398,105 +586,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode
-                                                        bits used to set permissions
-                                                        on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -1508,58 +633,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced Secret will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1567,52 +650,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
                                                 type: string
                                             required:
                                             - path
@@ -1621,162 +671,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: group to map volume access to Default
-                                        is no group
                                       type: string
                                     readOnly:
-                                      description: readOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
                                       type: string
                                     tenant:
-                                      description: tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
                                       type: string
                                     user:
-                                      description: user to map volume access to Defaults
-                                        to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'rbd represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     image:
-                                      description: 'image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: 'keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     monitors:
-                                      description: 'monitors is a collection of Ceph
-                                        monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'pool is the rados pool name. Default
-                                        is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is the rados user name. Default
-                                        is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: storageMode indicates whether the
-                                        storage for a volume should be ThickProvisioned
-                                        or ThinProvisioned. Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the name of a volume
-                                        already created in the ScaleIO system that
-                                        is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -1784,63 +748,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -1848,85 +768,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the
-                                        secret in the pod''s namespace to use. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: volumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: volumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -1949,57 +820,35 @@ spec:
                   type: object
                 type: array
               networkAttachments:
-                description: NetworkAttachments is a list of NetworkAttachment resource
-                  names to expose the services to the given network
                 items:
                   type: string
                 type: array
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes running
-                  this service. Setting here overrides any global NodeSelector settings
-                  within the Manila CR.
                 type: object
               passwordSelectors:
                 default:
                   database: ManilaDatabasePassword
                   service: ManilaPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: ManilaDatabasePassword
-                    description: 'Database - Selector to get the manila database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: ManilaPassword
-                    description: Service - Selector to get the manila service password
-                      from the Secret
                     type: string
                 type: object
               replicas:
                 default: 1
-                description: Replicas - manila Scheduler Replicas
                 format: int32
                 type: integer
               resources:
-                description: Resources - Compute Resources required by this service
-                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                 properties:
                   claims:
-                    description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable."
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: Name must match the name of one entry in pod.spec.resourceClaims
-                            of the Pod where this field is used. It makes that resource
-                            available inside a container.
                           type: string
                       required:
                       - name
@@ -2015,8 +864,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -2025,64 +872,33 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               secret:
-                description: Secret containing OpenStack password information for
-                  manilaDatabasePassword
                 type: string
               serviceUser:
                 default: manila
-                description: ServiceUser - optional username used for this service
-                  to register in manila
                 type: string
               transportURLSecret:
-                description: Secret containing RabbitMq transport URL
                 type: string
             type: object
           status:
-            description: ManilaSchedulerStatus defines the observed state of ManilaScheduler
             properties:
               conditions:
-                description: Conditions
                 items:
-                  description: Condition defines an observation of a API resource
-                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase.
                       type: string
                     severity:
-                      description: Severity provides a classification of Reason code,
-                        so the current situation is immediately understandable and
-                        could act accordingly. It is meant for situations where Status=False
-                        and it should be indicated if it is just informational, warning
-                        (next reconciliation might fix it) or an error (e.g. DB create
-                        issue and no actions to automatically resolve the issue can/should
-                        be done). For conditions where Status=Unknown or Status=True
-                        the Severity should be SeverityNone.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase.
                       type: string
                   required:
                   - lastTransitionTime
@@ -2093,17 +909,14 @@ spec:
               hash:
                 additionalProperties:
                   type: string
-                description: Map of hashes to track e.g. job status
                 type: object
               networkAttachments:
                 additionalProperties:
                   items:
                     type: string
                   type: array
-                description: NetworkAttachments status of the deployment pods
                 type: object
               readyCount:
-                description: ReadyCount of Manila Scheduler instances
                 format: int32
                 type: integer
             type: object

--- a/api/bases/manila.openstack.org_manilashares.yaml
+++ b/api/bases/manila.openstack.org_manilashares.yaml
@@ -31,118 +31,60 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ManilaShare is the Schema for the manilashares API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ManilaShareSpec defines the desired state of ManilaShare
             properties:
               containerImage:
-                description: ContainerImage - manila Volume Container Image URL
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
-                description: CustomServiceConfig - customize the service config using
-                  this parameter to change service defaults, or overwrite rendered
-                  information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
                 type: string
               databaseHostname:
-                description: DatabaseHostname - manila Database Hostname
                 type: string
               databaseUser:
                 default: manila
-                description: 'DatabaseUser - optional username used for manila DB,
-                  defaults to manila TODO: -> implement needs work in mariadb-operator,
-                  right now only manila'
                 type: string
               debug:
-                description: Debug - enable debug for different deploy stages. If
-                  an init container is used, it runs and the actual action pod gets
-                  started with sleep infinity
                 properties:
                   initContainer:
                     default: false
-                    description: initContainer enable debug (waits until /tmp/stop-init-container
-                      disappears)
                     type: boolean
                   service:
                     default: false
-                    description: service enable debug
                     type: boolean
                 type: object
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  .
                 type: object
               extraMounts:
-                description: ExtraMounts containing conf files and credentials
                 items:
-                  description: ManilaExtraVolMounts exposes additional parameters
-                    processed by the manila-operator and defines the common VolMounts
-                    structure provided by the main storage module
                   properties:
                     extraVol:
                       items:
-                        description: VolMounts is the data structure used to expose
-                          Volumes and Mounts that can be added to a pod according
-                          to the defined Propagation policy
                         properties:
                           extraVolType:
-                            description: Label associated to a given extraMount
                             type: string
                           mounts:
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -150,262 +92,110 @@ spec:
                               type: object
                             type: array
                           propagation:
-                            description: Propagation defines which pod should mount
-                              the volume
                             items:
-                              description: PropagationType identifies the Service,
-                                Group or instance (e.g. the backend) that receives
-                                an Extra Volume that can potentially be mounted
                               type: string
                             type: array
                           volumes:
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'awsElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly value true will force
-                                        the readOnly setting in VolumeMounts. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: boolean
                                     volumeID:
-                                      description: 'volumeID is unique ID of the persistent
-                                        disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'monitors is Required: Monitors
-                                        is a collection of Ceph monitors More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: boolean
                                     secretFile:
-                                      description: 'secretFile is Optional: SecretFile
-                                        is the path to key ring for User, default
-                                        is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                     secretRef:
-                                      description: 'secretRef is Optional: SecretRef
-                                        is reference to the authentication secret
-                                        for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is optional: User is the
-                                        rados user name, default is admin More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is optional: points
-                                        to a secret object containing parameters used
-                                        to connect to OpenStack.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: 'volumeID used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -413,159 +203,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
                                       type: string
                                     fsType:
-                                      description: fsType to mount. Ex. "ext4", "xfs",
-                                        "ntfs". If not provided, the empty value is
-                                        passed to the associated CSI driver which
-                                        will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: nodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: readOnly specifies a read-only
-                                        configuration for the volume. Defaults to
-                                        false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: volumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -577,136 +274,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of
-                                        storage medium should back this directory.
-                                        The default is "" which means to use the node''s
-                                        default medium. Must be an empty string (default)
-                                        or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'sizeLimit is the total amount
-                                        of local storage required for this EmptyDir
-                                        volume. The size limit is also applicable
-                                        for memory medium. The maximum usage on memory
-                                        medium EmptyDir would be the minimum value
-                                        between the SizeLimit specified here and the
-                                        sum of memory limits of all containers in
-                                        a pod. The default is nil which means that
-                                        the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "ephemeral represents a volume that
-                                    is handled by a cluster storage driver. The volume's
-                                    lifecycle is tied to the pod that defines it -
-                                    it will be created before the pod starts, and
-                                    deleted when the pod is removed. \n Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from
-                                    snapshot or capacity tracking are needed, c) the
-                                    storage driver is specified through a storage
-                                    class, and d) the storage driver supports dynamic
-                                    volume provisioning through a PersistentVolumeClaim
-                                    (see EphemeralVolumeSource for more information
-                                    on the connection between this volume type and
-                                    PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                    or one of the vendor-specific APIs for volumes
-                                    that persist for longer than the lifecycle of
-                                    an individual pod. \n Use CSI for light-weight
-                                    local ephemeral volumes if the CSI driver is meant
-                                    to be used that way - see the documentation of
-                                    the driver for more information. \n A pod can
-                                    use both types of ephemeral volumes and persistent
-                                    volumes at the same time."
                                   properties:
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations
-                                            that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
                                           type: object
                                         spec:
-                                          description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: 'accessModes contains the
-                                                desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'dataSource field can be
-                                                used to specify either: * An existing
-                                                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external
-                                                controller can support the specified
-                                                data source, it will create a new
-                                                volume based on the contents of the
-                                                specified data source. When the AnyVolumeDataSource
-                                                feature gate is enabled, dataSource
-                                                contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be
-                                                copied to dataSource when dataSourceRef.namespace
-                                                is not specified. If the namespace
-                                                is specified, then dataSourceRef will
-                                                not be copied to dataSource.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -714,113 +310,25 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: 'dataSourceRef specifies
-                                                the object from which to populate
-                                                the volume with data, if a non-empty
-                                                volume is desired. This may be any
-                                                object from a non-empty API group
-                                                (non core object) or a PersistentVolumeClaim
-                                                object. When this field is specified,
-                                                volume binding will only succeed if
-                                                the type of the specified object matches
-                                                some installed volume populator or
-                                                dynamic provisioner. This field will
-                                                replace the functionality of the dataSource
-                                                field and as such if both fields are
-                                                non-empty, they must have the same
-                                                value. For backwards compatibility,
-                                                when namespace isn''t specified in
-                                                dataSourceRef, both fields (dataSource
-                                                and dataSourceRef) will be set to
-                                                the same value automatically if one
-                                                of them is empty and the other is
-                                                non-empty. When namespace is specified
-                                                in dataSourceRef, dataSource isn''t
-                                                set to the same value and must be
-                                                empty. There are three important differences
-                                                between dataSource and dataSourceRef:
-                                                * While dataSource only allows two
-                                                specific types of objects, dataSourceRef
-                                                allows any non-core object, as well
-                                                as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed
-                                                values (dropping them), dataSourceRef
-                                                preserves all values, and generates
-                                                an error if a disallowed value is
-                                                specified. * While dataSource only
-                                                allows local objects, dataSourceRef
-                                                allows objects in any namespaces.
-                                                (Beta) Using this field requires the
-                                                AnyVolumeDataSource feature gate to
-                                                be enabled. (Alpha) Using the namespace
-                                                field of dataSourceRef requires the
-                                                CrossNamespaceVolumeDataSource feature
-                                                gate to be enabled.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: Namespace is the namespace
-                                                    of resource being referenced Note
-                                                    that when a namespace is specified,
-                                                    a gateway.networking.k8s.io/ReferenceGrant
-                                                    object is required in the referent
-                                                    namespace to allow that namespace's
-                                                    owner to accept the reference.
-                                                    See the ReferenceGrant documentation
-                                                    for details. (Alpha) This field
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'resources represents the
-                                                minimum resources the volume should
-                                                have. If RecoverVolumeExpansionFailure
-                                                feature is enabled users are allowed
-                                                to specify resource requirements that
-                                                are lower than previous value but
-                                                must still be higher than capacity
-                                                recorded in the status field of the
-                                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                               properties:
                                                 claims:
-                                                  description: "Claims lists the names
-                                                    of resources, defined in spec.resourceClaims,
-                                                    that are used by this container.
-                                                    \n This is an alpha field and
-                                                    requires enabling the DynamicResourceAllocation
-                                                    feature gate. \n This field is
-                                                    immutable."
                                                   items:
-                                                    description: ResourceClaim references
-                                                      one entry in PodSpec.ResourceClaims.
                                                     properties:
                                                       name:
-                                                        description: Name must match
-                                                          the name of one entry in
-                                                          pod.spec.resourceClaims
-                                                          of the Pod where this field
-                                                          is used. It makes that resource
-                                                          available inside a container.
                                                         type: string
                                                     required:
                                                     - name
@@ -836,9 +344,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the
-                                                    maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -847,54 +352,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
-                                                    the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -906,33 +375,14 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: 'storageClassName is the
-                                                name of the StorageClass required
-                                                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what
-                                                type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -940,84 +390,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. TODO: how do we prevent errors
-                                        in the filesystem from compromising the machine'
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'wwids Optional: FC volume world
-                                        wide identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: flexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". The default filesystem depends
-                                        on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: 'readOnly is Optional: defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is Optional: secretRef
-                                        is reference to the secret object containing
-                                        sensitive information to pass to the plugin
-                                        scripts. This may be empty if no secret object
-                                        is specified. If the secret object contains
-                                        more than one secret, all secrets are passed
-                                        to the plugin scripts.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -1025,205 +429,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: datasetName is Name of the dataset
-                                        stored as metadata -> name on the dataset
-                                        for Flocker should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'gcePersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   properties:
                                     fsType:
-                                      description: 'fsType is filesystem type of the
-                                        volume that you want to mount. Tip: Ensure
-                                        that the filesystem type is supported by the
-                                        host operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'pdName is unique name of the PD
-                                        resource in GCE. Used to identify the disk
-                                        in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'gitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
                                   properties:
                                     directory:
-                                      description: directory is the target directory
-                                        name. Must not contain or start with '..'.  If
-                                        '.' is supplied, the volume directory will
-                                        be the git repository.  Otherwise, if specified,
-                                        the volume will contain the git repository
-                                        in the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                   properties:
                                     endpoints:
-                                      description: 'endpoints is the endpoint name
-                                        that details Glusterfs topology. More info:
-                                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     path:
-                                      description: 'path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'iscsi represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     initiatorName:
-                                      description: initiatorName is the custom iSCSI
-                                        Initiator Name. If initiatorName is specified
-                                        with iscsiInterface simultaneously, new iSCSI
-                                        interface <target portal>:<volume name> will
-                                        be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iscsiInterface is the interface
-                                        Name that uses an iSCSI transport. Defaults
-                                        to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: portals is the iSCSI Target Portal
-                                        List. The portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: targetPortal is iSCSI Target Portal.
-                                        The Portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -1231,166 +518,67 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'name of the volume. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 nfs:
-                                  description: 'nfs represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   properties:
                                     path:
-                                      description: 'path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: boolean
                                     server:
-                                      description: 'server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly
-                                        setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used
-                                        to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777
-                                        or a decimal value between 0 and 511. YAML
-                                        accepts both octal and decimal values, JSON
-                                        requires decimal values for mode bits. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced ConfigMap
-                                                  will be projected into the volume
-                                                  as a file whose name is the key
-                                                  and content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1398,105 +586,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode
-                                                        bits used to set permissions
-                                                        on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -1508,58 +633,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced Secret will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1567,52 +650,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
                                                 type: string
                                             required:
                                             - path
@@ -1621,162 +671,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: group to map volume access to Default
-                                        is no group
                                       type: string
                                     readOnly:
-                                      description: readOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
                                       type: string
                                     tenant:
-                                      description: tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
                                       type: string
                                     user:
-                                      description: user to map volume access to Defaults
-                                        to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'rbd represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     image:
-                                      description: 'image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: 'keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     monitors:
-                                      description: 'monitors is a collection of Ceph
-                                        monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'pool is the rados pool name. Default
-                                        is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is the rados user name. Default
-                                        is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: storageMode indicates whether the
-                                        storage for a volume should be ThickProvisioned
-                                        or ThinProvisioned. Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the name of a volume
-                                        already created in the ScaleIO system that
-                                        is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -1784,63 +748,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -1848,85 +768,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the
-                                        secret in the pod''s namespace to use. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: volumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: volumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -1949,58 +820,36 @@ spec:
                   type: object
                 type: array
               networkAttachments:
-                description: NetworkAttachments is a list of NetworkAttachment resource
-                  names to expose the services to the given network
                 items:
                   type: string
                 type: array
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes running
-                  this service. Setting here overrides any global NodeSelector settings
-                  within the Manila CR.
                 type: object
               passwordSelectors:
                 default:
                   database: ManilaDatabasePassword
                   service: ManilaPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: ManilaDatabasePassword
-                    description: 'Database - Selector to get the manila database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: ManilaPassword
-                    description: Service - Selector to get the manila service password
-                      from the Secret
                     type: string
                 type: object
               replicas:
                 default: 1
-                description: Replicas - manila Volume Replicas
                 format: int32
                 maximum: 1
                 type: integer
               resources:
-                description: Resources - Compute Resources required by this service
-                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                 properties:
                   claims:
-                    description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable."
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: Name must match the name of one entry in pod.spec.resourceClaims
-                            of the Pod where this field is used. It makes that resource
-                            available inside a container.
                           type: string
                       required:
                       - name
@@ -2016,8 +865,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -2026,64 +873,33 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               secret:
-                description: Secret containing OpenStack password information for
-                  manilaDatabasePassword
                 type: string
               serviceUser:
                 default: manila
-                description: ServiceUser - optional username used for this service
-                  to register in manila
                 type: string
               transportURLSecret:
-                description: Secret containing RabbitMq transport URL
                 type: string
             type: object
           status:
-            description: ManilaShareStatus defines the observed state of ManilaShare
             properties:
               conditions:
-                description: Conditions
                 items:
-                  description: Condition defines an observation of a API resource
-                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase.
                       type: string
                     severity:
-                      description: Severity provides a classification of Reason code,
-                        so the current situation is immediately understandable and
-                        could act accordingly. It is meant for situations where Status=False
-                        and it should be indicated if it is just informational, warning
-                        (next reconciliation might fix it) or an error (e.g. DB create
-                        issue and no actions to automatically resolve the issue can/should
-                        be done). For conditions where Status=Unknown or Status=True
-                        the Severity should be SeverityNone.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase.
                       type: string
                   required:
                   - lastTransitionTime
@@ -2094,17 +910,14 @@ spec:
               hash:
                 additionalProperties:
                   type: string
-                description: Map of hashes to track e.g. job status
                 type: object
               networkAttachments:
                 additionalProperties:
                   items:
                     type: string
                   type: array
-                description: NetworkAttachments status of the deployment pods
                 type: object
               readyCount:
-                description: ReadyCount of ManilaShare instances
                 format: int32
                 type: integer
             type: object

--- a/config/crd/bases/manila.openstack.org_manilaapis.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaapis.yaml
@@ -31,160 +31,85 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ManilaAPI is the Schema for the manilaapis API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ManilaAPISpec defines the desired state of ManilaAPI
             properties:
               containerImage:
-                description: ContainerImage - Manila API Container Image URL
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
-                description: CustomServiceConfig - customize the service config using
-                  this parameter to change service defaults, or overwrite rendered
-                  information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
                 type: string
               databaseHostname:
-                description: DatabaseHostname - Manila Database Hostname
                 type: string
               databaseUser:
                 default: manila
-                description: 'DatabaseUser - optional username used for manila DB,
-                  defaults to manila TODO: -> implement needs work in mariadb-operator,
-                  right now only manila'
                 type: string
               debug:
-                description: Debug - enable debug for different deploy stages. If
-                  an init container is used, it runs and the actual action pod gets
-                  started with sleep infinity
                 properties:
                   initContainer:
                     default: false
-                    description: initContainer enable debug (waits until /tmp/stop-init-container
-                      disappears)
                     type: boolean
                   service:
                     default: false
-                    description: service enable debug
                     type: boolean
                 type: object
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  .
                 type: object
               externalEndpoints:
-                description: ExternalEndpoints, expose a VIP via MetalLB on the pre-created
-                  address pool
                 items:
-                  description: MetalLBConfig to configure the MetalLB loadbalancer
-                    service
                   properties:
                     endpoint:
-                      description: Endpoint, OpenStack endpoint this service maps
-                        to
                       enum:
                       - internal
                       - public
                       type: string
                     ipAddressPool:
-                      description: IPAddressPool expose VIP via MetalLB on the IPAddressPool
                       minLength: 1
                       type: string
                     loadBalancerIPs:
-                      description: LoadBalancerIPs, request given IPs from the pool
-                        if available. Using a list to allow dual stack (IPv4/IPv6)
-                        support
                       items:
                         type: string
                       type: array
                     sharedIP:
                       default: true
-                      description: SharedIP if true, VIP/VIPs get shared with multiple
-                        services
                       type: boolean
                     sharedIPKey:
                       default: ""
-                      description: SharedIPKey specifies the sharing key which gets
-                        set as the annotation on the LoadBalancer service. Services
-                        which share the same VIP must have the same SharedIPKey. Defaults
-                        to the IPAddressPool if SharedIP is true, but no SharedIPKey
-                        specified.
                       type: string
                   required:
                   - ipAddressPool
                   type: object
                 type: array
               extraMounts:
-                description: ExtraMounts containing conf files and credentials
                 items:
-                  description: ManilaExtraVolMounts exposes additional parameters
-                    processed by the manila-operator and defines the common VolMounts
-                    structure provided by the main storage module
                   properties:
                     extraVol:
                       items:
-                        description: VolMounts is the data structure used to expose
-                          Volumes and Mounts that can be added to a pod according
-                          to the defined Propagation policy
                         properties:
                           extraVolType:
-                            description: Label associated to a given extraMount
                             type: string
                           mounts:
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -192,262 +117,110 @@ spec:
                               type: object
                             type: array
                           propagation:
-                            description: Propagation defines which pod should mount
-                              the volume
                             items:
-                              description: PropagationType identifies the Service,
-                                Group or instance (e.g. the backend) that receives
-                                an Extra Volume that can potentially be mounted
                               type: string
                             type: array
                           volumes:
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'awsElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly value true will force
-                                        the readOnly setting in VolumeMounts. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: boolean
                                     volumeID:
-                                      description: 'volumeID is unique ID of the persistent
-                                        disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'monitors is Required: Monitors
-                                        is a collection of Ceph monitors More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: boolean
                                     secretFile:
-                                      description: 'secretFile is Optional: SecretFile
-                                        is the path to key ring for User, default
-                                        is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                     secretRef:
-                                      description: 'secretRef is Optional: SecretRef
-                                        is reference to the authentication secret
-                                        for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is optional: User is the
-                                        rados user name, default is admin More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is optional: points
-                                        to a secret object containing parameters used
-                                        to connect to OpenStack.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: 'volumeID used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -455,159 +228,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
                                       type: string
                                     fsType:
-                                      description: fsType to mount. Ex. "ext4", "xfs",
-                                        "ntfs". If not provided, the empty value is
-                                        passed to the associated CSI driver which
-                                        will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: nodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: readOnly specifies a read-only
-                                        configuration for the volume. Defaults to
-                                        false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: volumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -619,136 +299,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of
-                                        storage medium should back this directory.
-                                        The default is "" which means to use the node''s
-                                        default medium. Must be an empty string (default)
-                                        or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'sizeLimit is the total amount
-                                        of local storage required for this EmptyDir
-                                        volume. The size limit is also applicable
-                                        for memory medium. The maximum usage on memory
-                                        medium EmptyDir would be the minimum value
-                                        between the SizeLimit specified here and the
-                                        sum of memory limits of all containers in
-                                        a pod. The default is nil which means that
-                                        the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "ephemeral represents a volume that
-                                    is handled by a cluster storage driver. The volume's
-                                    lifecycle is tied to the pod that defines it -
-                                    it will be created before the pod starts, and
-                                    deleted when the pod is removed. \n Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from
-                                    snapshot or capacity tracking are needed, c) the
-                                    storage driver is specified through a storage
-                                    class, and d) the storage driver supports dynamic
-                                    volume provisioning through a PersistentVolumeClaim
-                                    (see EphemeralVolumeSource for more information
-                                    on the connection between this volume type and
-                                    PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                    or one of the vendor-specific APIs for volumes
-                                    that persist for longer than the lifecycle of
-                                    an individual pod. \n Use CSI for light-weight
-                                    local ephemeral volumes if the CSI driver is meant
-                                    to be used that way - see the documentation of
-                                    the driver for more information. \n A pod can
-                                    use both types of ephemeral volumes and persistent
-                                    volumes at the same time."
                                   properties:
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations
-                                            that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
                                           type: object
                                         spec:
-                                          description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: 'accessModes contains the
-                                                desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'dataSource field can be
-                                                used to specify either: * An existing
-                                                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external
-                                                controller can support the specified
-                                                data source, it will create a new
-                                                volume based on the contents of the
-                                                specified data source. When the AnyVolumeDataSource
-                                                feature gate is enabled, dataSource
-                                                contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be
-                                                copied to dataSource when dataSourceRef.namespace
-                                                is not specified. If the namespace
-                                                is specified, then dataSourceRef will
-                                                not be copied to dataSource.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -756,113 +335,25 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: 'dataSourceRef specifies
-                                                the object from which to populate
-                                                the volume with data, if a non-empty
-                                                volume is desired. This may be any
-                                                object from a non-empty API group
-                                                (non core object) or a PersistentVolumeClaim
-                                                object. When this field is specified,
-                                                volume binding will only succeed if
-                                                the type of the specified object matches
-                                                some installed volume populator or
-                                                dynamic provisioner. This field will
-                                                replace the functionality of the dataSource
-                                                field and as such if both fields are
-                                                non-empty, they must have the same
-                                                value. For backwards compatibility,
-                                                when namespace isn''t specified in
-                                                dataSourceRef, both fields (dataSource
-                                                and dataSourceRef) will be set to
-                                                the same value automatically if one
-                                                of them is empty and the other is
-                                                non-empty. When namespace is specified
-                                                in dataSourceRef, dataSource isn''t
-                                                set to the same value and must be
-                                                empty. There are three important differences
-                                                between dataSource and dataSourceRef:
-                                                * While dataSource only allows two
-                                                specific types of objects, dataSourceRef
-                                                allows any non-core object, as well
-                                                as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed
-                                                values (dropping them), dataSourceRef
-                                                preserves all values, and generates
-                                                an error if a disallowed value is
-                                                specified. * While dataSource only
-                                                allows local objects, dataSourceRef
-                                                allows objects in any namespaces.
-                                                (Beta) Using this field requires the
-                                                AnyVolumeDataSource feature gate to
-                                                be enabled. (Alpha) Using the namespace
-                                                field of dataSourceRef requires the
-                                                CrossNamespaceVolumeDataSource feature
-                                                gate to be enabled.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: Namespace is the namespace
-                                                    of resource being referenced Note
-                                                    that when a namespace is specified,
-                                                    a gateway.networking.k8s.io/ReferenceGrant
-                                                    object is required in the referent
-                                                    namespace to allow that namespace's
-                                                    owner to accept the reference.
-                                                    See the ReferenceGrant documentation
-                                                    for details. (Alpha) This field
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'resources represents the
-                                                minimum resources the volume should
-                                                have. If RecoverVolumeExpansionFailure
-                                                feature is enabled users are allowed
-                                                to specify resource requirements that
-                                                are lower than previous value but
-                                                must still be higher than capacity
-                                                recorded in the status field of the
-                                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                               properties:
                                                 claims:
-                                                  description: "Claims lists the names
-                                                    of resources, defined in spec.resourceClaims,
-                                                    that are used by this container.
-                                                    \n This is an alpha field and
-                                                    requires enabling the DynamicResourceAllocation
-                                                    feature gate. \n This field is
-                                                    immutable."
                                                   items:
-                                                    description: ResourceClaim references
-                                                      one entry in PodSpec.ResourceClaims.
                                                     properties:
                                                       name:
-                                                        description: Name must match
-                                                          the name of one entry in
-                                                          pod.spec.resourceClaims
-                                                          of the Pod where this field
-                                                          is used. It makes that resource
-                                                          available inside a container.
                                                         type: string
                                                     required:
                                                     - name
@@ -878,9 +369,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the
-                                                    maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -889,54 +377,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
-                                                    the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -948,33 +400,14 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: 'storageClassName is the
-                                                name of the StorageClass required
-                                                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what
-                                                type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -982,84 +415,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. TODO: how do we prevent errors
-                                        in the filesystem from compromising the machine'
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'wwids Optional: FC volume world
-                                        wide identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: flexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". The default filesystem depends
-                                        on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: 'readOnly is Optional: defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is Optional: secretRef
-                                        is reference to the secret object containing
-                                        sensitive information to pass to the plugin
-                                        scripts. This may be empty if no secret object
-                                        is specified. If the secret object contains
-                                        more than one secret, all secrets are passed
-                                        to the plugin scripts.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -1067,205 +454,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: datasetName is Name of the dataset
-                                        stored as metadata -> name on the dataset
-                                        for Flocker should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'gcePersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   properties:
                                     fsType:
-                                      description: 'fsType is filesystem type of the
-                                        volume that you want to mount. Tip: Ensure
-                                        that the filesystem type is supported by the
-                                        host operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'pdName is unique name of the PD
-                                        resource in GCE. Used to identify the disk
-                                        in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'gitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
                                   properties:
                                     directory:
-                                      description: directory is the target directory
-                                        name. Must not contain or start with '..'.  If
-                                        '.' is supplied, the volume directory will
-                                        be the git repository.  Otherwise, if specified,
-                                        the volume will contain the git repository
-                                        in the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                   properties:
                                     endpoints:
-                                      description: 'endpoints is the endpoint name
-                                        that details Glusterfs topology. More info:
-                                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     path:
-                                      description: 'path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'iscsi represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     initiatorName:
-                                      description: initiatorName is the custom iSCSI
-                                        Initiator Name. If initiatorName is specified
-                                        with iscsiInterface simultaneously, new iSCSI
-                                        interface <target portal>:<volume name> will
-                                        be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iscsiInterface is the interface
-                                        Name that uses an iSCSI transport. Defaults
-                                        to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: portals is the iSCSI Target Portal
-                                        List. The portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: targetPortal is iSCSI Target Portal.
-                                        The Portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -1273,166 +543,67 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'name of the volume. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 nfs:
-                                  description: 'nfs represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   properties:
                                     path:
-                                      description: 'path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: boolean
                                     server:
-                                      description: 'server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly
-                                        setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used
-                                        to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777
-                                        or a decimal value between 0 and 511. YAML
-                                        accepts both octal and decimal values, JSON
-                                        requires decimal values for mode bits. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced ConfigMap
-                                                  will be projected into the volume
-                                                  as a file whose name is the key
-                                                  and content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1440,105 +611,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode
-                                                        bits used to set permissions
-                                                        on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -1550,58 +658,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced Secret will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1609,52 +675,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
                                                 type: string
                                             required:
                                             - path
@@ -1663,162 +696,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: group to map volume access to Default
-                                        is no group
                                       type: string
                                     readOnly:
-                                      description: readOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
                                       type: string
                                     tenant:
-                                      description: tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
                                       type: string
                                     user:
-                                      description: user to map volume access to Defaults
-                                        to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'rbd represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     image:
-                                      description: 'image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: 'keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     monitors:
-                                      description: 'monitors is a collection of Ceph
-                                        monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'pool is the rados pool name. Default
-                                        is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is the rados user name. Default
-                                        is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: storageMode indicates whether the
-                                        storage for a volume should be ThickProvisioned
-                                        or ThinProvisioned. Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the name of a volume
-                                        already created in the ScaleIO system that
-                                        is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -1826,63 +773,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -1890,85 +793,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the
-                                        secret in the pod''s namespace to use. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: volumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: volumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -1991,57 +845,35 @@ spec:
                   type: object
                 type: array
               networkAttachments:
-                description: NetworkAttachments is a list of NetworkAttachment resource
-                  names to expose the services to the given network
                 items:
                   type: string
                 type: array
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes running
-                  this service. Setting here overrides any global NodeSelector settings
-                  within the Manila CR.
                 type: object
               passwordSelectors:
                 default:
                   database: ManilaDatabasePassword
                   service: ManilaPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: ManilaDatabasePassword
-                    description: 'Database - Selector to get the manila database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: ManilaPassword
-                    description: Service - Selector to get the manila service password
-                      from the Secret
                     type: string
                 type: object
               replicas:
                 default: 1
-                description: Replicas - Manila API Replicas
                 format: int32
                 type: integer
               resources:
-                description: Resources - Compute Resources required by this service
-                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                 properties:
                   claims:
-                    description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable."
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: Name must match the name of one entry in pod.spec.resourceClaims
-                            of the Pod where this field is used. It makes that resource
-                            available inside a container.
                           type: string
                       required:
                       - name
@@ -2057,8 +889,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -2067,71 +897,39 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               secret:
-                description: Secret containing OpenStack password information for
-                  ManilaDatabasePassword, AdminPassword
                 type: string
               serviceUser:
                 default: manila
-                description: ServiceUser - optional username used for this service
-                  to register in manila
                 type: string
               transportURLSecret:
-                description: Secret containing RabbitMq transport URL
                 type: string
             type: object
           status:
-            description: ManilaAPIStatus defines the observed state of ManilaAPI
             properties:
               apiEndpoints:
                 additionalProperties:
                   additionalProperties:
                     type: string
                   type: object
-                description: API endpoints
                 type: object
               conditions:
-                description: Conditions
                 items:
-                  description: Condition defines an observation of a API resource
-                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase.
                       type: string
                     severity:
-                      description: Severity provides a classification of Reason code,
-                        so the current situation is immediately understandable and
-                        could act accordingly. It is meant for situations where Status=False
-                        and it should be indicated if it is just informational, warning
-                        (next reconciliation might fix it) or an error (e.g. DB create
-                        issue and no actions to automatically resolve the issue can/should
-                        be done). For conditions where Status=Unknown or Status=True
-                        the Severity should be SeverityNone.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase.
                       type: string
                   required:
                   - lastTransitionTime
@@ -2142,23 +940,19 @@ spec:
               hash:
                 additionalProperties:
                   type: string
-                description: Map of hashes to track e.g. job status
                 type: object
               networkAttachments:
                 additionalProperties:
                   items:
                     type: string
                   type: array
-                description: NetworkAttachments status of the deployment pods
                 type: object
               readyCount:
-                description: ReadyCount of Manila API instances
                 format: int32
                 type: integer
               serviceIDs:
                 additionalProperties:
                   type: string
-                description: ServiceIDs
                 type: object
             type: object
         type: object

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -27,117 +27,58 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Manila is the Schema for the manilas API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ManilaSpec defines the desired state of Manila
             properties:
               customServiceConfig:
                 default: '# add your customization here'
-                description: CustomServiceConfig - customize the service config for
-                  all Manila services using this parameter to change service defaults,
-                  or overwrite rendered information using raw OpenStack config format.
-                  The content gets added to to /etc/<service>/<service>.conf.d directory
-                  as custom.conf file.
                 type: string
               databaseInstance:
-                description: MariaDB instance name Right now required by the maridb-operator
-                  to get the credentials from the instance to create the DB Might
-                  not be required in future
                 type: string
               databaseUser:
                 default: manila
-                description: 'DatabaseUser - optional username used for manila DB,
-                  defaults to manila TODO: -> implement needs work in mariadb-operator,
-                  right now only manila'
                 type: string
               debug:
-                description: Debug - enable debug for different deploy stages. If
-                  an init container is used, it runs and the actual action pod gets
-                  started with sleep infinity
                 properties:
                   dbInitContainer:
                     default: false
-                    description: dbInitContainer enable debug (waits until /tmp/stop-init-container
-                      disappears)
                     type: boolean
                   dbSync:
                     default: false
-                    description: dbSync enable debug
                     type: boolean
                 type: object
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: 'ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  . TODO: -> implement'
                 type: object
               extraMounts:
-                description: ExtraMounts containing conf files and credentials
                 items:
-                  description: ManilaExtraVolMounts exposes additional parameters
-                    processed by the manila-operator and defines the common VolMounts
-                    structure provided by the main storage module
                   properties:
                     extraVol:
                       items:
-                        description: VolMounts is the data structure used to expose
-                          Volumes and Mounts that can be added to a pod according
-                          to the defined Propagation policy
                         properties:
                           extraVolType:
-                            description: Label associated to a given extraMount
                             type: string
                           mounts:
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -145,262 +86,110 @@ spec:
                               type: object
                             type: array
                           propagation:
-                            description: Propagation defines which pod should mount
-                              the volume
                             items:
-                              description: PropagationType identifies the Service,
-                                Group or instance (e.g. the backend) that receives
-                                an Extra Volume that can potentially be mounted
                               type: string
                             type: array
                           volumes:
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'awsElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly value true will force
-                                        the readOnly setting in VolumeMounts. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: boolean
                                     volumeID:
-                                      description: 'volumeID is unique ID of the persistent
-                                        disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'monitors is Required: Monitors
-                                        is a collection of Ceph monitors More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: boolean
                                     secretFile:
-                                      description: 'secretFile is Optional: SecretFile
-                                        is the path to key ring for User, default
-                                        is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                     secretRef:
-                                      description: 'secretRef is Optional: SecretRef
-                                        is reference to the authentication secret
-                                        for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is optional: User is the
-                                        rados user name, default is admin More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is optional: points
-                                        to a secret object containing parameters used
-                                        to connect to OpenStack.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: 'volumeID used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -408,159 +197,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
                                       type: string
                                     fsType:
-                                      description: fsType to mount. Ex. "ext4", "xfs",
-                                        "ntfs". If not provided, the empty value is
-                                        passed to the associated CSI driver which
-                                        will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: nodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: readOnly specifies a read-only
-                                        configuration for the volume. Defaults to
-                                        false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: volumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -572,136 +268,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of
-                                        storage medium should back this directory.
-                                        The default is "" which means to use the node''s
-                                        default medium. Must be an empty string (default)
-                                        or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'sizeLimit is the total amount
-                                        of local storage required for this EmptyDir
-                                        volume. The size limit is also applicable
-                                        for memory medium. The maximum usage on memory
-                                        medium EmptyDir would be the minimum value
-                                        between the SizeLimit specified here and the
-                                        sum of memory limits of all containers in
-                                        a pod. The default is nil which means that
-                                        the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "ephemeral represents a volume that
-                                    is handled by a cluster storage driver. The volume's
-                                    lifecycle is tied to the pod that defines it -
-                                    it will be created before the pod starts, and
-                                    deleted when the pod is removed. \n Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from
-                                    snapshot or capacity tracking are needed, c) the
-                                    storage driver is specified through a storage
-                                    class, and d) the storage driver supports dynamic
-                                    volume provisioning through a PersistentVolumeClaim
-                                    (see EphemeralVolumeSource for more information
-                                    on the connection between this volume type and
-                                    PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                    or one of the vendor-specific APIs for volumes
-                                    that persist for longer than the lifecycle of
-                                    an individual pod. \n Use CSI for light-weight
-                                    local ephemeral volumes if the CSI driver is meant
-                                    to be used that way - see the documentation of
-                                    the driver for more information. \n A pod can
-                                    use both types of ephemeral volumes and persistent
-                                    volumes at the same time."
                                   properties:
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations
-                                            that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
                                           type: object
                                         spec:
-                                          description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: 'accessModes contains the
-                                                desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'dataSource field can be
-                                                used to specify either: * An existing
-                                                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external
-                                                controller can support the specified
-                                                data source, it will create a new
-                                                volume based on the contents of the
-                                                specified data source. When the AnyVolumeDataSource
-                                                feature gate is enabled, dataSource
-                                                contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be
-                                                copied to dataSource when dataSourceRef.namespace
-                                                is not specified. If the namespace
-                                                is specified, then dataSourceRef will
-                                                not be copied to dataSource.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -709,113 +304,25 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: 'dataSourceRef specifies
-                                                the object from which to populate
-                                                the volume with data, if a non-empty
-                                                volume is desired. This may be any
-                                                object from a non-empty API group
-                                                (non core object) or a PersistentVolumeClaim
-                                                object. When this field is specified,
-                                                volume binding will only succeed if
-                                                the type of the specified object matches
-                                                some installed volume populator or
-                                                dynamic provisioner. This field will
-                                                replace the functionality of the dataSource
-                                                field and as such if both fields are
-                                                non-empty, they must have the same
-                                                value. For backwards compatibility,
-                                                when namespace isn''t specified in
-                                                dataSourceRef, both fields (dataSource
-                                                and dataSourceRef) will be set to
-                                                the same value automatically if one
-                                                of them is empty and the other is
-                                                non-empty. When namespace is specified
-                                                in dataSourceRef, dataSource isn''t
-                                                set to the same value and must be
-                                                empty. There are three important differences
-                                                between dataSource and dataSourceRef:
-                                                * While dataSource only allows two
-                                                specific types of objects, dataSourceRef
-                                                allows any non-core object, as well
-                                                as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed
-                                                values (dropping them), dataSourceRef
-                                                preserves all values, and generates
-                                                an error if a disallowed value is
-                                                specified. * While dataSource only
-                                                allows local objects, dataSourceRef
-                                                allows objects in any namespaces.
-                                                (Beta) Using this field requires the
-                                                AnyVolumeDataSource feature gate to
-                                                be enabled. (Alpha) Using the namespace
-                                                field of dataSourceRef requires the
-                                                CrossNamespaceVolumeDataSource feature
-                                                gate to be enabled.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: Namespace is the namespace
-                                                    of resource being referenced Note
-                                                    that when a namespace is specified,
-                                                    a gateway.networking.k8s.io/ReferenceGrant
-                                                    object is required in the referent
-                                                    namespace to allow that namespace's
-                                                    owner to accept the reference.
-                                                    See the ReferenceGrant documentation
-                                                    for details. (Alpha) This field
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'resources represents the
-                                                minimum resources the volume should
-                                                have. If RecoverVolumeExpansionFailure
-                                                feature is enabled users are allowed
-                                                to specify resource requirements that
-                                                are lower than previous value but
-                                                must still be higher than capacity
-                                                recorded in the status field of the
-                                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                               properties:
                                                 claims:
-                                                  description: "Claims lists the names
-                                                    of resources, defined in spec.resourceClaims,
-                                                    that are used by this container.
-                                                    \n This is an alpha field and
-                                                    requires enabling the DynamicResourceAllocation
-                                                    feature gate. \n This field is
-                                                    immutable."
                                                   items:
-                                                    description: ResourceClaim references
-                                                      one entry in PodSpec.ResourceClaims.
                                                     properties:
                                                       name:
-                                                        description: Name must match
-                                                          the name of one entry in
-                                                          pod.spec.resourceClaims
-                                                          of the Pod where this field
-                                                          is used. It makes that resource
-                                                          available inside a container.
                                                         type: string
                                                     required:
                                                     - name
@@ -831,9 +338,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the
-                                                    maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -842,54 +346,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
-                                                    the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -901,33 +369,14 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: 'storageClassName is the
-                                                name of the StorageClass required
-                                                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what
-                                                type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -935,84 +384,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. TODO: how do we prevent errors
-                                        in the filesystem from compromising the machine'
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'wwids Optional: FC volume world
-                                        wide identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: flexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". The default filesystem depends
-                                        on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: 'readOnly is Optional: defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is Optional: secretRef
-                                        is reference to the secret object containing
-                                        sensitive information to pass to the plugin
-                                        scripts. This may be empty if no secret object
-                                        is specified. If the secret object contains
-                                        more than one secret, all secrets are passed
-                                        to the plugin scripts.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -1020,205 +423,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: datasetName is Name of the dataset
-                                        stored as metadata -> name on the dataset
-                                        for Flocker should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'gcePersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   properties:
                                     fsType:
-                                      description: 'fsType is filesystem type of the
-                                        volume that you want to mount. Tip: Ensure
-                                        that the filesystem type is supported by the
-                                        host operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'pdName is unique name of the PD
-                                        resource in GCE. Used to identify the disk
-                                        in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'gitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
                                   properties:
                                     directory:
-                                      description: directory is the target directory
-                                        name. Must not contain or start with '..'.  If
-                                        '.' is supplied, the volume directory will
-                                        be the git repository.  Otherwise, if specified,
-                                        the volume will contain the git repository
-                                        in the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                   properties:
                                     endpoints:
-                                      description: 'endpoints is the endpoint name
-                                        that details Glusterfs topology. More info:
-                                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     path:
-                                      description: 'path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'iscsi represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     initiatorName:
-                                      description: initiatorName is the custom iSCSI
-                                        Initiator Name. If initiatorName is specified
-                                        with iscsiInterface simultaneously, new iSCSI
-                                        interface <target portal>:<volume name> will
-                                        be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iscsiInterface is the interface
-                                        Name that uses an iSCSI transport. Defaults
-                                        to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: portals is the iSCSI Target Portal
-                                        List. The portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: targetPortal is iSCSI Target Portal.
-                                        The Portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -1226,166 +512,67 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'name of the volume. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 nfs:
-                                  description: 'nfs represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   properties:
                                     path:
-                                      description: 'path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: boolean
                                     server:
-                                      description: 'server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly
-                                        setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used
-                                        to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777
-                                        or a decimal value between 0 and 511. YAML
-                                        accepts both octal and decimal values, JSON
-                                        requires decimal values for mode bits. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced ConfigMap
-                                                  will be projected into the volume
-                                                  as a file whose name is the key
-                                                  and content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1393,105 +580,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode
-                                                        bits used to set permissions
-                                                        on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -1503,58 +627,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced Secret will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1562,52 +644,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
                                                 type: string
                                             required:
                                             - path
@@ -1616,162 +665,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: group to map volume access to Default
-                                        is no group
                                       type: string
                                     readOnly:
-                                      description: readOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
                                       type: string
                                     tenant:
-                                      description: tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
                                       type: string
                                     user:
-                                      description: user to map volume access to Defaults
-                                        to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'rbd represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     image:
-                                      description: 'image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: 'keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     monitors:
-                                      description: 'monitors is a collection of Ceph
-                                        monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'pool is the rados pool name. Default
-                                        is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is the rados user name. Default
-                                        is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: storageMode indicates whether the
-                                        storage for a volume should be ThickProvisioned
-                                        or ThinProvisioned. Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the name of a volume
-                                        already created in the ScaleIO system that
-                                        is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -1779,63 +742,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -1843,85 +762,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the
-                                        secret in the pod''s namespace to use. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: volumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: volumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -1944,148 +814,77 @@ spec:
                   type: object
                 type: array
               manilaAPI:
-                description: ManilaAPI - Spec definition for the API service of this
-                  Manila deployment
                 properties:
                   containerImage:
-                    description: ContainerImage - Manila API Container Image URL
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
-                    description: CustomServiceConfig - customize the service config
-                      using this parameter to change service defaults, or overwrite
-                      rendered information using raw OpenStack config format. The
-                      content gets added to to /etc/<service>/<service>.conf.d directory
-                      as custom.conf file.
                     type: string
                   databaseHostname:
-                    description: DatabaseHostname - Manila Database Hostname
                     type: string
                   databaseUser:
                     default: manila
-                    description: 'DatabaseUser - optional username used for manila
-                      DB, defaults to manila TODO: -> implement needs work in mariadb-operator,
-                      right now only manila'
                     type: string
                   debug:
-                    description: Debug - enable debug for different deploy stages.
-                      If an init container is used, it runs and the actual action
-                      pod gets started with sleep infinity
                     properties:
                       initContainer:
                         default: false
-                        description: initContainer enable debug (waits until /tmp/stop-init-container
-                          disappears)
                         type: boolean
                       service:
                         default: false
-                        description: service enable debug
                         type: boolean
                     type: object
                   defaultConfigOverwrite:
                     additionalProperties:
                       type: string
-                    description: ConfigOverwrite - interface to overwrite default
-                      config files like e.g. policy.json. But can also be used to
-                      add additional files. Those get added to the service config
-                      dir in /etc/<service> .
                     type: object
                   externalEndpoints:
-                    description: ExternalEndpoints, expose a VIP via MetalLB on the
-                      pre-created address pool
                     items:
-                      description: MetalLBConfig to configure the MetalLB loadbalancer
-                        service
                       properties:
                         endpoint:
-                          description: Endpoint, OpenStack endpoint this service maps
-                            to
                           enum:
                           - internal
                           - public
                           type: string
                         ipAddressPool:
-                          description: IPAddressPool expose VIP via MetalLB on the
-                            IPAddressPool
                           minLength: 1
                           type: string
                         loadBalancerIPs:
-                          description: LoadBalancerIPs, request given IPs from the
-                            pool if available. Using a list to allow dual stack (IPv4/IPv6)
-                            support
                           items:
                             type: string
                           type: array
                         sharedIP:
                           default: true
-                          description: SharedIP if true, VIP/VIPs get shared with
-                            multiple services
                           type: boolean
                         sharedIPKey:
                           default: ""
-                          description: SharedIPKey specifies the sharing key which
-                            gets set as the annotation on the LoadBalancer service.
-                            Services which share the same VIP must have the same SharedIPKey.
-                            Defaults to the IPAddressPool if SharedIP is true, but
-                            no SharedIPKey specified.
                           type: string
                       required:
                       - ipAddressPool
                       type: object
                     type: array
                   extraMounts:
-                    description: ExtraMounts containing conf files and credentials
                     items:
-                      description: ManilaExtraVolMounts exposes additional parameters
-                        processed by the manila-operator and defines the common VolMounts
-                        structure provided by the main storage module
                       properties:
                         extraVol:
                           items:
-                            description: VolMounts is the data structure used to expose
-                              Volumes and Mounts that can be added to a pod according
-                              to the defined Propagation policy
                             properties:
                               extraVolType:
-                                description: Label associated to a given extraMount
                                 type: string
                               mounts:
                                 items:
-                                  description: VolumeMount describes a mounting of
-                                    a Volume within a container.
                                   properties:
                                     mountPath:
-                                      description: Path within the container at which
-                                        the volume should be mounted.  Must not contain
-                                        ':'.
                                       type: string
                                     mountPropagation:
-                                      description: mountPropagation determines how
-                                        mounts are propagated from the host to container
-                                        and the other way around. When not set, MountPropagationNone
-                                        is used. This field is beta in 1.10.
                                       type: string
                                     name:
-                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
-                                      description: Mounted read-only if true, read-write
-                                        otherwise (false or unspecified). Defaults
-                                        to false.
                                       type: boolean
                                     subPath:
-                                      description: Path within the volume from which
-                                        the container's volume should be mounted.
-                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
-                                      description: Expanded path within the volume
-                                        from which the container's volume should be
-                                        mounted. Behaves similarly to SubPath but
-                                        environment variable references $(VAR_NAME)
-                                        are expanded using the container's environment.
-                                        Defaults to "" (volume's root). SubPathExpr
-                                        and SubPath are mutually exclusive.
                                       type: string
                                   required:
                                   - mountPath
@@ -2093,274 +892,110 @@ spec:
                                   type: object
                                 type: array
                               propagation:
-                                description: Propagation defines which pod should
-                                  mount the volume
                                 items:
-                                  description: PropagationType identifies the Service,
-                                    Group or instance (e.g. the backend) that receives
-                                    an Extra Volume that can potentially be mounted
                                   type: string
                                 type: array
                               volumes:
                                 items:
-                                  description: Volume represents a named volume in
-                                    a pod that may be accessed by any container in
-                                    the pod.
                                   properties:
                                     awsElasticBlockStore:
-                                      description: 'awsElasticBlockStore represents
-                                        an AWS Disk resource that is attached to a
-                                        kubelet''s host machine and then exposed to
-                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).'
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly value true will force
-                                            the readOnly setting in VolumeMounts.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                           type: boolean
                                         volumeID:
-                                          description: 'volumeID is unique ID of the
-                                            persistent disk resource in AWS (Amazon
-                                            EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     azureDisk:
-                                      description: azureDisk represents an Azure Data
-                                        Disk mount on the host and bind mount to the
-                                        pod.
                                       properties:
                                         cachingMode:
-                                          description: 'cachingMode is the Host Caching
-                                            mode: None, Read Only, Read Write.'
                                           type: string
                                         diskName:
-                                          description: diskName is the Name of the
-                                            data disk in the blob storage
                                           type: string
                                         diskURI:
-                                          description: diskURI is the URI of data
-                                            disk in the blob storage
                                           type: string
                                         fsType:
-                                          description: fsType is Filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         kind:
-                                          description: 'kind expected values are Shared:
-                                            multiple blob disks per storage account  Dedicated:
-                                            single blob disk per storage account  Managed:
-                                            azure managed data disk (only in managed
-                                            availability set). defaults to shared'
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                       required:
                                       - diskName
                                       - diskURI
                                       type: object
                                     azureFile:
-                                      description: azureFile represents an Azure File
-                                        Service mount on the host and bind mount to
-                                        the pod.
                                       properties:
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretName:
-                                          description: secretName is the  name of
-                                            secret that contains Azure Storage Account
-                                            Name and Key
                                           type: string
                                         shareName:
-                                          description: shareName is the azure share
-                                            Name
                                           type: string
                                       required:
                                       - secretName
                                       - shareName
                                       type: object
                                     cephfs:
-                                      description: cephFS represents a Ceph FS mount
-                                        on the host that shares a pod's lifetime
                                       properties:
                                         monitors:
-                                          description: 'monitors is Required: Monitors
-                                            is a collection of Ceph monitors More
-                                            info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           items:
                                             type: string
                                           type: array
                                         path:
-                                          description: 'path is Optional: Used as
-                                            the mounted root, rather than the full
-                                            Ceph tree, default is /'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: boolean
                                         secretFile:
-                                          description: 'secretFile is Optional: SecretFile
-                                            is the path to key ring for User, default
-                                            is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: string
                                         secretRef:
-                                          description: 'secretRef is Optional: SecretRef
-                                            is reference to the authentication secret
-                                            for User, default is empty. More info:
-                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is optional: User is
-                                            the rados user name, default is admin
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: string
                                       required:
                                       - monitors
                                       type: object
                                     cinder:
-                                      description: 'cinder represents a cinder volume
-                                        attached and mounted on kubelets host machine.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Examples:
-                                            "ext4", "xfs", "ntfs". Implicitly inferred
-                                            to be "ext4" if unspecified. More info:
-                                            https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is optional: points
-                                            to a secret object containing parameters
-                                            used to connect to OpenStack.'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeID:
-                                          description: 'volumeID used to identify
-                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     configMap:
-                                      description: configMap represents a configMap
-                                        that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced ConfigMap will be projected
-                                            into the volume as a file whose name is
-                                            the key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the ConfigMap,
-                                            the volume setup will error unless it
-                                            is marked optional. Paths must be relative
-                                            and may not contain the '..' path or start
-                                            with '..'.
                                           items:
-                                            description: Maps a string key to a path
-                                              within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
@@ -2368,168 +1003,66 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                         optional:
-                                          description: optional specify whether the
-                                            ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     csi:
-                                      description: csi (Container Storage Interface)
-                                        represents ephemeral storage that is handled
-                                        by certain external CSI drivers (Beta feature).
                                       properties:
                                         driver:
-                                          description: driver is the name of the CSI
-                                            driver that handles this volume. Consult
-                                            with your admin for the correct name as
-                                            registered in the cluster.
                                           type: string
                                         fsType:
-                                          description: fsType to mount. Ex. "ext4",
-                                            "xfs", "ntfs". If not provided, the empty
-                                            value is passed to the associated CSI
-                                            driver which will determine the default
-                                            filesystem to apply.
                                           type: string
                                         nodePublishSecretRef:
-                                          description: nodePublishSecretRef is a reference
-                                            to the secret object containing sensitive
-                                            information to pass to the CSI driver
-                                            to complete the CSI NodePublishVolume
-                                            and NodeUnpublishVolume calls. This field
-                                            is optional, and  may be empty if no secret
-                                            is required. If the secret object contains
-                                            more than one secret, all secret references
-                                            are passed.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         readOnly:
-                                          description: readOnly specifies a read-only
-                                            configuration for the volume. Defaults
-                                            to false (read/write).
                                           type: boolean
                                         volumeAttributes:
                                           additionalProperties:
                                             type: string
-                                          description: volumeAttributes stores driver-specific
-                                            properties that are passed to the CSI
-                                            driver. Consult your driver's documentation
-                                            for supported values.
                                           type: object
                                       required:
                                       - driver
                                       type: object
                                     downwardAPI:
-                                      description: downwardAPI represents downward
-                                        API about the pod that should populate this
-                                        volume
                                       properties:
                                         defaultMode:
-                                          description: 'Optional: mode bits to use
-                                            on created files by default. Must be a
-                                            Optional: mode bits used to set permissions
-                                            on created files by default. Must be an
-                                            octal value between 0000 and 0777 or a
-                                            decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. Defaults to 0644. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: Items is a list of downward
-                                            API volume file
                                           items:
-                                            description: DownwardAPIVolumeFile represents
-                                              information to create the file containing
-                                              the pod field
                                             properties:
                                               fieldRef:
-                                                description: 'Required: Selects a
-                                                  field of the pod: only annotations,
-                                                  labels, name and namespace are supported.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema
-                                                      the FieldPath is written in
-                                                      terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field
-                                                      to select in the specified API
-                                                      version.
                                                     type: string
                                                 required:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               mode:
-                                                description: 'Optional: mode bits
-                                                  used to set permissions on this
-                                                  file, must be an octal value between
-                                                  0000 and 0777 or a decimal value
-                                                  between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: 'Required: Path is  the
-                                                  relative path name of the file to
-                                                  be created. Must not be absolute
-                                                  or contain the ''..'' path. Must
-                                                  be utf-8 encoded. The first item
-                                                  of the relative path must not start
-                                                  with ''..'''
                                                 type: string
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  requests.cpu and requests.memory)
-                                                  are currently supported.'
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name:
-                                                      required for volumes, optional
-                                                      for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                     - type: integer
                                                     - type: string
-                                                    description: Specifies the output
-                                                      format of the exposed resources,
-                                                      defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource
-                                                      to select'
                                                     type: string
                                                 required:
                                                 - resource
@@ -2541,146 +1074,35 @@ spec:
                                           type: array
                                       type: object
                                     emptyDir:
-                                      description: 'emptyDir represents a temporary
-                                        directory that shares a pod''s lifetime. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       properties:
                                         medium:
-                                          description: 'medium represents what type
-                                            of storage medium should back this directory.
-                                            The default is "" which means to use the
-                                            node''s default medium. Must be an empty
-                                            string (default) or Memory. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: 'sizeLimit is the total amount
-                                            of local storage required for this EmptyDir
-                                            volume. The size limit is also applicable
-                                            for memory medium. The maximum usage on
-                                            memory medium EmptyDir would be the minimum
-                                            value between the SizeLimit specified
-                                            here and the sum of memory limits of all
-                                            containers in a pod. The default is nil
-                                            which means that the limit is undefined.
-                                            More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     ephemeral:
-                                      description: "ephemeral represents a volume
-                                        that is handled by a cluster storage driver.
-                                        The volume's lifecycle is tied to the pod
-                                        that defines it - it will be created before
-                                        the pod starts, and deleted when the pod is
-                                        removed. \n Use this if: a) the volume is
-                                        only needed while the pod runs, b) features
-                                        of normal volumes like restoring from snapshot
-                                        or capacity tracking are needed, c) the storage
-                                        driver is specified through a storage class,
-                                        and d) the storage driver supports dynamic
-                                        volume provisioning through a PersistentVolumeClaim
-                                        (see EphemeralVolumeSource for more information
-                                        on the connection between this volume type
-                                        and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                        or one of the vendor-specific APIs for volumes
-                                        that persist for longer than the lifecycle
-                                        of an individual pod. \n Use CSI for light-weight
-                                        local ephemeral volumes if the CSI driver
-                                        is meant to be used that way - see the documentation
-                                        of the driver for more information. \n A pod
-                                        can use both types of ephemeral volumes and
-                                        persistent volumes at the same time."
                                       properties:
                                         volumeClaimTemplate:
-                                          description: "Will be used to create a stand-alone
-                                            PVC to provision the volume. The pod in
-                                            which this EphemeralVolumeSource is embedded
-                                            will be the owner of the PVC, i.e. the
-                                            PVC will be deleted together with the
-                                            pod.  The name of the PVC will be `<pod
-                                            name>-<volume name>` where `<volume name>`
-                                            is the name from the `PodSpec.Volumes`
-                                            array entry. Pod validation will reject
-                                            the pod if the concatenated name is not
-                                            valid for a PVC (for example, too long).
-                                            \n An existing PVC with that name that
-                                            is not owned by the pod will *not* be
-                                            used for the pod to avoid using an unrelated
-                                            volume by mistake. Starting the pod is
-                                            then blocked until the unrelated PVC is
-                                            removed. If such a pre-created PVC is
-                                            meant to be used by the pod, the PVC has
-                                            to updated with an owner reference to
-                                            the pod once the pod exists. Normally
-                                            this should not be necessary, but it may
-                                            be useful when manually reconstructing
-                                            a broken cluster. \n This field is read-only
-                                            and no changes will be made by Kubernetes
-                                            to the PVC after it has been created.
-                                            \n Required, must not be nil."
                                           properties:
                                             metadata:
-                                              description: May contain labels and
-                                                annotations that will be copied into
-                                                the PVC when creating it. No other
-                                                fields are allowed and will be rejected
-                                                during validation.
                                               type: object
                                             spec:
-                                              description: The specification for the
-                                                PersistentVolumeClaim. The entire
-                                                content is copied unchanged into the
-                                                PVC that gets created from this template.
-                                                The same fields as in a PersistentVolumeClaim
-                                                are also valid here.
                                               properties:
                                                 accessModes:
-                                                  description: 'accessModes contains
-                                                    the desired access modes the volume
-                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                   items:
                                                     type: string
                                                   type: array
                                                 dataSource:
-                                                  description: 'dataSource field can
-                                                    be used to specify either: * An
-                                                    existing VolumeSnapshot object
-                                                    (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                    * An existing PVC (PersistentVolumeClaim)
-                                                    If the provisioner or an external
-                                                    controller can support the specified
-                                                    data source, it will create a
-                                                    new volume based on the contents
-                                                    of the specified data source.
-                                                    When the AnyVolumeDataSource feature
-                                                    gate is enabled, dataSource contents
-                                                    will be copied to dataSourceRef,
-                                                    and dataSourceRef contents will
-                                                    be copied to dataSource when dataSourceRef.namespace
-                                                    is not specified. If the namespace
-                                                    is specified, then dataSourceRef
-                                                    will not be copied to dataSource.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -2688,122 +1110,25 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 dataSourceRef:
-                                                  description: 'dataSourceRef specifies
-                                                    the object from which to populate
-                                                    the volume with data, if a non-empty
-                                                    volume is desired. This may be
-                                                    any object from a non-empty API
-                                                    group (non core object) or a PersistentVolumeClaim
-                                                    object. When this field is specified,
-                                                    volume binding will only succeed
-                                                    if the type of the specified object
-                                                    matches some installed volume
-                                                    populator or dynamic provisioner.
-                                                    This field will replace the functionality
-                                                    of the dataSource field and as
-                                                    such if both fields are non-empty,
-                                                    they must have the same value.
-                                                    For backwards compatibility, when
-                                                    namespace isn''t specified in
-                                                    dataSourceRef, both fields (dataSource
-                                                    and dataSourceRef) will be set
-                                                    to the same value automatically
-                                                    if one of them is empty and the
-                                                    other is non-empty. When namespace
-                                                    is specified in dataSourceRef,
-                                                    dataSource isn''t set to the same
-                                                    value and must be empty. There
-                                                    are three important differences
-                                                    between dataSource and dataSourceRef:
-                                                    * While dataSource only allows
-                                                    two specific types of objects,
-                                                    dataSourceRef allows any non-core
-                                                    object, as well as PersistentVolumeClaim
-                                                    objects. * While dataSource ignores
-                                                    disallowed values (dropping them),
-                                                    dataSourceRef preserves all values,
-                                                    and generates an error if a disallowed
-                                                    value is specified. * While dataSource
-                                                    only allows local objects, dataSourceRef
-                                                    allows objects in any namespaces.
-                                                    (Beta) Using this field requires
-                                                    the AnyVolumeDataSource feature
-                                                    gate to be enabled. (Alpha) Using
-                                                    the namespace field of dataSourceRef
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                     namespace:
-                                                      description: Namespace is the
-                                                        namespace of resource being
-                                                        referenced Note that when
-                                                        a namespace is specified,
-                                                        a gateway.networking.k8s.io/ReferenceGrant
-                                                        object is required in the
-                                                        referent namespace to allow
-                                                        that namespace's owner to
-                                                        accept the reference. See
-                                                        the ReferenceGrant documentation
-                                                        for details. (Alpha) This
-                                                        field requires the CrossNamespaceVolumeDataSource
-                                                        feature gate to be enabled.
                                                       type: string
                                                   required:
                                                   - kind
                                                   - name
                                                   type: object
                                                 resources:
-                                                  description: 'resources represents
-                                                    the minimum resources the volume
-                                                    should have. If RecoverVolumeExpansionFailure
-                                                    feature is enabled users are allowed
-                                                    to specify resource requirements
-                                                    that are lower than previous value
-                                                    but must still be higher than
-                                                    capacity recorded in the status
-                                                    field of the claim. More info:
-                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                   properties:
                                                     claims:
-                                                      description: "Claims lists the
-                                                        names of resources, defined
-                                                        in spec.resourceClaims, that
-                                                        are used by this container.
-                                                        \n This is an alpha field
-                                                        and requires enabling the
-                                                        DynamicResourceAllocation
-                                                        feature gate. \n This field
-                                                        is immutable."
                                                       items:
-                                                        description: ResourceClaim
-                                                          references one entry in
-                                                          PodSpec.ResourceClaims.
                                                         properties:
                                                           name:
-                                                            description: Name must
-                                                              match the name of one
-                                                              entry in pod.spec.resourceClaims
-                                                              of the Pod where this
-                                                              field is used. It makes
-                                                              that resource available
-                                                              inside a container.
                                                             type: string
                                                         required:
                                                         - name
@@ -2819,10 +1144,6 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Limits describes
-                                                        the maximum amount of compute
-                                                        resources allowed. More info:
-                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -2831,58 +1152,18 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Requests describes
-                                                        the minimum amount of compute
-                                                        resources required. If Requests
-                                                        is omitted for a container,
-                                                        it defaults to Limits if that
-                                                        is explicitly specified, otherwise
-                                                        to an implementation-defined
-                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                   type: object
                                                 selector:
-                                                  description: selector is a label
-                                                    query over volumes to consider
-                                                    for binding.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
-                                                          relates the key and values.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              label key that the selector
-                                                              applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
-                                                              merge patch.
                                                             items:
                                                               type: string
                                                             type: array
@@ -2894,35 +1175,14 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 storageClassName:
-                                                  description: 'storageClassName is
-                                                    the name of the StorageClass required
-                                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                   type: string
                                                 volumeMode:
-                                                  description: volumeMode defines
-                                                    what type of volume is required
-                                                    by the claim. Value of Filesystem
-                                                    is implied when not included in
-                                                    claim spec.
                                                   type: string
                                                 volumeName:
-                                                  description: volumeName is the binding
-                                                    reference to the PersistentVolume
-                                                    backing this claim.
                                                   type: string
                                               type: object
                                           required:
@@ -2930,85 +1190,38 @@ spec:
                                           type: object
                                       type: object
                                     fc:
-                                      description: fc represents a Fibre Channel resource
-                                        that is attached to a kubelet's host machine
-                                        and then exposed to the pod.
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. TODO: how do
-                                            we prevent errors in the filesystem from
-                                            compromising the machine'
                                           type: string
                                         lun:
-                                          description: 'lun is Optional: FC target
-                                            lun number'
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
                                           type: boolean
                                         targetWWNs:
-                                          description: 'targetWWNs is Optional: FC
-                                            target worldwide names (WWNs)'
                                           items:
                                             type: string
                                           type: array
                                         wwids:
-                                          description: 'wwids Optional: FC volume
-                                            world wide identifiers (wwids) Either
-                                            wwids or combination of targetWWNs and
-                                            lun must be set, but not both simultaneously.'
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     flexVolume:
-                                      description: flexVolume represents a generic
-                                        volume resource that is provisioned/attached
-                                        using an exec based plugin.
                                       properties:
                                         driver:
-                                          description: driver is the name of the driver
-                                            to use for this volume.
                                           type: string
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". The default filesystem
-                                            depends on FlexVolume script.
                                           type: string
                                         options:
                                           additionalProperties:
                                             type: string
-                                          description: 'options is Optional: this
-                                            field holds extra command options if any.'
                                           type: object
                                         readOnly:
-                                          description: 'readOnly is Optional: defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is Optional: secretRef
-                                            is reference to the secret object containing
-                                            sensitive information to pass to the plugin
-                                            scripts. This may be empty if no secret
-                                            object is specified. If the secret object
-                                            contains more than one secret, all secrets
-                                            are passed to the plugin scripts.'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -3016,216 +1229,88 @@ spec:
                                       - driver
                                       type: object
                                     flocker:
-                                      description: flocker represents a Flocker volume
-                                        attached to a kubelet's host machine. This
-                                        depends on the Flocker control service being
-                                        running
                                       properties:
                                         datasetName:
-                                          description: datasetName is Name of the
-                                            dataset stored as metadata -> name on
-                                            the dataset for Flocker should be considered
-                                            as deprecated
                                           type: string
                                         datasetUUID:
-                                          description: datasetUUID is the UUID of
-                                            the dataset. This is unique identifier
-                                            of a Flocker dataset
                                           type: string
                                       type: object
                                     gcePersistentDisk:
-                                      description: 'gcePersistentDisk represents a
-                                        GCE Disk resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       properties:
                                         fsType:
-                                          description: 'fsType is filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           format: int32
                                           type: integer
                                         pdName:
-                                          description: 'pdName is unique name of the
-                                            PD resource in GCE. Used to identify the
-                                            disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           type: boolean
                                       required:
                                       - pdName
                                       type: object
                                     gitRepo:
-                                      description: 'gitRepo represents a git repository
-                                        at a particular revision. DEPRECATED: GitRepo
-                                        is deprecated. To provision a container with
-                                        a git repo, mount an EmptyDir into an InitContainer
-                                        that clones the repo using git, then mount
-                                        the EmptyDir into the Pod''s container.'
                                       properties:
                                         directory:
-                                          description: directory is the target directory
-                                            name. Must not contain or start with '..'.  If
-                                            '.' is supplied, the volume directory
-                                            will be the git repository.  Otherwise,
-                                            if specified, the volume will contain
-                                            the git repository in the subdirectory
-                                            with the given name.
                                           type: string
                                         repository:
-                                          description: repository is the URL
                                           type: string
                                         revision:
-                                          description: revision is the commit hash
-                                            for the specified revision.
                                           type: string
                                       required:
                                       - repository
                                       type: object
                                     glusterfs:
-                                      description: 'glusterfs represents a Glusterfs
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                       properties:
                                         endpoints:
-                                          description: 'endpoints is the endpoint
-                                            name that details Glusterfs topology.
-                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: string
                                         path:
-                                          description: 'path is the Glusterfs volume
-                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            Glusterfs volume to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: boolean
                                       required:
                                       - endpoints
                                       - path
                                       type: object
                                     hostPath:
-                                      description: 'hostPath represents a pre-existing
-                                        file or directory on the host machine that
-                                        is directly exposed to the container. This
-                                        is generally used for system agents or other
-                                        privileged things that are allowed to see
-                                        the host machine. Most containers will NOT
-                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                        --- TODO(jonesdl) We need to restrict who
-                                        can use host directory mounts and who can/can
-                                        not mount host directories as read/write.'
                                       properties:
                                         path:
-                                          description: 'path of the directory on the
-                                            host. If the path is a symlink, it will
-                                            follow the link to the real path. More
-                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults
-                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                           type: string
                                       required:
                                       - path
                                       type: object
                                     iscsi:
-                                      description: 'iscsi represents an ISCSI Disk
-                                        resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                       properties:
                                         chapAuthDiscovery:
-                                          description: chapAuthDiscovery defines whether
-                                            support iSCSI Discovery CHAP authentication
                                           type: boolean
                                         chapAuthSession:
-                                          description: chapAuthSession defines whether
-                                            support iSCSI Session CHAP authentication
                                           type: boolean
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         initiatorName:
-                                          description: initiatorName is the custom
-                                            iSCSI Initiator Name. If initiatorName
-                                            is specified with iscsiInterface simultaneously,
-                                            new iSCSI interface <target portal>:<volume
-                                            name> will be created for the connection.
                                           type: string
                                         iqn:
-                                          description: iqn is the target iSCSI Qualified
-                                            Name.
                                           type: string
                                         iscsiInterface:
-                                          description: iscsiInterface is the interface
-                                            Name that uses an iSCSI transport. Defaults
-                                            to 'default' (tcp).
                                           type: string
                                         lun:
-                                          description: lun represents iSCSI Target
-                                            Lun number.
                                           format: int32
                                           type: integer
                                         portals:
-                                          description: portals is the iSCSI Target
-                                            Portal List. The portal is either an IP
-                                            or ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
                                           items:
                                             type: string
                                           type: array
                                         readOnly:
-                                          description: readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef is the CHAP Secret
-                                            for iSCSI target and initiator authentication
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         targetPortal:
-                                          description: targetPortal is iSCSI Target
-                                            Portal. The Portal is either an IP or
-                                            ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
                                           type: string
                                       required:
                                       - iqn
@@ -3233,182 +1318,67 @@ spec:
                                       - targetPortal
                                       type: object
                                     name:
-                                      description: 'name of the volume. Must be a
-                                        DNS_LABEL and unique within the pod. More
-                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                       type: string
                                     nfs:
-                                      description: 'nfs represents an NFS mount on
-                                        the host that shares a pod''s lifetime More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       properties:
                                         path:
-                                          description: 'path that is exported by the
-                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            NFS export to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: boolean
                                         server:
-                                          description: 'server is the hostname or
-                                            IP address of the NFS server. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: string
                                       required:
                                       - path
                                       - server
                                       type: object
                                     persistentVolumeClaim:
-                                      description: 'persistentVolumeClaimVolumeSource
-                                        represents a reference to a PersistentVolumeClaim
-                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       properties:
                                         claimName:
-                                          description: 'claimName is the name of a
-                                            PersistentVolumeClaim in the same namespace
-                                            as the pod using this volume. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                           type: string
                                         readOnly:
-                                          description: readOnly Will force the ReadOnly
-                                            setting in VolumeMounts. Default false.
                                           type: boolean
                                       required:
                                       - claimName
                                       type: object
                                     photonPersistentDisk:
-                                      description: photonPersistentDisk represents
-                                        a PhotonController persistent disk attached
-                                        and mounted on kubelets host machine
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         pdID:
-                                          description: pdID is the ID that identifies
-                                            Photon Controller persistent disk
                                           type: string
                                       required:
                                       - pdID
                                       type: object
                                     portworxVolume:
-                                      description: portworxVolume represents a portworx
-                                        volume attached and mounted on kubelets host
-                                        machine
                                       properties:
                                         fsType:
-                                          description: fSType represents the filesystem
-                                            type to mount Must be a filesystem type
-                                            supported by the host operating system.
-                                            Ex. "ext4", "xfs". Implicitly inferred
-                                            to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         volumeID:
-                                          description: volumeID uniquely identifies
-                                            a Portworx volume
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     projected:
-                                      description: projected items for all in one
-                                        resources secrets, configmaps, and downward
-                                        API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits
-                                            used to set permissions on created files
-                                            by default. Must be an octal value between
-                                            0000 and 0777 or a decimal value between
-                                            0 and 511. YAML accepts both octal and
-                                            decimal values, JSON requires decimal
-                                            values for mode bits. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.
                                           format: int32
                                           type: integer
                                         sources:
-                                          description: sources is the list of volume
-                                            projections
                                           items:
-                                            description: Projection that may be projected
-                                              along with other supported volume types
                                             properties:
                                               configMap:
-                                                description: configMap information
-                                                  about the configMap data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced ConfigMap
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the ConfigMap, the volume
-                                                      setup will error unless it is
-                                                      marked optional. Paths must
-                                                      be relative and may not contain
-                                                      the '..' path or start with
-                                                      '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -3416,116 +1386,42 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
                                                     type: string
                                                   optional:
-                                                    description: optional specify
-                                                      whether the ConfigMap or its
-                                                      keys must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               downwardAPI:
-                                                description: downwardAPI information
-                                                  about the downwardAPI data to project
                                                 properties:
                                                   items:
-                                                    description: Items is a list of
-                                                      DownwardAPIVolume file
                                                     items:
-                                                      description: DownwardAPIVolumeFile
-                                                        represents information to
-                                                        create the file containing
-                                                        the pod field
                                                       properties:
                                                         fieldRef:
-                                                          description: 'Required:
-                                                            Selects a field of the
-                                                            pod: only annotations,
-                                                            labels, name and namespace
-                                                            are supported.'
                                                           properties:
                                                             apiVersion:
-                                                              description: Version
-                                                                of the schema the
-                                                                FieldPath is written
-                                                                in terms of, defaults
-                                                                to "v1".
                                                               type: string
                                                             fieldPath:
-                                                              description: Path of
-                                                                the field to select
-                                                                in the specified API
-                                                                version.
                                                               type: string
                                                           required:
                                                           - fieldPath
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file,
-                                                            must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: 'Required:
-                                                            Path is  the relative
-                                                            path name of the file
-                                                            to be created. Must not
-                                                            be absolute or contain
-                                                            the ''..'' path. Must
-                                                            be utf-8 encoded. The
-                                                            first item of the relative
-                                                            path must not start with
-                                                            ''..'''
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a
-                                                            resource of the container:
-                                                            only resources limits
-                                                            and requests (limits.cpu,
-                                                            limits.memory, requests.cpu
-                                                            and requests.memory) are
-                                                            currently supported.'
                                                           properties:
                                                             containerName:
-                                                              description: 'Container
-                                                                name: required for
-                                                                volumes, optional
-                                                                for env vars'
                                                               type: string
                                                             divisor:
                                                               anyOf:
                                                               - type: integer
                                                               - type: string
-                                                              description: Specifies
-                                                                the output format
-                                                                of the exposed resources,
-                                                                defaults to "1"
                                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                               x-kubernetes-int-or-string: true
                                                             resource:
-                                                              description: 'Required:
-                                                                resource to select'
                                                               type: string
                                                           required:
                                                           - resource
@@ -3537,64 +1433,16 @@ spec:
                                                     type: array
                                                 type: object
                                               secret:
-                                                description: secret information about
-                                                  the secret data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced Secret
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the Secret, the volume setup
-                                                      will error unless it is marked
-                                                      optional. Paths must be relative
-                                                      and may not contain the '..'
-                                                      path or start with '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -3602,55 +1450,19 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
                                                     type: string
                                                   optional:
-                                                    description: optional field specify
-                                                      whether the Secret or its key
-                                                      must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               serviceAccountToken:
-                                                description: serviceAccountToken is
-                                                  information about the serviceAccountToken
-                                                  data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended
-                                                      audience of the token. A recipient
-                                                      of a token must identify itself
-                                                      with an identifier specified
-                                                      in the audience of the token,
-                                                      and otherwise should reject
-                                                      the token. The audience defaults
-                                                      to the identifier of the apiserver.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: expirationSeconds
-                                                      is the requested duration of
-                                                      validity of the service account
-                                                      token. As the token approaches
-                                                      expiration, the kubelet volume
-                                                      plugin will proactively rotate
-                                                      the service account token. The
-                                                      kubelet will start trying to
-                                                      rotate the token if the token
-                                                      is older than 80 percent of
-                                                      its time to live or if the token
-                                                      is older than 24 hours.Defaults
-                                                      to 1 hour and must be at least
-                                                      10 minutes.
                                                     format: int64
                                                     type: integer
                                                   path:
-                                                    description: path is the path
-                                                      relative to the mount point
-                                                      of the file to project the token
-                                                      into.
                                                     type: string
                                                 required:
                                                 - path
@@ -3659,168 +1471,76 @@ spec:
                                           type: array
                                       type: object
                                     quobyte:
-                                      description: quobyte represents a Quobyte mount
-                                        on the host that shares a pod's lifetime
                                       properties:
                                         group:
-                                          description: group to map volume access
-                                            to Default is no group
                                           type: string
                                         readOnly:
-                                          description: readOnly here will force the
-                                            Quobyte volume to be mounted with read-only
-                                            permissions. Defaults to false.
                                           type: boolean
                                         registry:
-                                          description: registry represents a single
-                                            or multiple Quobyte Registry services
-                                            specified as a string as host:port pair
-                                            (multiple entries are separated with commas)
-                                            which acts as the central registry for
-                                            volumes
                                           type: string
                                         tenant:
-                                          description: tenant owning the given Quobyte
-                                            volume in the Backend Used with dynamically
-                                            provisioned Quobyte volumes, value is
-                                            set by the plugin
                                           type: string
                                         user:
-                                          description: user to map volume access to
-                                            Defaults to serivceaccount user
                                           type: string
                                         volume:
-                                          description: volume is a string that references
-                                            an already created Quobyte volume by name.
                                           type: string
                                       required:
                                       - registry
                                       - volume
                                       type: object
                                     rbd:
-                                      description: 'rbd represents a Rados Block Device
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         image:
-                                          description: 'image is the rados image name.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         keyring:
-                                          description: 'keyring is the path to key
-                                            ring for RBDUser. Default is /etc/ceph/keyring.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         monitors:
-                                          description: 'monitors is a collection of
-                                            Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           items:
                                             type: string
                                           type: array
                                         pool:
-                                          description: 'pool is the rados pool name.
-                                            Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is name of the authentication
-                                            secret for RBDUser. If provided overrides
-                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is the rados user name.
-                                            Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                       required:
                                       - image
                                       - monitors
                                       type: object
                                     scaleIO:
-                                      description: scaleIO represents a ScaleIO persistent
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Default is "xfs".
                                           type: string
                                         gateway:
-                                          description: gateway is the host address
-                                            of the ScaleIO API Gateway.
                                           type: string
                                         protectionDomain:
-                                          description: protectionDomain is the name
-                                            of the ScaleIO Protection Domain for the
-                                            configured storage.
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef references to the
-                                            secret for ScaleIO user and other sensitive
-                                            information. If this is not provided,
-                                            Login operation will fail.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         sslEnabled:
-                                          description: sslEnabled Flag enable/disable
-                                            SSL communication with Gateway, default
-                                            false
                                           type: boolean
                                         storageMode:
-                                          description: storageMode indicates whether
-                                            the storage for a volume should be ThickProvisioned
-                                            or ThinProvisioned. Default is ThinProvisioned.
                                           type: string
                                         storagePool:
-                                          description: storagePool is the ScaleIO
-                                            Storage Pool associated with the protection
-                                            domain.
                                           type: string
                                         system:
-                                          description: system is the name of the storage
-                                            system as configured in ScaleIO.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the name of a
-                                            volume already created in the ScaleIO
-                                            system that is associated with this volume
-                                            source.
                                           type: string
                                       required:
                                       - gateway
@@ -3828,68 +1548,19 @@ spec:
                                       - system
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that
-                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced Secret will be projected into
-                                            the volume as a file whose name is the
-                                            key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the Secret, the
-                                            volume setup will error unless it is marked
-                                            optional. Paths must be relative and may
-                                            not contain the '..' path or start with
-                                            '..'.
                                           items:
-                                            description: Maps a string key to a path
-                                              within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
@@ -3897,90 +1568,36 @@ spec:
                                             type: object
                                           type: array
                                         optional:
-                                          description: optional field specify whether
-                                            the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of
-                                            the secret in the pod''s namespace to
-                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                           type: string
                                       type: object
                                     storageos:
-                                      description: storageOS represents a StorageOS
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef specifies the secret
-                                            to use for obtaining the StorageOS API
-                                            credentials.  If not specified, default
-                                            values will be attempted.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeName:
-                                          description: volumeName is the human-readable
-                                            name of the StorageOS volume.  Volume
-                                            names are only unique within a namespace.
                                           type: string
                                         volumeNamespace:
-                                          description: volumeNamespace specifies the
-                                            scope of the volume within StorageOS.  If
-                                            no namespace is specified then the Pod's
-                                            namespace will be used.  This allows the
-                                            Kubernetes name scoping to be mirrored
-                                            within StorageOS for tighter integration.
-                                            Set VolumeName to any name to override
-                                            the default behaviour. Set to "default"
-                                            if you are not using namespaces within
-                                            StorageOS. Namespaces that do not pre-exist
-                                            within StorageOS will be created.
                                           type: string
                                       type: object
                                     vsphereVolume:
-                                      description: vsphereVolume represents a vSphere
-                                        volume attached and mounted on kubelets host
-                                        machine
                                       properties:
                                         fsType:
-                                          description: fsType is filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         storagePolicyID:
-                                          description: storagePolicyID is the storage
-                                            Policy Based Management (SPBM) profile
-                                            ID associated with the StoragePolicyName.
                                           type: string
                                         storagePolicyName:
-                                          description: storagePolicyName is the storage
-                                            Policy Based Management (SPBM) profile
-                                            name.
                                           type: string
                                         volumePath:
-                                          description: volumePath is the path that
-                                            identifies vSphere volume vmdk
                                           type: string
                                       required:
                                       - volumePath
@@ -4003,59 +1620,35 @@ spec:
                       type: object
                     type: array
                   networkAttachments:
-                    description: NetworkAttachments is a list of NetworkAttachment
-                      resource names to expose the services to the given network
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes running
-                      this service. Setting here overrides any global NodeSelector
-                      settings within the Manila CR.
                     type: object
                   passwordSelectors:
                     default:
                       database: ManilaDatabasePassword
                       service: ManilaPassword
-                    description: PasswordSelectors - Selectors to identify the DB
-                      and ServiceUser password from the Secret
                     properties:
                       database:
                         default: ManilaDatabasePassword
-                        description: 'Database - Selector to get the manila database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
                         type: string
                       service:
                         default: ManilaPassword
-                        description: Service - Selector to get the manila service
-                          password from the Secret
                         type: string
                     type: object
                   replicas:
                     default: 1
-                    description: Replicas - Manila API Replicas
                     format: int32
                     type: integer
                   resources:
-                    description: Resources - Compute Resources required by this service
-                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     properties:
                       claims:
-                        description: "Claims lists the names of resources, defined
-                          in spec.resourceClaims, that are used by this container.
-                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable."
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: Name must match the name of one entry in
-                                pod.spec.resourceClaims of the Pod where this field
-                                is used. It makes that resource available inside a
-                                container.
                               type: string
                           required:
                           - name
@@ -4071,8 +1664,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                       requests:
                         additionalProperties:
@@ -4081,126 +1672,63 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   secret:
-                    description: Secret containing OpenStack password information
-                      for ManilaDatabasePassword, AdminPassword
                     type: string
                   serviceUser:
                     default: manila
-                    description: ServiceUser - optional username used for this service
-                      to register in manila
                     type: string
                   transportURLSecret:
-                    description: Secret containing RabbitMq transport URL
                     type: string
                 type: object
               manilaScheduler:
-                description: ManilaScheduler - Spec definition for the Scheduler service
-                  of this Manila deployment
                 properties:
                   containerImage:
-                    description: ContainerImage - manila Scheduler Container Image
-                      URL
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
-                    description: CustomServiceConfig - customize the service config
-                      using this parameter to change service defaults, or overwrite
-                      rendered information using raw OpenStack config format. The
-                      content gets added to to /etc/<service>/<service>.conf.d directory
-                      as custom.conf file.
                     type: string
                   databaseHostname:
-                    description: DatabaseHostname - manila Database Hostname
                     type: string
                   databaseUser:
                     default: manila
-                    description: 'DatabaseUser - optional username used for manila
-                      DB, defaults to manila TODO: -> implement needs work in mariadb-operator,
-                      right now only manila'
                     type: string
                   debug:
-                    description: Debug - enable debug for different deploy stages.
-                      If an init container is used, it runs and the actual action
-                      pod gets started with sleep infinity
                     properties:
                       initContainer:
                         default: false
-                        description: initContainer enable debug (waits until /tmp/stop-init-container
-                          disappears)
                         type: boolean
                       service:
                         default: false
-                        description: service enable debug
                         type: boolean
                     type: object
                   defaultConfigOverwrite:
                     additionalProperties:
                       type: string
-                    description: ConfigOverwrite - interface to overwrite default
-                      config files like e.g. policy.json. But can also be used to
-                      add additional files. Those get added to the service config
-                      dir in /etc/<service> .
                     type: object
                   extraMounts:
-                    description: ExtraMounts containing conf files and credentials
                     items:
-                      description: ManilaExtraVolMounts exposes additional parameters
-                        processed by the manila-operator and defines the common VolMounts
-                        structure provided by the main storage module
                       properties:
                         extraVol:
                           items:
-                            description: VolMounts is the data structure used to expose
-                              Volumes and Mounts that can be added to a pod according
-                              to the defined Propagation policy
                             properties:
                               extraVolType:
-                                description: Label associated to a given extraMount
                                 type: string
                               mounts:
                                 items:
-                                  description: VolumeMount describes a mounting of
-                                    a Volume within a container.
                                   properties:
                                     mountPath:
-                                      description: Path within the container at which
-                                        the volume should be mounted.  Must not contain
-                                        ':'.
                                       type: string
                                     mountPropagation:
-                                      description: mountPropagation determines how
-                                        mounts are propagated from the host to container
-                                        and the other way around. When not set, MountPropagationNone
-                                        is used. This field is beta in 1.10.
                                       type: string
                                     name:
-                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
-                                      description: Mounted read-only if true, read-write
-                                        otherwise (false or unspecified). Defaults
-                                        to false.
                                       type: boolean
                                     subPath:
-                                      description: Path within the volume from which
-                                        the container's volume should be mounted.
-                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
-                                      description: Expanded path within the volume
-                                        from which the container's volume should be
-                                        mounted. Behaves similarly to SubPath but
-                                        environment variable references $(VAR_NAME)
-                                        are expanded using the container's environment.
-                                        Defaults to "" (volume's root). SubPathExpr
-                                        and SubPath are mutually exclusive.
                                       type: string
                                   required:
                                   - mountPath
@@ -4208,274 +1736,110 @@ spec:
                                   type: object
                                 type: array
                               propagation:
-                                description: Propagation defines which pod should
-                                  mount the volume
                                 items:
-                                  description: PropagationType identifies the Service,
-                                    Group or instance (e.g. the backend) that receives
-                                    an Extra Volume that can potentially be mounted
                                   type: string
                                 type: array
                               volumes:
                                 items:
-                                  description: Volume represents a named volume in
-                                    a pod that may be accessed by any container in
-                                    the pod.
                                   properties:
                                     awsElasticBlockStore:
-                                      description: 'awsElasticBlockStore represents
-                                        an AWS Disk resource that is attached to a
-                                        kubelet''s host machine and then exposed to
-                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).'
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly value true will force
-                                            the readOnly setting in VolumeMounts.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                           type: boolean
                                         volumeID:
-                                          description: 'volumeID is unique ID of the
-                                            persistent disk resource in AWS (Amazon
-                                            EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     azureDisk:
-                                      description: azureDisk represents an Azure Data
-                                        Disk mount on the host and bind mount to the
-                                        pod.
                                       properties:
                                         cachingMode:
-                                          description: 'cachingMode is the Host Caching
-                                            mode: None, Read Only, Read Write.'
                                           type: string
                                         diskName:
-                                          description: diskName is the Name of the
-                                            data disk in the blob storage
                                           type: string
                                         diskURI:
-                                          description: diskURI is the URI of data
-                                            disk in the blob storage
                                           type: string
                                         fsType:
-                                          description: fsType is Filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         kind:
-                                          description: 'kind expected values are Shared:
-                                            multiple blob disks per storage account  Dedicated:
-                                            single blob disk per storage account  Managed:
-                                            azure managed data disk (only in managed
-                                            availability set). defaults to shared'
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                       required:
                                       - diskName
                                       - diskURI
                                       type: object
                                     azureFile:
-                                      description: azureFile represents an Azure File
-                                        Service mount on the host and bind mount to
-                                        the pod.
                                       properties:
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretName:
-                                          description: secretName is the  name of
-                                            secret that contains Azure Storage Account
-                                            Name and Key
                                           type: string
                                         shareName:
-                                          description: shareName is the azure share
-                                            Name
                                           type: string
                                       required:
                                       - secretName
                                       - shareName
                                       type: object
                                     cephfs:
-                                      description: cephFS represents a Ceph FS mount
-                                        on the host that shares a pod's lifetime
                                       properties:
                                         monitors:
-                                          description: 'monitors is Required: Monitors
-                                            is a collection of Ceph monitors More
-                                            info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           items:
                                             type: string
                                           type: array
                                         path:
-                                          description: 'path is Optional: Used as
-                                            the mounted root, rather than the full
-                                            Ceph tree, default is /'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: boolean
                                         secretFile:
-                                          description: 'secretFile is Optional: SecretFile
-                                            is the path to key ring for User, default
-                                            is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: string
                                         secretRef:
-                                          description: 'secretRef is Optional: SecretRef
-                                            is reference to the authentication secret
-                                            for User, default is empty. More info:
-                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is optional: User is
-                                            the rados user name, default is admin
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                           type: string
                                       required:
                                       - monitors
                                       type: object
                                     cinder:
-                                      description: 'cinder represents a cinder volume
-                                        attached and mounted on kubelets host machine.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Examples:
-                                            "ext4", "xfs", "ntfs". Implicitly inferred
-                                            to be "ext4" if unspecified. More info:
-                                            https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is optional: points
-                                            to a secret object containing parameters
-                                            used to connect to OpenStack.'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeID:
-                                          description: 'volumeID used to identify
-                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     configMap:
-                                      description: configMap represents a configMap
-                                        that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced ConfigMap will be projected
-                                            into the volume as a file whose name is
-                                            the key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the ConfigMap,
-                                            the volume setup will error unless it
-                                            is marked optional. Paths must be relative
-                                            and may not contain the '..' path or start
-                                            with '..'.
                                           items:
-                                            description: Maps a string key to a path
-                                              within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
@@ -4483,168 +1847,66 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                         optional:
-                                          description: optional specify whether the
-                                            ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     csi:
-                                      description: csi (Container Storage Interface)
-                                        represents ephemeral storage that is handled
-                                        by certain external CSI drivers (Beta feature).
                                       properties:
                                         driver:
-                                          description: driver is the name of the CSI
-                                            driver that handles this volume. Consult
-                                            with your admin for the correct name as
-                                            registered in the cluster.
                                           type: string
                                         fsType:
-                                          description: fsType to mount. Ex. "ext4",
-                                            "xfs", "ntfs". If not provided, the empty
-                                            value is passed to the associated CSI
-                                            driver which will determine the default
-                                            filesystem to apply.
                                           type: string
                                         nodePublishSecretRef:
-                                          description: nodePublishSecretRef is a reference
-                                            to the secret object containing sensitive
-                                            information to pass to the CSI driver
-                                            to complete the CSI NodePublishVolume
-                                            and NodeUnpublishVolume calls. This field
-                                            is optional, and  may be empty if no secret
-                                            is required. If the secret object contains
-                                            more than one secret, all secret references
-                                            are passed.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         readOnly:
-                                          description: readOnly specifies a read-only
-                                            configuration for the volume. Defaults
-                                            to false (read/write).
                                           type: boolean
                                         volumeAttributes:
                                           additionalProperties:
                                             type: string
-                                          description: volumeAttributes stores driver-specific
-                                            properties that are passed to the CSI
-                                            driver. Consult your driver's documentation
-                                            for supported values.
                                           type: object
                                       required:
                                       - driver
                                       type: object
                                     downwardAPI:
-                                      description: downwardAPI represents downward
-                                        API about the pod that should populate this
-                                        volume
                                       properties:
                                         defaultMode:
-                                          description: 'Optional: mode bits to use
-                                            on created files by default. Must be a
-                                            Optional: mode bits used to set permissions
-                                            on created files by default. Must be an
-                                            octal value between 0000 and 0777 or a
-                                            decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. Defaults to 0644. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: Items is a list of downward
-                                            API volume file
                                           items:
-                                            description: DownwardAPIVolumeFile represents
-                                              information to create the file containing
-                                              the pod field
                                             properties:
                                               fieldRef:
-                                                description: 'Required: Selects a
-                                                  field of the pod: only annotations,
-                                                  labels, name and namespace are supported.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema
-                                                      the FieldPath is written in
-                                                      terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field
-                                                      to select in the specified API
-                                                      version.
                                                     type: string
                                                 required:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               mode:
-                                                description: 'Optional: mode bits
-                                                  used to set permissions on this
-                                                  file, must be an octal value between
-                                                  0000 and 0777 or a decimal value
-                                                  between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: 'Required: Path is  the
-                                                  relative path name of the file to
-                                                  be created. Must not be absolute
-                                                  or contain the ''..'' path. Must
-                                                  be utf-8 encoded. The first item
-                                                  of the relative path must not start
-                                                  with ''..'''
                                                 type: string
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  requests.cpu and requests.memory)
-                                                  are currently supported.'
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name:
-                                                      required for volumes, optional
-                                                      for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                     - type: integer
                                                     - type: string
-                                                    description: Specifies the output
-                                                      format of the exposed resources,
-                                                      defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource
-                                                      to select'
                                                     type: string
                                                 required:
                                                 - resource
@@ -4656,146 +1918,35 @@ spec:
                                           type: array
                                       type: object
                                     emptyDir:
-                                      description: 'emptyDir represents a temporary
-                                        directory that shares a pod''s lifetime. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       properties:
                                         medium:
-                                          description: 'medium represents what type
-                                            of storage medium should back this directory.
-                                            The default is "" which means to use the
-                                            node''s default medium. Must be an empty
-                                            string (default) or Memory. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: 'sizeLimit is the total amount
-                                            of local storage required for this EmptyDir
-                                            volume. The size limit is also applicable
-                                            for memory medium. The maximum usage on
-                                            memory medium EmptyDir would be the minimum
-                                            value between the SizeLimit specified
-                                            here and the sum of memory limits of all
-                                            containers in a pod. The default is nil
-                                            which means that the limit is undefined.
-                                            More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     ephemeral:
-                                      description: "ephemeral represents a volume
-                                        that is handled by a cluster storage driver.
-                                        The volume's lifecycle is tied to the pod
-                                        that defines it - it will be created before
-                                        the pod starts, and deleted when the pod is
-                                        removed. \n Use this if: a) the volume is
-                                        only needed while the pod runs, b) features
-                                        of normal volumes like restoring from snapshot
-                                        or capacity tracking are needed, c) the storage
-                                        driver is specified through a storage class,
-                                        and d) the storage driver supports dynamic
-                                        volume provisioning through a PersistentVolumeClaim
-                                        (see EphemeralVolumeSource for more information
-                                        on the connection between this volume type
-                                        and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                        or one of the vendor-specific APIs for volumes
-                                        that persist for longer than the lifecycle
-                                        of an individual pod. \n Use CSI for light-weight
-                                        local ephemeral volumes if the CSI driver
-                                        is meant to be used that way - see the documentation
-                                        of the driver for more information. \n A pod
-                                        can use both types of ephemeral volumes and
-                                        persistent volumes at the same time."
                                       properties:
                                         volumeClaimTemplate:
-                                          description: "Will be used to create a stand-alone
-                                            PVC to provision the volume. The pod in
-                                            which this EphemeralVolumeSource is embedded
-                                            will be the owner of the PVC, i.e. the
-                                            PVC will be deleted together with the
-                                            pod.  The name of the PVC will be `<pod
-                                            name>-<volume name>` where `<volume name>`
-                                            is the name from the `PodSpec.Volumes`
-                                            array entry. Pod validation will reject
-                                            the pod if the concatenated name is not
-                                            valid for a PVC (for example, too long).
-                                            \n An existing PVC with that name that
-                                            is not owned by the pod will *not* be
-                                            used for the pod to avoid using an unrelated
-                                            volume by mistake. Starting the pod is
-                                            then blocked until the unrelated PVC is
-                                            removed. If such a pre-created PVC is
-                                            meant to be used by the pod, the PVC has
-                                            to updated with an owner reference to
-                                            the pod once the pod exists. Normally
-                                            this should not be necessary, but it may
-                                            be useful when manually reconstructing
-                                            a broken cluster. \n This field is read-only
-                                            and no changes will be made by Kubernetes
-                                            to the PVC after it has been created.
-                                            \n Required, must not be nil."
                                           properties:
                                             metadata:
-                                              description: May contain labels and
-                                                annotations that will be copied into
-                                                the PVC when creating it. No other
-                                                fields are allowed and will be rejected
-                                                during validation.
                                               type: object
                                             spec:
-                                              description: The specification for the
-                                                PersistentVolumeClaim. The entire
-                                                content is copied unchanged into the
-                                                PVC that gets created from this template.
-                                                The same fields as in a PersistentVolumeClaim
-                                                are also valid here.
                                               properties:
                                                 accessModes:
-                                                  description: 'accessModes contains
-                                                    the desired access modes the volume
-                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                   items:
                                                     type: string
                                                   type: array
                                                 dataSource:
-                                                  description: 'dataSource field can
-                                                    be used to specify either: * An
-                                                    existing VolumeSnapshot object
-                                                    (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                    * An existing PVC (PersistentVolumeClaim)
-                                                    If the provisioner or an external
-                                                    controller can support the specified
-                                                    data source, it will create a
-                                                    new volume based on the contents
-                                                    of the specified data source.
-                                                    When the AnyVolumeDataSource feature
-                                                    gate is enabled, dataSource contents
-                                                    will be copied to dataSourceRef,
-                                                    and dataSourceRef contents will
-                                                    be copied to dataSource when dataSourceRef.namespace
-                                                    is not specified. If the namespace
-                                                    is specified, then dataSourceRef
-                                                    will not be copied to dataSource.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -4803,122 +1954,25 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 dataSourceRef:
-                                                  description: 'dataSourceRef specifies
-                                                    the object from which to populate
-                                                    the volume with data, if a non-empty
-                                                    volume is desired. This may be
-                                                    any object from a non-empty API
-                                                    group (non core object) or a PersistentVolumeClaim
-                                                    object. When this field is specified,
-                                                    volume binding will only succeed
-                                                    if the type of the specified object
-                                                    matches some installed volume
-                                                    populator or dynamic provisioner.
-                                                    This field will replace the functionality
-                                                    of the dataSource field and as
-                                                    such if both fields are non-empty,
-                                                    they must have the same value.
-                                                    For backwards compatibility, when
-                                                    namespace isn''t specified in
-                                                    dataSourceRef, both fields (dataSource
-                                                    and dataSourceRef) will be set
-                                                    to the same value automatically
-                                                    if one of them is empty and the
-                                                    other is non-empty. When namespace
-                                                    is specified in dataSourceRef,
-                                                    dataSource isn''t set to the same
-                                                    value and must be empty. There
-                                                    are three important differences
-                                                    between dataSource and dataSourceRef:
-                                                    * While dataSource only allows
-                                                    two specific types of objects,
-                                                    dataSourceRef allows any non-core
-                                                    object, as well as PersistentVolumeClaim
-                                                    objects. * While dataSource ignores
-                                                    disallowed values (dropping them),
-                                                    dataSourceRef preserves all values,
-                                                    and generates an error if a disallowed
-                                                    value is specified. * While dataSource
-                                                    only allows local objects, dataSourceRef
-                                                    allows objects in any namespaces.
-                                                    (Beta) Using this field requires
-                                                    the AnyVolumeDataSource feature
-                                                    gate to be enabled. (Alpha) Using
-                                                    the namespace field of dataSourceRef
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                     namespace:
-                                                      description: Namespace is the
-                                                        namespace of resource being
-                                                        referenced Note that when
-                                                        a namespace is specified,
-                                                        a gateway.networking.k8s.io/ReferenceGrant
-                                                        object is required in the
-                                                        referent namespace to allow
-                                                        that namespace's owner to
-                                                        accept the reference. See
-                                                        the ReferenceGrant documentation
-                                                        for details. (Alpha) This
-                                                        field requires the CrossNamespaceVolumeDataSource
-                                                        feature gate to be enabled.
                                                       type: string
                                                   required:
                                                   - kind
                                                   - name
                                                   type: object
                                                 resources:
-                                                  description: 'resources represents
-                                                    the minimum resources the volume
-                                                    should have. If RecoverVolumeExpansionFailure
-                                                    feature is enabled users are allowed
-                                                    to specify resource requirements
-                                                    that are lower than previous value
-                                                    but must still be higher than
-                                                    capacity recorded in the status
-                                                    field of the claim. More info:
-                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                   properties:
                                                     claims:
-                                                      description: "Claims lists the
-                                                        names of resources, defined
-                                                        in spec.resourceClaims, that
-                                                        are used by this container.
-                                                        \n This is an alpha field
-                                                        and requires enabling the
-                                                        DynamicResourceAllocation
-                                                        feature gate. \n This field
-                                                        is immutable."
                                                       items:
-                                                        description: ResourceClaim
-                                                          references one entry in
-                                                          PodSpec.ResourceClaims.
                                                         properties:
                                                           name:
-                                                            description: Name must
-                                                              match the name of one
-                                                              entry in pod.spec.resourceClaims
-                                                              of the Pod where this
-                                                              field is used. It makes
-                                                              that resource available
-                                                              inside a container.
                                                             type: string
                                                         required:
                                                         - name
@@ -4934,10 +1988,6 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Limits describes
-                                                        the maximum amount of compute
-                                                        resources allowed. More info:
-                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -4946,58 +1996,18 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Requests describes
-                                                        the minimum amount of compute
-                                                        resources required. If Requests
-                                                        is omitted for a container,
-                                                        it defaults to Limits if that
-                                                        is explicitly specified, otherwise
-                                                        to an implementation-defined
-                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                   type: object
                                                 selector:
-                                                  description: selector is a label
-                                                    query over volumes to consider
-                                                    for binding.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
-                                                          relates the key and values.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              label key that the selector
-                                                              applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
-                                                              merge patch.
                                                             items:
                                                               type: string
                                                             type: array
@@ -5009,35 +2019,14 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 storageClassName:
-                                                  description: 'storageClassName is
-                                                    the name of the StorageClass required
-                                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                   type: string
                                                 volumeMode:
-                                                  description: volumeMode defines
-                                                    what type of volume is required
-                                                    by the claim. Value of Filesystem
-                                                    is implied when not included in
-                                                    claim spec.
                                                   type: string
                                                 volumeName:
-                                                  description: volumeName is the binding
-                                                    reference to the PersistentVolume
-                                                    backing this claim.
                                                   type: string
                                               type: object
                                           required:
@@ -5045,85 +2034,38 @@ spec:
                                           type: object
                                       type: object
                                     fc:
-                                      description: fc represents a Fibre Channel resource
-                                        that is attached to a kubelet's host machine
-                                        and then exposed to the pod.
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. TODO: how do
-                                            we prevent errors in the filesystem from
-                                            compromising the machine'
                                           type: string
                                         lun:
-                                          description: 'lun is Optional: FC target
-                                            lun number'
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
                                           type: boolean
                                         targetWWNs:
-                                          description: 'targetWWNs is Optional: FC
-                                            target worldwide names (WWNs)'
                                           items:
                                             type: string
                                           type: array
                                         wwids:
-                                          description: 'wwids Optional: FC volume
-                                            world wide identifiers (wwids) Either
-                                            wwids or combination of targetWWNs and
-                                            lun must be set, but not both simultaneously.'
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     flexVolume:
-                                      description: flexVolume represents a generic
-                                        volume resource that is provisioned/attached
-                                        using an exec based plugin.
                                       properties:
                                         driver:
-                                          description: driver is the name of the driver
-                                            to use for this volume.
                                           type: string
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". The default filesystem
-                                            depends on FlexVolume script.
                                           type: string
                                         options:
                                           additionalProperties:
                                             type: string
-                                          description: 'options is Optional: this
-                                            field holds extra command options if any.'
                                           type: object
                                         readOnly:
-                                          description: 'readOnly is Optional: defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is Optional: secretRef
-                                            is reference to the secret object containing
-                                            sensitive information to pass to the plugin
-                                            scripts. This may be empty if no secret
-                                            object is specified. If the secret object
-                                            contains more than one secret, all secrets
-                                            are passed to the plugin scripts.'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -5131,216 +2073,88 @@ spec:
                                       - driver
                                       type: object
                                     flocker:
-                                      description: flocker represents a Flocker volume
-                                        attached to a kubelet's host machine. This
-                                        depends on the Flocker control service being
-                                        running
                                       properties:
                                         datasetName:
-                                          description: datasetName is Name of the
-                                            dataset stored as metadata -> name on
-                                            the dataset for Flocker should be considered
-                                            as deprecated
                                           type: string
                                         datasetUUID:
-                                          description: datasetUUID is the UUID of
-                                            the dataset. This is unique identifier
-                                            of a Flocker dataset
                                           type: string
                                       type: object
                                     gcePersistentDisk:
-                                      description: 'gcePersistentDisk represents a
-                                        GCE Disk resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       properties:
                                         fsType:
-                                          description: 'fsType is filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           format: int32
                                           type: integer
                                         pdName:
-                                          description: 'pdName is unique name of the
-                                            PD resource in GCE. Used to identify the
-                                            disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                           type: boolean
                                       required:
                                       - pdName
                                       type: object
                                     gitRepo:
-                                      description: 'gitRepo represents a git repository
-                                        at a particular revision. DEPRECATED: GitRepo
-                                        is deprecated. To provision a container with
-                                        a git repo, mount an EmptyDir into an InitContainer
-                                        that clones the repo using git, then mount
-                                        the EmptyDir into the Pod''s container.'
                                       properties:
                                         directory:
-                                          description: directory is the target directory
-                                            name. Must not contain or start with '..'.  If
-                                            '.' is supplied, the volume directory
-                                            will be the git repository.  Otherwise,
-                                            if specified, the volume will contain
-                                            the git repository in the subdirectory
-                                            with the given name.
                                           type: string
                                         repository:
-                                          description: repository is the URL
                                           type: string
                                         revision:
-                                          description: revision is the commit hash
-                                            for the specified revision.
                                           type: string
                                       required:
                                       - repository
                                       type: object
                                     glusterfs:
-                                      description: 'glusterfs represents a Glusterfs
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                       properties:
                                         endpoints:
-                                          description: 'endpoints is the endpoint
-                                            name that details Glusterfs topology.
-                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: string
                                         path:
-                                          description: 'path is the Glusterfs volume
-                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            Glusterfs volume to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                           type: boolean
                                       required:
                                       - endpoints
                                       - path
                                       type: object
                                     hostPath:
-                                      description: 'hostPath represents a pre-existing
-                                        file or directory on the host machine that
-                                        is directly exposed to the container. This
-                                        is generally used for system agents or other
-                                        privileged things that are allowed to see
-                                        the host machine. Most containers will NOT
-                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                        --- TODO(jonesdl) We need to restrict who
-                                        can use host directory mounts and who can/can
-                                        not mount host directories as read/write.'
                                       properties:
                                         path:
-                                          description: 'path of the directory on the
-                                            host. If the path is a symlink, it will
-                                            follow the link to the real path. More
-                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults
-                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                           type: string
                                       required:
                                       - path
                                       type: object
                                     iscsi:
-                                      description: 'iscsi represents an ISCSI Disk
-                                        resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                       properties:
                                         chapAuthDiscovery:
-                                          description: chapAuthDiscovery defines whether
-                                            support iSCSI Discovery CHAP authentication
                                           type: boolean
                                         chapAuthSession:
-                                          description: chapAuthSession defines whether
-                                            support iSCSI Session CHAP authentication
                                           type: boolean
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         initiatorName:
-                                          description: initiatorName is the custom
-                                            iSCSI Initiator Name. If initiatorName
-                                            is specified with iscsiInterface simultaneously,
-                                            new iSCSI interface <target portal>:<volume
-                                            name> will be created for the connection.
                                           type: string
                                         iqn:
-                                          description: iqn is the target iSCSI Qualified
-                                            Name.
                                           type: string
                                         iscsiInterface:
-                                          description: iscsiInterface is the interface
-                                            Name that uses an iSCSI transport. Defaults
-                                            to 'default' (tcp).
                                           type: string
                                         lun:
-                                          description: lun represents iSCSI Target
-                                            Lun number.
                                           format: int32
                                           type: integer
                                         portals:
-                                          description: portals is the iSCSI Target
-                                            Portal List. The portal is either an IP
-                                            or ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
                                           items:
                                             type: string
                                           type: array
                                         readOnly:
-                                          description: readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef is the CHAP Secret
-                                            for iSCSI target and initiator authentication
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         targetPortal:
-                                          description: targetPortal is iSCSI Target
-                                            Portal. The Portal is either an IP or
-                                            ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
                                           type: string
                                       required:
                                       - iqn
@@ -5348,182 +2162,67 @@ spec:
                                       - targetPortal
                                       type: object
                                     name:
-                                      description: 'name of the volume. Must be a
-                                        DNS_LABEL and unique within the pod. More
-                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                       type: string
                                     nfs:
-                                      description: 'nfs represents an NFS mount on
-                                        the host that shares a pod''s lifetime More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       properties:
                                         path:
-                                          description: 'path that is exported by the
-                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            NFS export to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: boolean
                                         server:
-                                          description: 'server is the hostname or
-                                            IP address of the NFS server. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                           type: string
                                       required:
                                       - path
                                       - server
                                       type: object
                                     persistentVolumeClaim:
-                                      description: 'persistentVolumeClaimVolumeSource
-                                        represents a reference to a PersistentVolumeClaim
-                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       properties:
                                         claimName:
-                                          description: 'claimName is the name of a
-                                            PersistentVolumeClaim in the same namespace
-                                            as the pod using this volume. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                           type: string
                                         readOnly:
-                                          description: readOnly Will force the ReadOnly
-                                            setting in VolumeMounts. Default false.
                                           type: boolean
                                       required:
                                       - claimName
                                       type: object
                                     photonPersistentDisk:
-                                      description: photonPersistentDisk represents
-                                        a PhotonController persistent disk attached
-                                        and mounted on kubelets host machine
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         pdID:
-                                          description: pdID is the ID that identifies
-                                            Photon Controller persistent disk
                                           type: string
                                       required:
                                       - pdID
                                       type: object
                                     portworxVolume:
-                                      description: portworxVolume represents a portworx
-                                        volume attached and mounted on kubelets host
-                                        machine
                                       properties:
                                         fsType:
-                                          description: fSType represents the filesystem
-                                            type to mount Must be a filesystem type
-                                            supported by the host operating system.
-                                            Ex. "ext4", "xfs". Implicitly inferred
-                                            to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         volumeID:
-                                          description: volumeID uniquely identifies
-                                            a Portworx volume
                                           type: string
                                       required:
                                       - volumeID
                                       type: object
                                     projected:
-                                      description: projected items for all in one
-                                        resources secrets, configmaps, and downward
-                                        API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits
-                                            used to set permissions on created files
-                                            by default. Must be an octal value between
-                                            0000 and 0777 or a decimal value between
-                                            0 and 511. YAML accepts both octal and
-                                            decimal values, JSON requires decimal
-                                            values for mode bits. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.
                                           format: int32
                                           type: integer
                                         sources:
-                                          description: sources is the list of volume
-                                            projections
                                           items:
-                                            description: Projection that may be projected
-                                              along with other supported volume types
                                             properties:
                                               configMap:
-                                                description: configMap information
-                                                  about the configMap data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced ConfigMap
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the ConfigMap, the volume
-                                                      setup will error unless it is
-                                                      marked optional. Paths must
-                                                      be relative and may not contain
-                                                      the '..' path or start with
-                                                      '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -5531,116 +2230,42 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
                                                     type: string
                                                   optional:
-                                                    description: optional specify
-                                                      whether the ConfigMap or its
-                                                      keys must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               downwardAPI:
-                                                description: downwardAPI information
-                                                  about the downwardAPI data to project
                                                 properties:
                                                   items:
-                                                    description: Items is a list of
-                                                      DownwardAPIVolume file
                                                     items:
-                                                      description: DownwardAPIVolumeFile
-                                                        represents information to
-                                                        create the file containing
-                                                        the pod field
                                                       properties:
                                                         fieldRef:
-                                                          description: 'Required:
-                                                            Selects a field of the
-                                                            pod: only annotations,
-                                                            labels, name and namespace
-                                                            are supported.'
                                                           properties:
                                                             apiVersion:
-                                                              description: Version
-                                                                of the schema the
-                                                                FieldPath is written
-                                                                in terms of, defaults
-                                                                to "v1".
                                                               type: string
                                                             fieldPath:
-                                                              description: Path of
-                                                                the field to select
-                                                                in the specified API
-                                                                version.
                                                               type: string
                                                           required:
                                                           - fieldPath
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file,
-                                                            must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: 'Required:
-                                                            Path is  the relative
-                                                            path name of the file
-                                                            to be created. Must not
-                                                            be absolute or contain
-                                                            the ''..'' path. Must
-                                                            be utf-8 encoded. The
-                                                            first item of the relative
-                                                            path must not start with
-                                                            ''..'''
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a
-                                                            resource of the container:
-                                                            only resources limits
-                                                            and requests (limits.cpu,
-                                                            limits.memory, requests.cpu
-                                                            and requests.memory) are
-                                                            currently supported.'
                                                           properties:
                                                             containerName:
-                                                              description: 'Container
-                                                                name: required for
-                                                                volumes, optional
-                                                                for env vars'
                                                               type: string
                                                             divisor:
                                                               anyOf:
                                                               - type: integer
                                                               - type: string
-                                                              description: Specifies
-                                                                the output format
-                                                                of the exposed resources,
-                                                                defaults to "1"
                                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                               x-kubernetes-int-or-string: true
                                                             resource:
-                                                              description: 'Required:
-                                                                resource to select'
                                                               type: string
                                                           required:
                                                           - resource
@@ -5652,64 +2277,16 @@ spec:
                                                     type: array
                                                 type: object
                                               secret:
-                                                description: secret information about
-                                                  the secret data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced Secret
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the Secret, the volume setup
-                                                      will error unless it is marked
-                                                      optional. Paths must be relative
-                                                      and may not contain the '..'
-                                                      path or start with '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -5717,55 +2294,19 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
                                                     type: string
                                                   optional:
-                                                    description: optional field specify
-                                                      whether the Secret or its key
-                                                      must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               serviceAccountToken:
-                                                description: serviceAccountToken is
-                                                  information about the serviceAccountToken
-                                                  data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended
-                                                      audience of the token. A recipient
-                                                      of a token must identify itself
-                                                      with an identifier specified
-                                                      in the audience of the token,
-                                                      and otherwise should reject
-                                                      the token. The audience defaults
-                                                      to the identifier of the apiserver.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: expirationSeconds
-                                                      is the requested duration of
-                                                      validity of the service account
-                                                      token. As the token approaches
-                                                      expiration, the kubelet volume
-                                                      plugin will proactively rotate
-                                                      the service account token. The
-                                                      kubelet will start trying to
-                                                      rotate the token if the token
-                                                      is older than 80 percent of
-                                                      its time to live or if the token
-                                                      is older than 24 hours.Defaults
-                                                      to 1 hour and must be at least
-                                                      10 minutes.
                                                     format: int64
                                                     type: integer
                                                   path:
-                                                    description: path is the path
-                                                      relative to the mount point
-                                                      of the file to project the token
-                                                      into.
                                                     type: string
                                                 required:
                                                 - path
@@ -5774,168 +2315,76 @@ spec:
                                           type: array
                                       type: object
                                     quobyte:
-                                      description: quobyte represents a Quobyte mount
-                                        on the host that shares a pod's lifetime
                                       properties:
                                         group:
-                                          description: group to map volume access
-                                            to Default is no group
                                           type: string
                                         readOnly:
-                                          description: readOnly here will force the
-                                            Quobyte volume to be mounted with read-only
-                                            permissions. Defaults to false.
                                           type: boolean
                                         registry:
-                                          description: registry represents a single
-                                            or multiple Quobyte Registry services
-                                            specified as a string as host:port pair
-                                            (multiple entries are separated with commas)
-                                            which acts as the central registry for
-                                            volumes
                                           type: string
                                         tenant:
-                                          description: tenant owning the given Quobyte
-                                            volume in the Backend Used with dynamically
-                                            provisioned Quobyte volumes, value is
-                                            set by the plugin
                                           type: string
                                         user:
-                                          description: user to map volume access to
-                                            Defaults to serivceaccount user
                                           type: string
                                         volume:
-                                          description: volume is a string that references
-                                            an already created Quobyte volume by name.
                                           type: string
                                       required:
                                       - registry
                                       - volume
                                       type: object
                                     rbd:
-                                      description: 'rbd represents a Rados Block Device
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
                                           type: string
                                         image:
-                                          description: 'image is the rados image name.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         keyring:
-                                          description: 'keyring is the path to key
-                                            ring for RBDUser. Default is /etc/ceph/keyring.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         monitors:
-                                          description: 'monitors is a collection of
-                                            Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           items:
                                             type: string
                                           type: array
                                         pool:
-                                          description: 'pool is the rados pool name.
-                                            Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is name of the authentication
-                                            secret for RBDUser. If provided overrides
-                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is the rados user name.
-                                            Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                           type: string
                                       required:
                                       - image
                                       - monitors
                                       type: object
                                     scaleIO:
-                                      description: scaleIO represents a ScaleIO persistent
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Default is "xfs".
                                           type: string
                                         gateway:
-                                          description: gateway is the host address
-                                            of the ScaleIO API Gateway.
                                           type: string
                                         protectionDomain:
-                                          description: protectionDomain is the name
-                                            of the ScaleIO Protection Domain for the
-                                            configured storage.
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef references to the
-                                            secret for ScaleIO user and other sensitive
-                                            information. If this is not provided,
-                                            Login operation will fail.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         sslEnabled:
-                                          description: sslEnabled Flag enable/disable
-                                            SSL communication with Gateway, default
-                                            false
                                           type: boolean
                                         storageMode:
-                                          description: storageMode indicates whether
-                                            the storage for a volume should be ThickProvisioned
-                                            or ThinProvisioned. Default is ThinProvisioned.
                                           type: string
                                         storagePool:
-                                          description: storagePool is the ScaleIO
-                                            Storage Pool associated with the protection
-                                            domain.
                                           type: string
                                         system:
-                                          description: system is the name of the storage
-                                            system as configured in ScaleIO.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the name of a
-                                            volume already created in the ScaleIO
-                                            system that is associated with this volume
-                                            source.
                                           type: string
                                       required:
                                       - gateway
@@ -5943,68 +2392,19 @@ spec:
                                       - system
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that
-                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced Secret will be projected into
-                                            the volume as a file whose name is the
-                                            key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the Secret, the
-                                            volume setup will error unless it is marked
-                                            optional. Paths must be relative and may
-                                            not contain the '..' path or start with
-                                            '..'.
                                           items:
-                                            description: Maps a string key to a path
-                                              within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
@@ -6012,90 +2412,36 @@ spec:
                                             type: object
                                           type: array
                                         optional:
-                                          description: optional field specify whether
-                                            the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of
-                                            the secret in the pod''s namespace to
-                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                           type: string
                                       type: object
                                     storageos:
-                                      description: storageOS represents a StorageOS
-                                        volume attached and mounted on Kubernetes
-                                        nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef specifies the secret
-                                            to use for obtaining the StorageOS API
-                                            credentials.  If not specified, default
-                                            values will be attempted.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeName:
-                                          description: volumeName is the human-readable
-                                            name of the StorageOS volume.  Volume
-                                            names are only unique within a namespace.
                                           type: string
                                         volumeNamespace:
-                                          description: volumeNamespace specifies the
-                                            scope of the volume within StorageOS.  If
-                                            no namespace is specified then the Pod's
-                                            namespace will be used.  This allows the
-                                            Kubernetes name scoping to be mirrored
-                                            within StorageOS for tighter integration.
-                                            Set VolumeName to any name to override
-                                            the default behaviour. Set to "default"
-                                            if you are not using namespaces within
-                                            StorageOS. Namespaces that do not pre-exist
-                                            within StorageOS will be created.
                                           type: string
                                       type: object
                                     vsphereVolume:
-                                      description: vsphereVolume represents a vSphere
-                                        volume attached and mounted on kubelets host
-                                        machine
                                       properties:
                                         fsType:
-                                          description: fsType is filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
                                           type: string
                                         storagePolicyID:
-                                          description: storagePolicyID is the storage
-                                            Policy Based Management (SPBM) profile
-                                            ID associated with the StoragePolicyName.
                                           type: string
                                         storagePolicyName:
-                                          description: storagePolicyName is the storage
-                                            Policy Based Management (SPBM) profile
-                                            name.
                                           type: string
                                         volumePath:
-                                          description: volumePath is the path that
-                                            identifies vSphere volume vmdk
                                           type: string
                                       required:
                                       - volumePath
@@ -6118,59 +2464,35 @@ spec:
                       type: object
                     type: array
                   networkAttachments:
-                    description: NetworkAttachments is a list of NetworkAttachment
-                      resource names to expose the services to the given network
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes running
-                      this service. Setting here overrides any global NodeSelector
-                      settings within the Manila CR.
                     type: object
                   passwordSelectors:
                     default:
                       database: ManilaDatabasePassword
                       service: ManilaPassword
-                    description: PasswordSelectors - Selectors to identify the DB
-                      and ServiceUser password from the Secret
                     properties:
                       database:
                         default: ManilaDatabasePassword
-                        description: 'Database - Selector to get the manila database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
                         type: string
                       service:
                         default: ManilaPassword
-                        description: Service - Selector to get the manila service
-                          password from the Secret
                         type: string
                     type: object
                   replicas:
                     default: 1
-                    description: Replicas - manila Scheduler Replicas
                     format: int32
                     type: integer
                   resources:
-                    description: Resources - Compute Resources required by this service
-                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     properties:
                       claims:
-                        description: "Claims lists the names of resources, defined
-                          in spec.resourceClaims, that are used by this container.
-                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable."
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: Name must match the name of one entry in
-                                pod.spec.resourceClaims of the Pod where this field
-                                is used. It makes that resource available inside a
-                                container.
                               type: string
                           required:
                           - name
@@ -6186,8 +2508,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                       requests:
                         additionalProperties:
@@ -6196,128 +2516,64 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   secret:
-                    description: Secret containing OpenStack password information
-                      for manilaDatabasePassword
                     type: string
                   serviceUser:
                     default: manila
-                    description: ServiceUser - optional username used for this service
-                      to register in manila
                     type: string
                   transportURLSecret:
-                    description: Secret containing RabbitMq transport URL
                     type: string
                 type: object
               manilaShares:
                 additionalProperties:
-                  description: ManilaShareSpec defines the desired state of ManilaShare
                   properties:
                     containerImage:
-                      description: ContainerImage - manila Volume Container Image
-                        URL
                       type: string
                     customServiceConfig:
                       default: '# add your customization here'
-                      description: CustomServiceConfig - customize the service config
-                        using this parameter to change service defaults, or overwrite
-                        rendered information using raw OpenStack config format. The
-                        content gets added to to /etc/<service>/<service>.conf.d directory
-                        as custom.conf file.
                       type: string
                     databaseHostname:
-                      description: DatabaseHostname - manila Database Hostname
                       type: string
                     databaseUser:
                       default: manila
-                      description: 'DatabaseUser - optional username used for manila
-                        DB, defaults to manila TODO: -> implement needs work in mariadb-operator,
-                        right now only manila'
                       type: string
                     debug:
-                      description: Debug - enable debug for different deploy stages.
-                        If an init container is used, it runs and the actual action
-                        pod gets started with sleep infinity
                       properties:
                         initContainer:
                           default: false
-                          description: initContainer enable debug (waits until /tmp/stop-init-container
-                            disappears)
                           type: boolean
                         service:
                           default: false
-                          description: service enable debug
                           type: boolean
                       type: object
                     defaultConfigOverwrite:
                       additionalProperties:
                         type: string
-                      description: ConfigOverwrite - interface to overwrite default
-                        config files like e.g. policy.json. But can also be used to
-                        add additional files. Those get added to the service config
-                        dir in /etc/<service> .
                       type: object
                     extraMounts:
-                      description: ExtraMounts containing conf files and credentials
                       items:
-                        description: ManilaExtraVolMounts exposes additional parameters
-                          processed by the manila-operator and defines the common
-                          VolMounts structure provided by the main storage module
                         properties:
                           extraVol:
                             items:
-                              description: VolMounts is the data structure used to
-                                expose Volumes and Mounts that can be added to a pod
-                                according to the defined Propagation policy
                               properties:
                                 extraVolType:
-                                  description: Label associated to a given extraMount
                                   type: string
                                 mounts:
                                   items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: Path within the container at
-                                          which the volume should be mounted.  Must
-                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: mountPropagation determines how
-                                          mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
                                         type: string
                                       name:
-                                        description: This must match the Name of a
-                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: Mounted read-only if true, read-write
-                                          otherwise (false or unspecified). Defaults
-                                          to false.
                                         type: boolean
                                       subPath:
-                                        description: Path within the volume from which
-                                          the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: Expanded path within the volume
-                                          from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -6325,280 +2581,110 @@ spec:
                                     type: object
                                   type: array
                                 propagation:
-                                  description: Propagation defines which pod should
-                                    mount the volume
                                   items:
-                                    description: PropagationType identifies the Service,
-                                      Group or instance (e.g. the backend) that receives
-                                      an Extra Volume that can potentially be mounted
                                     type: string
                                   type: array
                                 volumes:
                                   items:
-                                    description: Volume represents a named volume
-                                      in a pod that may be accessed by any container
-                                      in the pod.
                                     properties:
                                       awsElasticBlockStore:
-                                        description: 'awsElasticBlockStore represents
-                                          an AWS Disk resource that is attached to
-                                          a kubelet''s host machine and then exposed
-                                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         properties:
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type of the volume that you want to
-                                              mount. Tip: Ensure that the filesystem
-                                              type is supported by the host operating
-                                              system. Examples: "ext4", "xfs", "ntfs".
-                                              Implicitly inferred to be "ext4" if
-                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           partition:
-                                            description: 'partition is the partition
-                                              in the volume that you want to mount.
-                                              If omitted, the default is to mount
-                                              by volume name. Examples: For volume
-                                              /dev/sda1, you specify the partition
-                                              as "1". Similarly, the volume partition
-                                              for /dev/sda is "0" (or you can leave
-                                              the property empty).'
                                             format: int32
                                             type: integer
                                           readOnly:
-                                            description: 'readOnly value true will
-                                              force the readOnly setting in VolumeMounts.
-                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                             type: boolean
                                           volumeID:
-                                            description: 'volumeID is unique ID of
-                                              the persistent disk resource in AWS
-                                              (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                             type: string
                                         required:
                                         - volumeID
                                         type: object
                                       azureDisk:
-                                        description: azureDisk represents an Azure
-                                          Data Disk mount on the host and bind mount
-                                          to the pod.
                                         properties:
                                           cachingMode:
-                                            description: 'cachingMode is the Host
-                                              Caching mode: None, Read Only, Read
-                                              Write.'
                                             type: string
                                           diskName:
-                                            description: diskName is the Name of the
-                                              data disk in the blob storage
                                             type: string
                                           diskURI:
-                                            description: diskURI is the URI of data
-                                              disk in the blob storage
                                             type: string
                                           fsType:
-                                            description: fsType is Filesystem type
-                                              to mount. Must be a filesystem type
-                                              supported by the host operating system.
-                                              Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           kind:
-                                            description: 'kind expected values are
-                                              Shared: multiple blob disks per storage
-                                              account  Dedicated: single blob disk
-                                              per storage account  Managed: azure
-                                              managed data disk (only in managed availability
-                                              set). defaults to shared'
                                             type: string
                                           readOnly:
-                                            description: readOnly Defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                         required:
                                         - diskName
                                         - diskURI
                                         type: object
                                       azureFile:
-                                        description: azureFile represents an Azure
-                                          File Service mount on the host and bind
-                                          mount to the pod.
                                         properties:
                                           readOnly:
-                                            description: readOnly defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           secretName:
-                                            description: secretName is the  name of
-                                              secret that contains Azure Storage Account
-                                              Name and Key
                                             type: string
                                           shareName:
-                                            description: shareName is the azure share
-                                              Name
                                             type: string
                                         required:
                                         - secretName
                                         - shareName
                                         type: object
                                       cephfs:
-                                        description: cephFS represents a Ceph FS mount
-                                          on the host that shares a pod's lifetime
                                         properties:
                                           monitors:
-                                            description: 'monitors is Required: Monitors
-                                              is a collection of Ceph monitors More
-                                              info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             items:
                                               type: string
                                             type: array
                                           path:
-                                            description: 'path is Optional: Used as
-                                              the mounted root, rather than the full
-                                              Ceph tree, default is /'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly is Optional: Defaults
-                                              to false (read/write). ReadOnly here
-                                              will force the ReadOnly setting in VolumeMounts.
-                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             type: boolean
                                           secretFile:
-                                            description: 'secretFile is Optional:
-                                              SecretFile is the path to key ring for
-                                              User, default is /etc/ceph/user.secret
-                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             type: string
                                           secretRef:
-                                            description: 'secretRef is Optional: SecretRef
-                                              is reference to the authentication secret
-                                              for User, default is empty. More info:
-                                              https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           user:
-                                            description: 'user is optional: User is
-                                              the rados user name, default is admin
-                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             type: string
                                         required:
                                         - monitors
                                         type: object
                                       cinder:
-                                        description: 'cinder represents a cinder volume
-                                          attached and mounted on kubelets host machine.
-                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         properties:
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Examples: "ext4", "xfs", "ntfs".
-                                              Implicitly inferred to be "ext4" if
-                                              unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
-                                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                             type: boolean
                                           secretRef:
-                                            description: 'secretRef is optional: points
-                                              to a secret object containing parameters
-                                              used to connect to OpenStack.'
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           volumeID:
-                                            description: 'volumeID used to identify
-                                              the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                             type: string
                                         required:
                                         - volumeID
                                         type: object
                                       configMap:
-                                        description: configMap represents a configMap
-                                          that should populate this volume
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is optional:
-                                              mode bits used to set permissions on
-                                              created files by default. Must be an
-                                              octal value between 0000 and 0777 or
-                                              a decimal value between 0 and 511. YAML
-                                              accepts both octal and decimal values,
-                                              JSON requires decimal values for mode
-                                              bits. Defaults to 0644. Directories
-                                              within the path are not affected by
-                                              this setting. This might be in conflict
-                                              with other options that affect the file
-                                              mode, like fsGroup, and the result can
-                                              be other mode bits set.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced ConfigMap will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the ConfigMap, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
                                                   type: string
                                               required:
                                               - key
@@ -6606,171 +2692,66 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       csi:
-                                        description: csi (Container Storage Interface)
-                                          represents ephemeral storage that is handled
-                                          by certain external CSI drivers (Beta feature).
                                         properties:
                                           driver:
-                                            description: driver is the name of the
-                                              CSI driver that handles this volume.
-                                              Consult with your admin for the correct
-                                              name as registered in the cluster.
                                             type: string
                                           fsType:
-                                            description: fsType to mount. Ex. "ext4",
-                                              "xfs", "ntfs". If not provided, the
-                                              empty value is passed to the associated
-                                              CSI driver which will determine the
-                                              default filesystem to apply.
                                             type: string
                                           nodePublishSecretRef:
-                                            description: nodePublishSecretRef is a
-                                              reference to the secret object containing
-                                              sensitive information to pass to the
-                                              CSI driver to complete the CSI NodePublishVolume
-                                              and NodeUnpublishVolume calls. This
-                                              field is optional, and  may be empty
-                                              if no secret is required. If the secret
-                                              object contains more than one secret,
-                                              all secret references are passed.
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           readOnly:
-                                            description: readOnly specifies a read-only
-                                              configuration for the volume. Defaults
-                                              to false (read/write).
                                             type: boolean
                                           volumeAttributes:
                                             additionalProperties:
                                               type: string
-                                            description: volumeAttributes stores driver-specific
-                                              properties that are passed to the CSI
-                                              driver. Consult your driver's documentation
-                                              for supported values.
                                             type: object
                                         required:
                                         - driver
                                         type: object
                                       downwardAPI:
-                                        description: downwardAPI represents downward
-                                          API about the pod that should populate this
-                                          volume
                                         properties:
                                           defaultMode:
-                                            description: 'Optional: mode bits to use
-                                              on created files by default. Must be
-                                              a Optional: mode bits used to set permissions
-                                              on created files by default. Must be
-                                              an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. Defaults to 0644. Directories
-                                              within the path are not affected by
-                                              this setting. This might be in conflict
-                                              with other options that affect the file
-                                              mode, like fsGroup, and the result can
-                                              be other mode bits set.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: Items is a list of downward
-                                              API volume file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file, must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: 'Selects a resource
-                                                    of the container: only resources
-                                                    limits and requests (limits.cpu,
-                                                    limits.memory, requests.cpu and
-                                                    requests.memory) are currently
-                                                    supported.'
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -6782,150 +2763,35 @@ spec:
                                             type: array
                                         type: object
                                       emptyDir:
-                                        description: 'emptyDir represents a temporary
-                                          directory that shares a pod''s lifetime.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         properties:
                                           medium:
-                                            description: 'medium represents what type
-                                              of storage medium should back this directory.
-                                              The default is "" which means to use
-                                              the node''s default medium. Must be
-                                              an empty string (default) or Memory.
-                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                             type: string
                                           sizeLimit:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: 'sizeLimit is the total amount
-                                              of local storage required for this EmptyDir
-                                              volume. The size limit is also applicable
-                                              for memory medium. The maximum usage
-                                              on memory medium EmptyDir would be the
-                                              minimum value between the SizeLimit
-                                              specified here and the sum of memory
-                                              limits of all containers in a pod. The
-                                              default is nil which means that the
-                                              limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       ephemeral:
-                                        description: "ephemeral represents a volume
-                                          that is handled by a cluster storage driver.
-                                          The volume's lifecycle is tied to the pod
-                                          that defines it - it will be created before
-                                          the pod starts, and deleted when the pod
-                                          is removed. \n Use this if: a) the volume
-                                          is only needed while the pod runs, b) features
-                                          of normal volumes like restoring from snapshot
-                                          or capacity tracking are needed, c) the
-                                          storage driver is specified through a storage
-                                          class, and d) the storage driver supports
-                                          dynamic volume provisioning through a PersistentVolumeClaim
-                                          (see EphemeralVolumeSource for more information
-                                          on the connection between this volume type
-                                          and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                          or one of the vendor-specific APIs for volumes
-                                          that persist for longer than the lifecycle
-                                          of an individual pod. \n Use CSI for light-weight
-                                          local ephemeral volumes if the CSI driver
-                                          is meant to be used that way - see the documentation
-                                          of the driver for more information. \n A
-                                          pod can use both types of ephemeral volumes
-                                          and persistent volumes at the same time."
                                         properties:
                                           volumeClaimTemplate:
-                                            description: "Will be used to create a
-                                              stand-alone PVC to provision the volume.
-                                              The pod in which this EphemeralVolumeSource
-                                              is embedded will be the owner of the
-                                              PVC, i.e. the PVC will be deleted together
-                                              with the pod.  The name of the PVC will
-                                              be `<pod name>-<volume name>` where
-                                              `<volume name>` is the name from the
-                                              `PodSpec.Volumes` array entry. Pod validation
-                                              will reject the pod if the concatenated
-                                              name is not valid for a PVC (for example,
-                                              too long). \n An existing PVC with that
-                                              name that is not owned by the pod will
-                                              *not* be used for the pod to avoid using
-                                              an unrelated volume by mistake. Starting
-                                              the pod is then blocked until the unrelated
-                                              PVC is removed. If such a pre-created
-                                              PVC is meant to be used by the pod,
-                                              the PVC has to updated with an owner
-                                              reference to the pod once the pod exists.
-                                              Normally this should not be necessary,
-                                              but it may be useful when manually reconstructing
-                                              a broken cluster. \n This field is read-only
-                                              and no changes will be made by Kubernetes
-                                              to the PVC after it has been created.
-                                              \n Required, must not be nil."
                                             properties:
                                               metadata:
-                                                description: May contain labels and
-                                                  annotations that will be copied
-                                                  into the PVC when creating it. No
-                                                  other fields are allowed and will
-                                                  be rejected during validation.
                                                 type: object
                                               spec:
-                                                description: The specification for
-                                                  the PersistentVolumeClaim. The entire
-                                                  content is copied unchanged into
-                                                  the PVC that gets created from this
-                                                  template. The same fields as in
-                                                  a PersistentVolumeClaim are also
-                                                  valid here.
                                                 properties:
                                                   accessModes:
-                                                    description: 'accessModes contains
-                                                      the desired access modes the
-                                                      volume should have. More info:
-                                                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                     items:
                                                       type: string
                                                     type: array
                                                   dataSource:
-                                                    description: 'dataSource field
-                                                      can be used to specify either:
-                                                      * An existing VolumeSnapshot
-                                                      object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                      * An existing PVC (PersistentVolumeClaim)
-                                                      If the provisioner or an external
-                                                      controller can support the specified
-                                                      data source, it will create
-                                                      a new volume based on the contents
-                                                      of the specified data source.
-                                                      When the AnyVolumeDataSource
-                                                      feature gate is enabled, dataSource
-                                                      contents will be copied to dataSourceRef,
-                                                      and dataSourceRef contents will
-                                                      be copied to dataSource when
-                                                      dataSourceRef.namespace is not
-                                                      specified. If the namespace
-                                                      is specified, then dataSourceRef
-                                                      will not be copied to dataSource.'
                                                     properties:
                                                       apiGroup:
-                                                        description: APIGroup is the
-                                                          group for the resource being
-                                                          referenced. If APIGroup
-                                                          is not specified, the specified
-                                                          Kind must be in the core
-                                                          API group. For any other
-                                                          third-party types, APIGroup
-                                                          is required.
                                                         type: string
                                                       kind:
-                                                        description: Kind is the type
-                                                          of resource being referenced
                                                         type: string
                                                       name:
-                                                        description: Name is the name
-                                                          of resource being referenced
                                                         type: string
                                                     required:
                                                     - kind
@@ -6933,128 +2799,25 @@ spec:
                                                     type: object
                                                     x-kubernetes-map-type: atomic
                                                   dataSourceRef:
-                                                    description: 'dataSourceRef specifies
-                                                      the object from which to populate
-                                                      the volume with data, if a non-empty
-                                                      volume is desired. This may
-                                                      be any object from a non-empty
-                                                      API group (non core object)
-                                                      or a PersistentVolumeClaim object.
-                                                      When this field is specified,
-                                                      volume binding will only succeed
-                                                      if the type of the specified
-                                                      object matches some installed
-                                                      volume populator or dynamic
-                                                      provisioner. This field will
-                                                      replace the functionality of
-                                                      the dataSource field and as
-                                                      such if both fields are non-empty,
-                                                      they must have the same value.
-                                                      For backwards compatibility,
-                                                      when namespace isn''t specified
-                                                      in dataSourceRef, both fields
-                                                      (dataSource and dataSourceRef)
-                                                      will be set to the same value
-                                                      automatically if one of them
-                                                      is empty and the other is non-empty.
-                                                      When namespace is specified
-                                                      in dataSourceRef, dataSource
-                                                      isn''t set to the same value
-                                                      and must be empty. There are
-                                                      three important differences
-                                                      between dataSource and dataSourceRef:
-                                                      * While dataSource only allows
-                                                      two specific types of objects,
-                                                      dataSourceRef allows any non-core
-                                                      object, as well as PersistentVolumeClaim
-                                                      objects. * While dataSource
-                                                      ignores disallowed values (dropping
-                                                      them), dataSourceRef preserves
-                                                      all values, and generates an
-                                                      error if a disallowed value
-                                                      is specified. * While dataSource
-                                                      only allows local objects, dataSourceRef
-                                                      allows objects in any namespaces.
-                                                      (Beta) Using this field requires
-                                                      the AnyVolumeDataSource feature
-                                                      gate to be enabled. (Alpha)
-                                                      Using the namespace field of
-                                                      dataSourceRef requires the CrossNamespaceVolumeDataSource
-                                                      feature gate to be enabled.'
                                                     properties:
                                                       apiGroup:
-                                                        description: APIGroup is the
-                                                          group for the resource being
-                                                          referenced. If APIGroup
-                                                          is not specified, the specified
-                                                          Kind must be in the core
-                                                          API group. For any other
-                                                          third-party types, APIGroup
-                                                          is required.
                                                         type: string
                                                       kind:
-                                                        description: Kind is the type
-                                                          of resource being referenced
                                                         type: string
                                                       name:
-                                                        description: Name is the name
-                                                          of resource being referenced
                                                         type: string
                                                       namespace:
-                                                        description: Namespace is
-                                                          the namespace of resource
-                                                          being referenced Note that
-                                                          when a namespace is specified,
-                                                          a gateway.networking.k8s.io/ReferenceGrant
-                                                          object is required in the
-                                                          referent namespace to allow
-                                                          that namespace's owner to
-                                                          accept the reference. See
-                                                          the ReferenceGrant documentation
-                                                          for details. (Alpha) This
-                                                          field requires the CrossNamespaceVolumeDataSource
-                                                          feature gate to be enabled.
                                                         type: string
                                                     required:
                                                     - kind
                                                     - name
                                                     type: object
                                                   resources:
-                                                    description: 'resources represents
-                                                      the minimum resources the volume
-                                                      should have. If RecoverVolumeExpansionFailure
-                                                      feature is enabled users are
-                                                      allowed to specify resource
-                                                      requirements that are lower
-                                                      than previous value but must
-                                                      still be higher than capacity
-                                                      recorded in the status field
-                                                      of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                     properties:
                                                       claims:
-                                                        description: "Claims lists
-                                                          the names of resources,
-                                                          defined in spec.resourceClaims,
-                                                          that are used by this container.
-                                                          \n This is an alpha field
-                                                          and requires enabling the
-                                                          DynamicResourceAllocation
-                                                          feature gate. \n This field
-                                                          is immutable."
                                                         items:
-                                                          description: ResourceClaim
-                                                            references one entry in
-                                                            PodSpec.ResourceClaims.
                                                           properties:
                                                             name:
-                                                              description: Name must
-                                                                match the name of
-                                                                one entry in pod.spec.resourceClaims
-                                                                of the Pod where this
-                                                                field is used. It
-                                                                makes that resource
-                                                                available inside a
-                                                                container.
                                                               type: string
                                                           required:
                                                           - name
@@ -7070,10 +2833,6 @@ spec:
                                                           - type: string
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
-                                                        description: 'Limits describes
-                                                          the maximum amount of compute
-                                                          resources allowed. More
-                                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                         type: object
                                                       requests:
                                                         additionalProperties:
@@ -7082,63 +2841,18 @@ spec:
                                                           - type: string
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
-                                                        description: 'Requests describes
-                                                          the minimum amount of compute
-                                                          resources required. If Requests
-                                                          is omitted for a container,
-                                                          it defaults to Limits if
-                                                          that is explicitly specified,
-                                                          otherwise to an implementation-defined
-                                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                         type: object
                                                     type: object
                                                   selector:
-                                                    description: selector is a label
-                                                      query over volumes to consider
-                                                      for binding.
                                                     properties:
                                                       matchExpressions:
-                                                        description: matchExpressions
-                                                          is a list of label selector
-                                                          requirements. The requirements
-                                                          are ANDed.
                                                         items:
-                                                          description: A label selector
-                                                            requirement is a selector
-                                                            that contains values,
-                                                            a key, and an operator
-                                                            that relates the key and
-                                                            values.
                                                           properties:
                                                             key:
-                                                              description: key is
-                                                                the label key that
-                                                                the selector applies
-                                                                to.
                                                               type: string
                                                             operator:
-                                                              description: operator
-                                                                represents a key's
-                                                                relationship to a
-                                                                set of values. Valid
-                                                                operators are In,
-                                                                NotIn, Exists and
-                                                                DoesNotExist.
                                                               type: string
                                                             values:
-                                                              description: values
-                                                                is an array of string
-                                                                values. If the operator
-                                                                is In or NotIn, the
-                                                                values array must
-                                                                be non-empty. If the
-                                                                operator is Exists
-                                                                or DoesNotExist, the
-                                                                values array must
-                                                                be empty. This array
-                                                                is replaced during
-                                                                a strategic merge
-                                                                patch.
                                                               items:
                                                                 type: string
                                                               type: array
@@ -7150,36 +2864,14 @@ spec:
                                                       matchLabels:
                                                         additionalProperties:
                                                           type: string
-                                                        description: matchLabels is
-                                                          a map of {key,value} pairs.
-                                                          A single {key,value} in
-                                                          the matchLabels map is equivalent
-                                                          to an element of matchExpressions,
-                                                          whose key field is "key",
-                                                          the operator is "In", and
-                                                          the values array contains
-                                                          only "value". The requirements
-                                                          are ANDed.
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
                                                   storageClassName:
-                                                    description: 'storageClassName
-                                                      is the name of the StorageClass
-                                                      required by the claim. More
-                                                      info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                     type: string
                                                   volumeMode:
-                                                    description: volumeMode defines
-                                                      what type of volume is required
-                                                      by the claim. Value of Filesystem
-                                                      is implied when not included
-                                                      in claim spec.
                                                     type: string
                                                   volumeName:
-                                                    description: volumeName is the
-                                                      binding reference to the PersistentVolume
-                                                      backing this claim.
                                                     type: string
                                                 type: object
                                             required:
@@ -7187,88 +2879,38 @@ spec:
                                             type: object
                                         type: object
                                       fc:
-                                        description: fc represents a Fibre Channel
-                                          resource that is attached to a kubelet's
-                                          host machine and then exposed to the pod.
                                         properties:
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           lun:
-                                            description: 'lun is Optional: FC target
-                                              lun number'
                                             format: int32
                                             type: integer
                                           readOnly:
-                                            description: 'readOnly is Optional: Defaults
-                                              to false (read/write). ReadOnly here
-                                              will force the ReadOnly setting in VolumeMounts.'
                                             type: boolean
                                           targetWWNs:
-                                            description: 'targetWWNs is Optional:
-                                              FC target worldwide names (WWNs)'
                                             items:
                                               type: string
                                             type: array
                                           wwids:
-                                            description: 'wwids Optional: FC volume
-                                              world wide identifiers (wwids) Either
-                                              wwids or combination of targetWWNs and
-                                              lun must be set, but not both simultaneously.'
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       flexVolume:
-                                        description: flexVolume represents a generic
-                                          volume resource that is provisioned/attached
-                                          using an exec based plugin.
                                         properties:
                                           driver:
-                                            description: driver is the name of the
-                                              driver to use for this volume.
                                             type: string
                                           fsType:
-                                            description: fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". The
-                                              default filesystem depends on FlexVolume
-                                              script.
                                             type: string
                                           options:
                                             additionalProperties:
                                               type: string
-                                            description: 'options is Optional: this
-                                              field holds extra command options if
-                                              any.'
                                             type: object
                                           readOnly:
-                                            description: 'readOnly is Optional: defaults
-                                              to false (read/write). ReadOnly here
-                                              will force the ReadOnly setting in VolumeMounts.'
                                             type: boolean
                                           secretRef:
-                                            description: 'secretRef is Optional: secretRef
-                                              is reference to the secret object containing
-                                              sensitive information to pass to the
-                                              plugin scripts. This may be empty if
-                                              no secret object is specified. If the
-                                              secret object contains more than one
-                                              secret, all secrets are passed to the
-                                              plugin scripts.'
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
@@ -7276,220 +2918,88 @@ spec:
                                         - driver
                                         type: object
                                       flocker:
-                                        description: flocker represents a Flocker
-                                          volume attached to a kubelet's host machine.
-                                          This depends on the Flocker control service
-                                          being running
                                         properties:
                                           datasetName:
-                                            description: datasetName is Name of the
-                                              dataset stored as metadata -> name on
-                                              the dataset for Flocker should be considered
-                                              as deprecated
                                             type: string
                                           datasetUUID:
-                                            description: datasetUUID is the UUID of
-                                              the dataset. This is unique identifier
-                                              of a Flocker dataset
                                             type: string
                                         type: object
                                       gcePersistentDisk:
-                                        description: 'gcePersistentDisk represents
-                                          a GCE Disk resource that is attached to
-                                          a kubelet''s host machine and then exposed
-                                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         properties:
                                           fsType:
-                                            description: 'fsType is filesystem type
-                                              of the volume that you want to mount.
-                                              Tip: Ensure that the filesystem type
-                                              is supported by the host operating system.
-                                              Examples: "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
-                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           partition:
-                                            description: 'partition is the partition
-                                              in the volume that you want to mount.
-                                              If omitted, the default is to mount
-                                              by volume name. Examples: For volume
-                                              /dev/sda1, you specify the partition
-                                              as "1". Similarly, the volume partition
-                                              for /dev/sda is "0" (or you can leave
-                                              the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                             format: int32
                                             type: integer
                                           pdName:
-                                            description: 'pdName is unique name of
-                                              the PD resource in GCE. Used to identify
-                                              the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
-                                              Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                             type: boolean
                                         required:
                                         - pdName
                                         type: object
                                       gitRepo:
-                                        description: 'gitRepo represents a git repository
-                                          at a particular revision. DEPRECATED: GitRepo
-                                          is deprecated. To provision a container
-                                          with a git repo, mount an EmptyDir into
-                                          an InitContainer that clones the repo using
-                                          git, then mount the EmptyDir into the Pod''s
-                                          container.'
                                         properties:
                                           directory:
-                                            description: directory is the target directory
-                                              name. Must not contain or start with
-                                              '..'.  If '.' is supplied, the volume
-                                              directory will be the git repository.  Otherwise,
-                                              if specified, the volume will contain
-                                              the git repository in the subdirectory
-                                              with the given name.
                                             type: string
                                           repository:
-                                            description: repository is the URL
                                             type: string
                                           revision:
-                                            description: revision is the commit hash
-                                              for the specified revision.
                                             type: string
                                         required:
                                         - repository
                                         type: object
                                       glusterfs:
-                                        description: 'glusterfs represents a Glusterfs
-                                          mount on the host that shares a pod''s lifetime.
-                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                         properties:
                                           endpoints:
-                                            description: 'endpoints is the endpoint
-                                              name that details Glusterfs topology.
-                                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                             type: string
                                           path:
-                                            description: 'path is the Glusterfs volume
-                                              path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly here will force
-                                              the Glusterfs volume to be mounted with
-                                              read-only permissions. Defaults to false.
-                                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                             type: boolean
                                         required:
                                         - endpoints
                                         - path
                                         type: object
                                       hostPath:
-                                        description: 'hostPath represents a pre-existing
-                                          file or directory on the host machine that
-                                          is directly exposed to the container. This
-                                          is generally used for system agents or other
-                                          privileged things that are allowed to see
-                                          the host machine. Most containers will NOT
-                                          need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                          --- TODO(jonesdl) We need to restrict who
-                                          can use host directory mounts and who can/can
-                                          not mount host directories as read/write.'
                                         properties:
                                           path:
-                                            description: 'path of the directory on
-                                              the host. If the path is a symlink,
-                                              it will follow the link to the real
-                                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                             type: string
                                           type:
-                                            description: 'type for HostPath Volume
-                                              Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       iscsi:
-                                        description: 'iscsi represents an ISCSI Disk
-                                          resource that is attached to a kubelet''s
-                                          host machine and then exposed to the pod.
-                                          More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                         properties:
                                           chapAuthDiscovery:
-                                            description: chapAuthDiscovery defines
-                                              whether support iSCSI Discovery CHAP
-                                              authentication
                                             type: boolean
                                           chapAuthSession:
-                                            description: chapAuthSession defines whether
-                                              support iSCSI Session CHAP authentication
                                             type: boolean
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type of the volume that you want to
-                                              mount. Tip: Ensure that the filesystem
-                                              type is supported by the host operating
-                                              system. Examples: "ext4", "xfs", "ntfs".
-                                              Implicitly inferred to be "ext4" if
-                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           initiatorName:
-                                            description: initiatorName is the custom
-                                              iSCSI Initiator Name. If initiatorName
-                                              is specified with iscsiInterface simultaneously,
-                                              new iSCSI interface <target portal>:<volume
-                                              name> will be created for the connection.
                                             type: string
                                           iqn:
-                                            description: iqn is the target iSCSI Qualified
-                                              Name.
                                             type: string
                                           iscsiInterface:
-                                            description: iscsiInterface is the interface
-                                              Name that uses an iSCSI transport. Defaults
-                                              to 'default' (tcp).
                                             type: string
                                           lun:
-                                            description: lun represents iSCSI Target
-                                              Lun number.
                                             format: int32
                                             type: integer
                                           portals:
-                                            description: portals is the iSCSI Target
-                                              Portal List. The portal is either an
-                                              IP or ip_addr:port if the port is other
-                                              than default (typically TCP ports 860
-                                              and 3260).
                                             items:
                                               type: string
                                             type: array
                                           readOnly:
-                                            description: readOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
-                                              Defaults to false.
                                             type: boolean
                                           secretRef:
-                                            description: secretRef is the CHAP Secret
-                                              for iSCSI target and initiator authentication
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           targetPortal:
-                                            description: targetPortal is iSCSI Target
-                                              Portal. The Portal is either an IP or
-                                              ip_addr:port if the port is other than
-                                              default (typically TCP ports 860 and
-                                              3260).
                                             type: string
                                         required:
                                         - iqn
@@ -7497,185 +3007,67 @@ spec:
                                         - targetPortal
                                         type: object
                                       name:
-                                        description: 'name of the volume. Must be
-                                          a DNS_LABEL and unique within the pod. More
-                                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                       nfs:
-                                        description: 'nfs represents an NFS mount
-                                          on the host that shares a pod''s lifetime
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         properties:
                                           path:
-                                            description: 'path that is exported by
-                                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly here will force
-                                              the NFS export to be mounted with read-only
-                                              permissions. Defaults to false. More
-                                              info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                             type: boolean
                                           server:
-                                            description: 'server is the hostname or
-                                              IP address of the NFS server. More info:
-                                              https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                             type: string
                                         required:
                                         - path
                                         - server
                                         type: object
                                       persistentVolumeClaim:
-                                        description: 'persistentVolumeClaimVolumeSource
-                                          represents a reference to a PersistentVolumeClaim
-                                          in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         properties:
                                           claimName:
-                                            description: 'claimName is the name of
-                                              a PersistentVolumeClaim in the same
-                                              namespace as the pod using this volume.
-                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                             type: string
                                           readOnly:
-                                            description: readOnly Will force the ReadOnly
-                                              setting in VolumeMounts. Default false.
                                             type: boolean
                                         required:
                                         - claimName
                                         type: object
                                       photonPersistentDisk:
-                                        description: photonPersistentDisk represents
-                                          a PhotonController persistent disk attached
-                                          and mounted on kubelets host machine
                                         properties:
                                           fsType:
-                                            description: fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           pdID:
-                                            description: pdID is the ID that identifies
-                                              Photon Controller persistent disk
                                             type: string
                                         required:
                                         - pdID
                                         type: object
                                       portworxVolume:
-                                        description: portworxVolume represents a portworx
-                                          volume attached and mounted on kubelets
-                                          host machine
                                         properties:
                                           fsType:
-                                            description: fSType represents the filesystem
-                                              type to mount Must be a filesystem type
-                                              supported by the host operating system.
-                                              Ex. "ext4", "xfs". Implicitly inferred
-                                              to be "ext4" if unspecified.
                                             type: string
                                           readOnly:
-                                            description: readOnly defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           volumeID:
-                                            description: volumeID uniquely identifies
-                                              a Portworx volume
                                             type: string
                                         required:
                                         - volumeID
                                         type: object
                                       projected:
-                                        description: projected items for all in one
-                                          resources secrets, configmaps, and downward
-                                          API
                                         properties:
                                           defaultMode:
-                                            description: defaultMode are the mode
-                                              bits used to set permissions on created
-                                              files by default. Must be an octal value
-                                              between 0000 and 0777 or a decimal value
-                                              between 0 and 511. YAML accepts both
-                                              octal and decimal values, JSON requires
-                                              decimal values for mode bits. Directories
-                                              within the path are not affected by
-                                              this setting. This might be in conflict
-                                              with other options that affect the file
-                                              mode, like fsGroup, and the result can
-                                              be other mode bits set.
                                             format: int32
                                             type: integer
                                           sources:
-                                            description: sources is the list of volume
-                                              projections
                                             items:
-                                              description: Projection that may be
-                                                projected along with other supported
-                                                volume types
                                               properties:
                                                 configMap:
-                                                  description: configMap information
-                                                    about the configMap data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified,
-                                                        each key-value pair in the
-                                                        Data field of the referenced
-                                                        ConfigMap will be projected
-                                                        into the volume as a file
-                                                        whose name is the key and
-                                                        content is the value. If specified,
-                                                        the listed keys will be projected
-                                                        into the specified paths,
-                                                        and unlisted keys will not
-                                                        be present. If a key is specified
-                                                        which is not present in the
-                                                        ConfigMap, the volume setup
-                                                        will error unless it is marked
-                                                        optional. Paths must be relative
-                                                        and may not contain the '..'
-                                                        path or start with '..'.
                                                       items:
-                                                        description: Maps a string
-                                                          key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is
-                                                              Optional: mode bits
-                                                              used to set permissions
-                                                              on this file. Must be
-                                                              an octal value between
-                                                              0000 and 0777 or a decimal
-                                                              value between 0 and
-                                                              511. YAML accepts both
-                                                              octal and decimal values,
-                                                              JSON requires decimal
-                                                              values for mode bits.
-                                                              If not specified, the
-                                                              volume defaultMode will
-                                                              be used. This might
-                                                              be in conflict with
-                                                              other options that affect
-                                                              the file mode, like
-                                                              fsGroup, and the result
-                                                              can be other mode bits
-                                                              set.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the
-                                                              relative path of the
-                                                              file to map the key
-                                                              to. May not be an absolute
-                                                              path. May not contain
-                                                              the path element '..'.
-                                                              May not start with the
-                                                              string '..'.
                                                             type: string
                                                         required:
                                                         - key
@@ -7683,119 +3075,42 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent.
-                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Add other useful fields.
-                                                        apiVersion, kind, uid?'
                                                       type: string
                                                     optional:
-                                                      description: optional specify
-                                                        whether the ConfigMap or its
-                                                        keys must be defined
                                                       type: boolean
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 downwardAPI:
-                                                  description: downwardAPI information
-                                                    about the downwardAPI data to
-                                                    project
                                                   properties:
                                                     items:
-                                                      description: Items is a list
-                                                        of DownwardAPIVolume file
                                                       items:
-                                                        description: DownwardAPIVolumeFile
-                                                          represents information to
-                                                          create the file containing
-                                                          the pod field
                                                         properties:
                                                           fieldRef:
-                                                            description: 'Required:
-                                                              Selects a field of the
-                                                              pod: only annotations,
-                                                              labels, name and namespace
-                                                              are supported.'
                                                             properties:
                                                               apiVersion:
-                                                                description: Version
-                                                                  of the schema the
-                                                                  FieldPath is written
-                                                                  in terms of, defaults
-                                                                  to "v1".
                                                                 type: string
                                                               fieldPath:
-                                                                description: Path
-                                                                  of the field to
-                                                                  select in the specified
-                                                                  API version.
                                                                 type: string
                                                             required:
                                                             - fieldPath
                                                             type: object
                                                             x-kubernetes-map-type: atomic
                                                           mode:
-                                                            description: 'Optional:
-                                                              mode bits used to set
-                                                              permissions on this
-                                                              file, must be an octal
-                                                              value between 0000 and
-                                                              0777 or a decimal value
-                                                              between 0 and 511. YAML
-                                                              accepts both octal and
-                                                              decimal values, JSON
-                                                              requires decimal values
-                                                              for mode bits. If not
-                                                              specified, the volume
-                                                              defaultMode will be
-                                                              used. This might be
-                                                              in conflict with other
-                                                              options that affect
-                                                              the file mode, like
-                                                              fsGroup, and the result
-                                                              can be other mode bits
-                                                              set.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: 'Required:
-                                                              Path is  the relative
-                                                              path name of the file
-                                                              to be created. Must
-                                                              not be absolute or contain
-                                                              the ''..'' path. Must
-                                                              be utf-8 encoded. The
-                                                              first item of the relative
-                                                              path must not start
-                                                              with ''..'''
                                                             type: string
                                                           resourceFieldRef:
-                                                            description: 'Selects
-                                                              a resource of the container:
-                                                              only resources limits
-                                                              and requests (limits.cpu,
-                                                              limits.memory, requests.cpu
-                                                              and requests.memory)
-                                                              are currently supported.'
                                                             properties:
                                                               containerName:
-                                                                description: 'Container
-                                                                  name: required for
-                                                                  volumes, optional
-                                                                  for env vars'
                                                                 type: string
                                                               divisor:
                                                                 anyOf:
                                                                 - type: integer
                                                                 - type: string
-                                                                description: Specifies
-                                                                  the output format
-                                                                  of the exposed resources,
-                                                                  defaults to "1"
                                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                                 x-kubernetes-int-or-string: true
                                                               resource:
-                                                                description: 'Required:
-                                                                  resource to select'
                                                                 type: string
                                                             required:
                                                             - resource
@@ -7807,67 +3122,16 @@ spec:
                                                       type: array
                                                   type: object
                                                 secret:
-                                                  description: secret information
-                                                    about the secret data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified,
-                                                        each key-value pair in the
-                                                        Data field of the referenced
-                                                        Secret will be projected into
-                                                        the volume as a file whose
-                                                        name is the key and content
-                                                        is the value. If specified,
-                                                        the listed keys will be projected
-                                                        into the specified paths,
-                                                        and unlisted keys will not
-                                                        be present. If a key is specified
-                                                        which is not present in the
-                                                        Secret, the volume setup will
-                                                        error unless it is marked
-                                                        optional. Paths must be relative
-                                                        and may not contain the '..'
-                                                        path or start with '..'.
                                                       items:
-                                                        description: Maps a string
-                                                          key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is
-                                                              Optional: mode bits
-                                                              used to set permissions
-                                                              on this file. Must be
-                                                              an octal value between
-                                                              0000 and 0777 or a decimal
-                                                              value between 0 and
-                                                              511. YAML accepts both
-                                                              octal and decimal values,
-                                                              JSON requires decimal
-                                                              values for mode bits.
-                                                              If not specified, the
-                                                              volume defaultMode will
-                                                              be used. This might
-                                                              be in conflict with
-                                                              other options that affect
-                                                              the file mode, like
-                                                              fsGroup, and the result
-                                                              can be other mode bits
-                                                              set.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the
-                                                              relative path of the
-                                                              file to map the key
-                                                              to. May not be an absolute
-                                                              path. May not contain
-                                                              the path element '..'.
-                                                              May not start with the
-                                                              string '..'.
                                                             type: string
                                                         required:
                                                         - key
@@ -7875,57 +3139,19 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent.
-                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Add other useful fields.
-                                                        apiVersion, kind, uid?'
                                                       type: string
                                                     optional:
-                                                      description: optional field
-                                                        specify whether the Secret
-                                                        or its key must be defined
                                                       type: boolean
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 serviceAccountToken:
-                                                  description: serviceAccountToken
-                                                    is information about the serviceAccountToken
-                                                    data to project
                                                   properties:
                                                     audience:
-                                                      description: audience is the
-                                                        intended audience of the token.
-                                                        A recipient of a token must
-                                                        identify itself with an identifier
-                                                        specified in the audience
-                                                        of the token, and otherwise
-                                                        should reject the token. The
-                                                        audience defaults to the identifier
-                                                        of the apiserver.
                                                       type: string
                                                     expirationSeconds:
-                                                      description: expirationSeconds
-                                                        is the requested duration
-                                                        of validity of the service
-                                                        account token. As the token
-                                                        approaches expiration, the
-                                                        kubelet volume plugin will
-                                                        proactively rotate the service
-                                                        account token. The kubelet
-                                                        will start trying to rotate
-                                                        the token if the token is
-                                                        older than 80 percent of its
-                                                        time to live or if the token
-                                                        is older than 24 hours.Defaults
-                                                        to 1 hour and must be at least
-                                                        10 minutes.
                                                       format: int64
                                                       type: integer
                                                     path:
-                                                      description: path is the path
-                                                        relative to the mount point
-                                                        of the file to project the
-                                                        token into.
                                                       type: string
                                                   required:
                                                   - path
@@ -7934,171 +3160,76 @@ spec:
                                             type: array
                                         type: object
                                       quobyte:
-                                        description: quobyte represents a Quobyte
-                                          mount on the host that shares a pod's lifetime
                                         properties:
                                           group:
-                                            description: group to map volume access
-                                              to Default is no group
                                             type: string
                                           readOnly:
-                                            description: readOnly here will force
-                                              the Quobyte volume to be mounted with
-                                              read-only permissions. Defaults to false.
                                             type: boolean
                                           registry:
-                                            description: registry represents a single
-                                              or multiple Quobyte Registry services
-                                              specified as a string as host:port pair
-                                              (multiple entries are separated with
-                                              commas) which acts as the central registry
-                                              for volumes
                                             type: string
                                           tenant:
-                                            description: tenant owning the given Quobyte
-                                              volume in the Backend Used with dynamically
-                                              provisioned Quobyte volumes, value is
-                                              set by the plugin
                                             type: string
                                           user:
-                                            description: user to map volume access
-                                              to Defaults to serivceaccount user
                                             type: string
                                           volume:
-                                            description: volume is a string that references
-                                              an already created Quobyte volume by
-                                              name.
                                             type: string
                                         required:
                                         - registry
                                         - volume
                                         type: object
                                       rbd:
-                                        description: 'rbd represents a Rados Block
-                                          Device mount on the host that shares a pod''s
-                                          lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                         properties:
                                           fsType:
-                                            description: 'fsType is the filesystem
-                                              type of the volume that you want to
-                                              mount. Tip: Ensure that the filesystem
-                                              type is supported by the host operating
-                                              system. Examples: "ext4", "xfs", "ntfs".
-                                              Implicitly inferred to be "ext4" if
-                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                              TODO: how do we prevent errors in the
-                                              filesystem from compromising the machine'
                                             type: string
                                           image:
-                                            description: 'image is the rados image
-                                              name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                           keyring:
-                                            description: 'keyring is the path to key
-                                              ring for RBDUser. Default is /etc/ceph/keyring.
-                                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                           monitors:
-                                            description: 'monitors is a collection
-                                              of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             items:
                                               type: string
                                             type: array
                                           pool:
-                                            description: 'pool is the rados pool name.
-                                              Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                           readOnly:
-                                            description: 'readOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
-                                              Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: boolean
                                           secretRef:
-                                            description: 'secretRef is name of the
-                                              authentication secret for RBDUser. If
-                                              provided overrides keyring. Default
-                                              is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           user:
-                                            description: 'user is the rados user name.
-                                              Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                         required:
                                         - image
                                         - monitors
                                         type: object
                                       scaleIO:
-                                        description: scaleIO represents a ScaleIO
-                                          persistent volume attached and mounted on
-                                          Kubernetes nodes.
                                         properties:
                                           fsType:
-                                            description: fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". Default
-                                              is "xfs".
                                             type: string
                                           gateway:
-                                            description: gateway is the host address
-                                              of the ScaleIO API Gateway.
                                             type: string
                                           protectionDomain:
-                                            description: protectionDomain is the name
-                                              of the ScaleIO Protection Domain for
-                                              the configured storage.
                                             type: string
                                           readOnly:
-                                            description: readOnly Defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           secretRef:
-                                            description: secretRef references to the
-                                              secret for ScaleIO user and other sensitive
-                                              information. If this is not provided,
-                                              Login operation will fail.
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           sslEnabled:
-                                            description: sslEnabled Flag enable/disable
-                                              SSL communication with Gateway, default
-                                              false
                                             type: boolean
                                           storageMode:
-                                            description: storageMode indicates whether
-                                              the storage for a volume should be ThickProvisioned
-                                              or ThinProvisioned. Default is ThinProvisioned.
                                             type: string
                                           storagePool:
-                                            description: storagePool is the ScaleIO
-                                              Storage Pool associated with the protection
-                                              domain.
                                             type: string
                                           system:
-                                            description: system is the name of the
-                                              storage system as configured in ScaleIO.
                                             type: string
                                           volumeName:
-                                            description: volumeName is the name of
-                                              a volume already created in the ScaleIO
-                                              system that is associated with this
-                                              volume source.
                                             type: string
                                         required:
                                         - gateway
@@ -8106,71 +3237,19 @@ spec:
                                         - system
                                         type: object
                                       secret:
-                                        description: 'secret represents a secret that
-                                          should populate this volume. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is Optional:
-                                              mode bits used to set permissions on
-                                              created files by default. Must be an
-                                              octal value between 0000 and 0777 or
-                                              a decimal value between 0 and 511. YAML
-                                              accepts both octal and decimal values,
-                                              JSON requires decimal values for mode
-                                              bits. Defaults to 0644. Directories
-                                              within the path are not affected by
-                                              this setting. This might be in conflict
-                                              with other options that affect the file
-                                              mode, like fsGroup, and the result can
-                                              be other mode bits set.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items If unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced Secret will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the Secret, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8178,90 +3257,36 @@ spec:
                                               type: object
                                             type: array
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its keys must be defined
                                             type: boolean
                                           secretName:
-                                            description: 'secretName is the name of
-                                              the secret in the pod''s namespace to
-                                              use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                             type: string
                                         type: object
                                       storageos:
-                                        description: storageOS represents a StorageOS
-                                          volume attached and mounted on Kubernetes
-                                          nodes.
                                         properties:
                                           fsType:
-                                            description: fsType is the filesystem
-                                              type to mount. Must be a filesystem
-                                              type supported by the host operating
-                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           readOnly:
-                                            description: readOnly defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           secretRef:
-                                            description: secretRef specifies the secret
-                                              to use for obtaining the StorageOS API
-                                              credentials.  If not specified, default
-                                              values will be attempted.
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           volumeName:
-                                            description: volumeName is the human-readable
-                                              name of the StorageOS volume.  Volume
-                                              names are only unique within a namespace.
                                             type: string
                                           volumeNamespace:
-                                            description: volumeNamespace specifies
-                                              the scope of the volume within StorageOS.  If
-                                              no namespace is specified then the Pod's
-                                              namespace will be used.  This allows
-                                              the Kubernetes name scoping to be mirrored
-                                              within StorageOS for tighter integration.
-                                              Set VolumeName to any name to override
-                                              the default behaviour. Set to "default"
-                                              if you are not using namespaces within
-                                              StorageOS. Namespaces that do not pre-exist
-                                              within StorageOS will be created.
                                             type: string
                                         type: object
                                       vsphereVolume:
-                                        description: vsphereVolume represents a vSphere
-                                          volume attached and mounted on kubelets
-                                          host machine
                                         properties:
                                           fsType:
-                                            description: fsType is filesystem type
-                                              to mount. Must be a filesystem type
-                                              supported by the host operating system.
-                                              Ex. "ext4", "xfs", "ntfs". Implicitly
-                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           storagePolicyID:
-                                            description: storagePolicyID is the storage
-                                              Policy Based Management (SPBM) profile
-                                              ID associated with the StoragePolicyName.
                                             type: string
                                           storagePolicyName:
-                                            description: storagePolicyName is the
-                                              storage Policy Based Management (SPBM)
-                                              profile name.
                                             type: string
                                           volumePath:
-                                            description: volumePath is the path that
-                                              identifies vSphere volume vmdk
                                             type: string
                                         required:
                                         - volumePath
@@ -8284,60 +3309,36 @@ spec:
                         type: object
                       type: array
                     networkAttachments:
-                      description: NetworkAttachments is a list of NetworkAttachment
-                        resource names to expose the services to the given network
                       items:
                         type: string
                       type: array
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: NodeSelector to target subset of worker nodes running
-                        this service. Setting here overrides any global NodeSelector
-                        settings within the Manila CR.
                       type: object
                     passwordSelectors:
                       default:
                         database: ManilaDatabasePassword
                         service: ManilaPassword
-                      description: PasswordSelectors - Selectors to identify the DB
-                        and ServiceUser password from the Secret
                       properties:
                         database:
                           default: ManilaDatabasePassword
-                          description: 'Database - Selector to get the manila database
-                            user password from the Secret TODO: not used, need change
-                            in mariadb-operator'
                           type: string
                         service:
                           default: ManilaPassword
-                          description: Service - Selector to get the manila service
-                            password from the Secret
                           type: string
                       type: object
                     replicas:
                       default: 1
-                      description: Replicas - manila Volume Replicas
                       format: int32
                       maximum: 1
                       type: integer
                     resources:
-                      description: Resources - Compute Resources required by this
-                        service (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable."
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry
-                                  in pod.spec.resourceClaims of the Pod where this
-                                  field is used. It makes that resource available
-                                  inside a container.
                                 type: string
                             required:
                             - name
@@ -8353,8 +3354,6 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -8363,72 +3362,43 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     secret:
-                      description: Secret containing OpenStack password information
-                        for manilaDatabasePassword
                       type: string
                     serviceUser:
                       default: manila
-                      description: ServiceUser - optional username used for this service
-                        to register in manila
                       type: string
                     transportURLSecret:
-                      description: Secret containing RabbitMq transport URL
                       type: string
                   type: object
-                description: ManilaShares - Map of chosen names to spec definitions
-                  for the Share(s) service(s) of this Manila deployment
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes running
-                  this service. Setting NodeSelector here acts as a default value
-                  and can be overridden by service specific NodeSelector Settings.
                 type: object
               passwordSelectors:
                 default:
                   database: ManilaDatabasePassword
                   service: ManilaPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: ManilaDatabasePassword
-                    description: 'Database - Selector to get the manila database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: ManilaPassword
-                    description: Service - Selector to get the manila service password
-                      from the Secret
                     type: string
                 type: object
               preserveJobs:
                 default: false
-                description: PreserveJobs - do not delete jobs after they finished
-                  e.g. to check logs
                 type: boolean
               rabbitMqClusterName:
                 default: rabbitmq
-                description: RabbitMQ instance name Needed to request a transportURL
-                  that is created and used in Manila
                 type: string
               secret:
-                description: Secret containing OpenStack password information for
-                  ManilaDatabasePassword, ManilaPassword
                 type: string
               serviceUser:
                 default: manila
-                description: ServiceUser - optional username used for this service
-                  to register in manila
                 type: string
             required:
             - manilaAPI
@@ -8436,51 +3406,28 @@ spec:
             - rabbitMqClusterName
             type: object
           status:
-            description: ManilaStatus defines the observed state of Manila
             properties:
               apiEndpoints:
                 additionalProperties:
                   additionalProperties:
                     type: string
                   type: object
-                description: API endpoints
                 type: object
               conditions:
-                description: Conditions
                 items:
-                  description: Condition defines an observation of a API resource
-                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase.
                       type: string
                     severity:
-                      description: Severity provides a classification of Reason code,
-                        so the current situation is immediately understandable and
-                        could act accordingly. It is meant for situations where Status=False
-                        and it should be indicated if it is just informational, warning
-                        (next reconciliation might fix it) or an error (e.g. DB create
-                        issue and no actions to automatically resolve the issue can/should
-                        be done). For conditions where Status=Unknown or Status=True
-                        the Severity should be SeverityNone.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase.
                       type: string
                   required:
                   - lastTransitionTime
@@ -8489,34 +3436,27 @@ spec:
                   type: object
                 type: array
               databaseHostname:
-                description: Manila Database Hostname
                 type: string
               hash:
                 additionalProperties:
                   type: string
-                description: Map of hashes to track e.g. job status
                 type: object
               manilaAPIReadyCount:
-                description: ReadyCount of Manila API instance
                 format: int32
                 type: integer
               manilaSchedulerReadyCount:
-                description: ReadyCount of Manila Scheduler instance
                 format: int32
                 type: integer
               manilaSharesReadyCounts:
                 additionalProperties:
                   format: int32
                   type: integer
-                description: ReadyCounts of Manila Share instances
                 type: object
               serviceIDs:
                 additionalProperties:
                   type: string
-                description: ServiceIDs
                 type: object
               transportURLSecret:
-                description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string
             type: object
         type: object

--- a/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
@@ -31,118 +31,60 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ManilaScheduler is the Schema for the manilaschedulers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ManilaSchedulerSpec defines the desired state of ManilaScheduler
             properties:
               containerImage:
-                description: ContainerImage - manila Scheduler Container Image URL
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
-                description: CustomServiceConfig - customize the service config using
-                  this parameter to change service defaults, or overwrite rendered
-                  information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
                 type: string
               databaseHostname:
-                description: DatabaseHostname - manila Database Hostname
                 type: string
               databaseUser:
                 default: manila
-                description: 'DatabaseUser - optional username used for manila DB,
-                  defaults to manila TODO: -> implement needs work in mariadb-operator,
-                  right now only manila'
                 type: string
               debug:
-                description: Debug - enable debug for different deploy stages. If
-                  an init container is used, it runs and the actual action pod gets
-                  started with sleep infinity
                 properties:
                   initContainer:
                     default: false
-                    description: initContainer enable debug (waits until /tmp/stop-init-container
-                      disappears)
                     type: boolean
                   service:
                     default: false
-                    description: service enable debug
                     type: boolean
                 type: object
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  .
                 type: object
               extraMounts:
-                description: ExtraMounts containing conf files and credentials
                 items:
-                  description: ManilaExtraVolMounts exposes additional parameters
-                    processed by the manila-operator and defines the common VolMounts
-                    structure provided by the main storage module
                   properties:
                     extraVol:
                       items:
-                        description: VolMounts is the data structure used to expose
-                          Volumes and Mounts that can be added to a pod according
-                          to the defined Propagation policy
                         properties:
                           extraVolType:
-                            description: Label associated to a given extraMount
                             type: string
                           mounts:
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -150,262 +92,110 @@ spec:
                               type: object
                             type: array
                           propagation:
-                            description: Propagation defines which pod should mount
-                              the volume
                             items:
-                              description: PropagationType identifies the Service,
-                                Group or instance (e.g. the backend) that receives
-                                an Extra Volume that can potentially be mounted
                               type: string
                             type: array
                           volumes:
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'awsElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly value true will force
-                                        the readOnly setting in VolumeMounts. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: boolean
                                     volumeID:
-                                      description: 'volumeID is unique ID of the persistent
-                                        disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'monitors is Required: Monitors
-                                        is a collection of Ceph monitors More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: boolean
                                     secretFile:
-                                      description: 'secretFile is Optional: SecretFile
-                                        is the path to key ring for User, default
-                                        is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                     secretRef:
-                                      description: 'secretRef is Optional: SecretRef
-                                        is reference to the authentication secret
-                                        for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is optional: User is the
-                                        rados user name, default is admin More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is optional: points
-                                        to a secret object containing parameters used
-                                        to connect to OpenStack.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: 'volumeID used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -413,159 +203,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
                                       type: string
                                     fsType:
-                                      description: fsType to mount. Ex. "ext4", "xfs",
-                                        "ntfs". If not provided, the empty value is
-                                        passed to the associated CSI driver which
-                                        will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: nodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: readOnly specifies a read-only
-                                        configuration for the volume. Defaults to
-                                        false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: volumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -577,136 +274,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of
-                                        storage medium should back this directory.
-                                        The default is "" which means to use the node''s
-                                        default medium. Must be an empty string (default)
-                                        or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'sizeLimit is the total amount
-                                        of local storage required for this EmptyDir
-                                        volume. The size limit is also applicable
-                                        for memory medium. The maximum usage on memory
-                                        medium EmptyDir would be the minimum value
-                                        between the SizeLimit specified here and the
-                                        sum of memory limits of all containers in
-                                        a pod. The default is nil which means that
-                                        the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "ephemeral represents a volume that
-                                    is handled by a cluster storage driver. The volume's
-                                    lifecycle is tied to the pod that defines it -
-                                    it will be created before the pod starts, and
-                                    deleted when the pod is removed. \n Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from
-                                    snapshot or capacity tracking are needed, c) the
-                                    storage driver is specified through a storage
-                                    class, and d) the storage driver supports dynamic
-                                    volume provisioning through a PersistentVolumeClaim
-                                    (see EphemeralVolumeSource for more information
-                                    on the connection between this volume type and
-                                    PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                    or one of the vendor-specific APIs for volumes
-                                    that persist for longer than the lifecycle of
-                                    an individual pod. \n Use CSI for light-weight
-                                    local ephemeral volumes if the CSI driver is meant
-                                    to be used that way - see the documentation of
-                                    the driver for more information. \n A pod can
-                                    use both types of ephemeral volumes and persistent
-                                    volumes at the same time."
                                   properties:
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations
-                                            that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
                                           type: object
                                         spec:
-                                          description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: 'accessModes contains the
-                                                desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'dataSource field can be
-                                                used to specify either: * An existing
-                                                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external
-                                                controller can support the specified
-                                                data source, it will create a new
-                                                volume based on the contents of the
-                                                specified data source. When the AnyVolumeDataSource
-                                                feature gate is enabled, dataSource
-                                                contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be
-                                                copied to dataSource when dataSourceRef.namespace
-                                                is not specified. If the namespace
-                                                is specified, then dataSourceRef will
-                                                not be copied to dataSource.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -714,113 +310,25 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: 'dataSourceRef specifies
-                                                the object from which to populate
-                                                the volume with data, if a non-empty
-                                                volume is desired. This may be any
-                                                object from a non-empty API group
-                                                (non core object) or a PersistentVolumeClaim
-                                                object. When this field is specified,
-                                                volume binding will only succeed if
-                                                the type of the specified object matches
-                                                some installed volume populator or
-                                                dynamic provisioner. This field will
-                                                replace the functionality of the dataSource
-                                                field and as such if both fields are
-                                                non-empty, they must have the same
-                                                value. For backwards compatibility,
-                                                when namespace isn''t specified in
-                                                dataSourceRef, both fields (dataSource
-                                                and dataSourceRef) will be set to
-                                                the same value automatically if one
-                                                of them is empty and the other is
-                                                non-empty. When namespace is specified
-                                                in dataSourceRef, dataSource isn''t
-                                                set to the same value and must be
-                                                empty. There are three important differences
-                                                between dataSource and dataSourceRef:
-                                                * While dataSource only allows two
-                                                specific types of objects, dataSourceRef
-                                                allows any non-core object, as well
-                                                as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed
-                                                values (dropping them), dataSourceRef
-                                                preserves all values, and generates
-                                                an error if a disallowed value is
-                                                specified. * While dataSource only
-                                                allows local objects, dataSourceRef
-                                                allows objects in any namespaces.
-                                                (Beta) Using this field requires the
-                                                AnyVolumeDataSource feature gate to
-                                                be enabled. (Alpha) Using the namespace
-                                                field of dataSourceRef requires the
-                                                CrossNamespaceVolumeDataSource feature
-                                                gate to be enabled.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: Namespace is the namespace
-                                                    of resource being referenced Note
-                                                    that when a namespace is specified,
-                                                    a gateway.networking.k8s.io/ReferenceGrant
-                                                    object is required in the referent
-                                                    namespace to allow that namespace's
-                                                    owner to accept the reference.
-                                                    See the ReferenceGrant documentation
-                                                    for details. (Alpha) This field
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'resources represents the
-                                                minimum resources the volume should
-                                                have. If RecoverVolumeExpansionFailure
-                                                feature is enabled users are allowed
-                                                to specify resource requirements that
-                                                are lower than previous value but
-                                                must still be higher than capacity
-                                                recorded in the status field of the
-                                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                               properties:
                                                 claims:
-                                                  description: "Claims lists the names
-                                                    of resources, defined in spec.resourceClaims,
-                                                    that are used by this container.
-                                                    \n This is an alpha field and
-                                                    requires enabling the DynamicResourceAllocation
-                                                    feature gate. \n This field is
-                                                    immutable."
                                                   items:
-                                                    description: ResourceClaim references
-                                                      one entry in PodSpec.ResourceClaims.
                                                     properties:
                                                       name:
-                                                        description: Name must match
-                                                          the name of one entry in
-                                                          pod.spec.resourceClaims
-                                                          of the Pod where this field
-                                                          is used. It makes that resource
-                                                          available inside a container.
                                                         type: string
                                                     required:
                                                     - name
@@ -836,9 +344,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the
-                                                    maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -847,54 +352,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
-                                                    the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -906,33 +375,14 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: 'storageClassName is the
-                                                name of the StorageClass required
-                                                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what
-                                                type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -940,84 +390,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. TODO: how do we prevent errors
-                                        in the filesystem from compromising the machine'
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'wwids Optional: FC volume world
-                                        wide identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: flexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". The default filesystem depends
-                                        on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: 'readOnly is Optional: defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is Optional: secretRef
-                                        is reference to the secret object containing
-                                        sensitive information to pass to the plugin
-                                        scripts. This may be empty if no secret object
-                                        is specified. If the secret object contains
-                                        more than one secret, all secrets are passed
-                                        to the plugin scripts.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -1025,205 +429,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: datasetName is Name of the dataset
-                                        stored as metadata -> name on the dataset
-                                        for Flocker should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'gcePersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   properties:
                                     fsType:
-                                      description: 'fsType is filesystem type of the
-                                        volume that you want to mount. Tip: Ensure
-                                        that the filesystem type is supported by the
-                                        host operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'pdName is unique name of the PD
-                                        resource in GCE. Used to identify the disk
-                                        in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'gitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
                                   properties:
                                     directory:
-                                      description: directory is the target directory
-                                        name. Must not contain or start with '..'.  If
-                                        '.' is supplied, the volume directory will
-                                        be the git repository.  Otherwise, if specified,
-                                        the volume will contain the git repository
-                                        in the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                   properties:
                                     endpoints:
-                                      description: 'endpoints is the endpoint name
-                                        that details Glusterfs topology. More info:
-                                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     path:
-                                      description: 'path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'iscsi represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     initiatorName:
-                                      description: initiatorName is the custom iSCSI
-                                        Initiator Name. If initiatorName is specified
-                                        with iscsiInterface simultaneously, new iSCSI
-                                        interface <target portal>:<volume name> will
-                                        be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iscsiInterface is the interface
-                                        Name that uses an iSCSI transport. Defaults
-                                        to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: portals is the iSCSI Target Portal
-                                        List. The portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: targetPortal is iSCSI Target Portal.
-                                        The Portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -1231,166 +518,67 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'name of the volume. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 nfs:
-                                  description: 'nfs represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   properties:
                                     path:
-                                      description: 'path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: boolean
                                     server:
-                                      description: 'server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly
-                                        setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used
-                                        to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777
-                                        or a decimal value between 0 and 511. YAML
-                                        accepts both octal and decimal values, JSON
-                                        requires decimal values for mode bits. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced ConfigMap
-                                                  will be projected into the volume
-                                                  as a file whose name is the key
-                                                  and content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1398,105 +586,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode
-                                                        bits used to set permissions
-                                                        on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -1508,58 +633,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced Secret will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1567,52 +650,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
                                                 type: string
                                             required:
                                             - path
@@ -1621,162 +671,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: group to map volume access to Default
-                                        is no group
                                       type: string
                                     readOnly:
-                                      description: readOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
                                       type: string
                                     tenant:
-                                      description: tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
                                       type: string
                                     user:
-                                      description: user to map volume access to Defaults
-                                        to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'rbd represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     image:
-                                      description: 'image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: 'keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     monitors:
-                                      description: 'monitors is a collection of Ceph
-                                        monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'pool is the rados pool name. Default
-                                        is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is the rados user name. Default
-                                        is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: storageMode indicates whether the
-                                        storage for a volume should be ThickProvisioned
-                                        or ThinProvisioned. Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the name of a volume
-                                        already created in the ScaleIO system that
-                                        is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -1784,63 +748,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -1848,85 +768,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the
-                                        secret in the pod''s namespace to use. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: volumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: volumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -1949,57 +820,35 @@ spec:
                   type: object
                 type: array
               networkAttachments:
-                description: NetworkAttachments is a list of NetworkAttachment resource
-                  names to expose the services to the given network
                 items:
                   type: string
                 type: array
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes running
-                  this service. Setting here overrides any global NodeSelector settings
-                  within the Manila CR.
                 type: object
               passwordSelectors:
                 default:
                   database: ManilaDatabasePassword
                   service: ManilaPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: ManilaDatabasePassword
-                    description: 'Database - Selector to get the manila database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: ManilaPassword
-                    description: Service - Selector to get the manila service password
-                      from the Secret
                     type: string
                 type: object
               replicas:
                 default: 1
-                description: Replicas - manila Scheduler Replicas
                 format: int32
                 type: integer
               resources:
-                description: Resources - Compute Resources required by this service
-                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                 properties:
                   claims:
-                    description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable."
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: Name must match the name of one entry in pod.spec.resourceClaims
-                            of the Pod where this field is used. It makes that resource
-                            available inside a container.
                           type: string
                       required:
                       - name
@@ -2015,8 +864,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -2025,64 +872,33 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               secret:
-                description: Secret containing OpenStack password information for
-                  manilaDatabasePassword
                 type: string
               serviceUser:
                 default: manila
-                description: ServiceUser - optional username used for this service
-                  to register in manila
                 type: string
               transportURLSecret:
-                description: Secret containing RabbitMq transport URL
                 type: string
             type: object
           status:
-            description: ManilaSchedulerStatus defines the observed state of ManilaScheduler
             properties:
               conditions:
-                description: Conditions
                 items:
-                  description: Condition defines an observation of a API resource
-                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase.
                       type: string
                     severity:
-                      description: Severity provides a classification of Reason code,
-                        so the current situation is immediately understandable and
-                        could act accordingly. It is meant for situations where Status=False
-                        and it should be indicated if it is just informational, warning
-                        (next reconciliation might fix it) or an error (e.g. DB create
-                        issue and no actions to automatically resolve the issue can/should
-                        be done). For conditions where Status=Unknown or Status=True
-                        the Severity should be SeverityNone.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase.
                       type: string
                   required:
                   - lastTransitionTime
@@ -2093,17 +909,14 @@ spec:
               hash:
                 additionalProperties:
                   type: string
-                description: Map of hashes to track e.g. job status
                 type: object
               networkAttachments:
                 additionalProperties:
                   items:
                     type: string
                   type: array
-                description: NetworkAttachments status of the deployment pods
                 type: object
               readyCount:
-                description: ReadyCount of Manila Scheduler instances
                 format: int32
                 type: integer
             type: object

--- a/config/crd/bases/manila.openstack.org_manilashares.yaml
+++ b/config/crd/bases/manila.openstack.org_manilashares.yaml
@@ -31,118 +31,60 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ManilaShare is the Schema for the manilashares API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ManilaShareSpec defines the desired state of ManilaShare
             properties:
               containerImage:
-                description: ContainerImage - manila Volume Container Image URL
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
-                description: CustomServiceConfig - customize the service config using
-                  this parameter to change service defaults, or overwrite rendered
-                  information using raw OpenStack config format. The content gets
-                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
-                  file.
                 type: string
               databaseHostname:
-                description: DatabaseHostname - manila Database Hostname
                 type: string
               databaseUser:
                 default: manila
-                description: 'DatabaseUser - optional username used for manila DB,
-                  defaults to manila TODO: -> implement needs work in mariadb-operator,
-                  right now only manila'
                 type: string
               debug:
-                description: Debug - enable debug for different deploy stages. If
-                  an init container is used, it runs and the actual action pod gets
-                  started with sleep infinity
                 properties:
                   initContainer:
                     default: false
-                    description: initContainer enable debug (waits until /tmp/stop-init-container
-                      disappears)
                     type: boolean
                   service:
                     default: false
-                    description: service enable debug
                     type: boolean
                 type: object
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  .
                 type: object
               extraMounts:
-                description: ExtraMounts containing conf files and credentials
                 items:
-                  description: ManilaExtraVolMounts exposes additional parameters
-                    processed by the manila-operator and defines the common VolMounts
-                    structure provided by the main storage module
                   properties:
                     extraVol:
                       items:
-                        description: VolMounts is the data structure used to expose
-                          Volumes and Mounts that can be added to a pod according
-                          to the defined Propagation policy
                         properties:
                           extraVolType:
-                            description: Label associated to a given extraMount
                             type: string
                           mounts:
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -150,262 +92,110 @@ spec:
                               type: object
                             type: array
                           propagation:
-                            description: Propagation defines which pod should mount
-                              the volume
                             items:
-                              description: PropagationType identifies the Service,
-                                Group or instance (e.g. the backend) that receives
-                                an Extra Volume that can potentially be mounted
                               type: string
                             type: array
                           volumes:
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'awsElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly value true will force
-                                        the readOnly setting in VolumeMounts. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: boolean
                                     volumeID:
-                                      description: 'volumeID is unique ID of the persistent
-                                        disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'monitors is Required: Monitors
-                                        is a collection of Ceph monitors More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: boolean
                                     secretFile:
-                                      description: 'secretFile is Optional: SecretFile
-                                        is the path to key ring for User, default
-                                        is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                     secretRef:
-                                      description: 'secretRef is Optional: SecretRef
-                                        is reference to the authentication secret
-                                        for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is optional: User is the
-                                        rados user name, default is admin More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is optional: points
-                                        to a secret object containing parameters used
-                                        to connect to OpenStack.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: 'volumeID used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -413,159 +203,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
                                       type: string
                                     fsType:
-                                      description: fsType to mount. Ex. "ext4", "xfs",
-                                        "ntfs". If not provided, the empty value is
-                                        passed to the associated CSI driver which
-                                        will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: nodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: readOnly specifies a read-only
-                                        configuration for the volume. Defaults to
-                                        false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: volumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -577,136 +274,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of
-                                        storage medium should back this directory.
-                                        The default is "" which means to use the node''s
-                                        default medium. Must be an empty string (default)
-                                        or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'sizeLimit is the total amount
-                                        of local storage required for this EmptyDir
-                                        volume. The size limit is also applicable
-                                        for memory medium. The maximum usage on memory
-                                        medium EmptyDir would be the minimum value
-                                        between the SizeLimit specified here and the
-                                        sum of memory limits of all containers in
-                                        a pod. The default is nil which means that
-                                        the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "ephemeral represents a volume that
-                                    is handled by a cluster storage driver. The volume's
-                                    lifecycle is tied to the pod that defines it -
-                                    it will be created before the pod starts, and
-                                    deleted when the pod is removed. \n Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from
-                                    snapshot or capacity tracking are needed, c) the
-                                    storage driver is specified through a storage
-                                    class, and d) the storage driver supports dynamic
-                                    volume provisioning through a PersistentVolumeClaim
-                                    (see EphemeralVolumeSource for more information
-                                    on the connection between this volume type and
-                                    PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                    or one of the vendor-specific APIs for volumes
-                                    that persist for longer than the lifecycle of
-                                    an individual pod. \n Use CSI for light-weight
-                                    local ephemeral volumes if the CSI driver is meant
-                                    to be used that way - see the documentation of
-                                    the driver for more information. \n A pod can
-                                    use both types of ephemeral volumes and persistent
-                                    volumes at the same time."
                                   properties:
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations
-                                            that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
                                           type: object
                                         spec:
-                                          description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: 'accessModes contains the
-                                                desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'dataSource field can be
-                                                used to specify either: * An existing
-                                                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external
-                                                controller can support the specified
-                                                data source, it will create a new
-                                                volume based on the contents of the
-                                                specified data source. When the AnyVolumeDataSource
-                                                feature gate is enabled, dataSource
-                                                contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be
-                                                copied to dataSource when dataSourceRef.namespace
-                                                is not specified. If the namespace
-                                                is specified, then dataSourceRef will
-                                                not be copied to dataSource.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -714,113 +310,25 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: 'dataSourceRef specifies
-                                                the object from which to populate
-                                                the volume with data, if a non-empty
-                                                volume is desired. This may be any
-                                                object from a non-empty API group
-                                                (non core object) or a PersistentVolumeClaim
-                                                object. When this field is specified,
-                                                volume binding will only succeed if
-                                                the type of the specified object matches
-                                                some installed volume populator or
-                                                dynamic provisioner. This field will
-                                                replace the functionality of the dataSource
-                                                field and as such if both fields are
-                                                non-empty, they must have the same
-                                                value. For backwards compatibility,
-                                                when namespace isn''t specified in
-                                                dataSourceRef, both fields (dataSource
-                                                and dataSourceRef) will be set to
-                                                the same value automatically if one
-                                                of them is empty and the other is
-                                                non-empty. When namespace is specified
-                                                in dataSourceRef, dataSource isn''t
-                                                set to the same value and must be
-                                                empty. There are three important differences
-                                                between dataSource and dataSourceRef:
-                                                * While dataSource only allows two
-                                                specific types of objects, dataSourceRef
-                                                allows any non-core object, as well
-                                                as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed
-                                                values (dropping them), dataSourceRef
-                                                preserves all values, and generates
-                                                an error if a disallowed value is
-                                                specified. * While dataSource only
-                                                allows local objects, dataSourceRef
-                                                allows objects in any namespaces.
-                                                (Beta) Using this field requires the
-                                                AnyVolumeDataSource feature gate to
-                                                be enabled. (Alpha) Using the namespace
-                                                field of dataSourceRef requires the
-                                                CrossNamespaceVolumeDataSource feature
-                                                gate to be enabled.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: Namespace is the namespace
-                                                    of resource being referenced Note
-                                                    that when a namespace is specified,
-                                                    a gateway.networking.k8s.io/ReferenceGrant
-                                                    object is required in the referent
-                                                    namespace to allow that namespace's
-                                                    owner to accept the reference.
-                                                    See the ReferenceGrant documentation
-                                                    for details. (Alpha) This field
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'resources represents the
-                                                minimum resources the volume should
-                                                have. If RecoverVolumeExpansionFailure
-                                                feature is enabled users are allowed
-                                                to specify resource requirements that
-                                                are lower than previous value but
-                                                must still be higher than capacity
-                                                recorded in the status field of the
-                                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                               properties:
                                                 claims:
-                                                  description: "Claims lists the names
-                                                    of resources, defined in spec.resourceClaims,
-                                                    that are used by this container.
-                                                    \n This is an alpha field and
-                                                    requires enabling the DynamicResourceAllocation
-                                                    feature gate. \n This field is
-                                                    immutable."
                                                   items:
-                                                    description: ResourceClaim references
-                                                      one entry in PodSpec.ResourceClaims.
                                                     properties:
                                                       name:
-                                                        description: Name must match
-                                                          the name of one entry in
-                                                          pod.spec.resourceClaims
-                                                          of the Pod where this field
-                                                          is used. It makes that resource
-                                                          available inside a container.
                                                         type: string
                                                     required:
                                                     - name
@@ -836,9 +344,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the
-                                                    maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -847,54 +352,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
-                                                    the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -906,33 +375,14 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: 'storageClassName is the
-                                                name of the StorageClass required
-                                                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what
-                                                type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -940,84 +390,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. TODO: how do we prevent errors
-                                        in the filesystem from compromising the machine'
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'wwids Optional: FC volume world
-                                        wide identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: flexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". The default filesystem depends
-                                        on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: 'readOnly is Optional: defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is Optional: secretRef
-                                        is reference to the secret object containing
-                                        sensitive information to pass to the plugin
-                                        scripts. This may be empty if no secret object
-                                        is specified. If the secret object contains
-                                        more than one secret, all secrets are passed
-                                        to the plugin scripts.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -1025,205 +429,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: datasetName is Name of the dataset
-                                        stored as metadata -> name on the dataset
-                                        for Flocker should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'gcePersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   properties:
                                     fsType:
-                                      description: 'fsType is filesystem type of the
-                                        volume that you want to mount. Tip: Ensure
-                                        that the filesystem type is supported by the
-                                        host operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'pdName is unique name of the PD
-                                        resource in GCE. Used to identify the disk
-                                        in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'gitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
                                   properties:
                                     directory:
-                                      description: directory is the target directory
-                                        name. Must not contain or start with '..'.  If
-                                        '.' is supplied, the volume directory will
-                                        be the git repository.  Otherwise, if specified,
-                                        the volume will contain the git repository
-                                        in the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                   properties:
                                     endpoints:
-                                      description: 'endpoints is the endpoint name
-                                        that details Glusterfs topology. More info:
-                                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     path:
-                                      description: 'path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'iscsi represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     initiatorName:
-                                      description: initiatorName is the custom iSCSI
-                                        Initiator Name. If initiatorName is specified
-                                        with iscsiInterface simultaneously, new iSCSI
-                                        interface <target portal>:<volume name> will
-                                        be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iscsiInterface is the interface
-                                        Name that uses an iSCSI transport. Defaults
-                                        to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: portals is the iSCSI Target Portal
-                                        List. The portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: targetPortal is iSCSI Target Portal.
-                                        The Portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -1231,166 +518,67 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'name of the volume. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 nfs:
-                                  description: 'nfs represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   properties:
                                     path:
-                                      description: 'path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: boolean
                                     server:
-                                      description: 'server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly
-                                        setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used
-                                        to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777
-                                        or a decimal value between 0 and 511. YAML
-                                        accepts both octal and decimal values, JSON
-                                        requires decimal values for mode bits. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced ConfigMap
-                                                  will be projected into the volume
-                                                  as a file whose name is the key
-                                                  and content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1398,105 +586,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode
-                                                        bits used to set permissions
-                                                        on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -1508,58 +633,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced Secret will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -1567,52 +650,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
                                                 type: string
                                             required:
                                             - path
@@ -1621,162 +671,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: group to map volume access to Default
-                                        is no group
                                       type: string
                                     readOnly:
-                                      description: readOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
                                       type: string
                                     tenant:
-                                      description: tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
                                       type: string
                                     user:
-                                      description: user to map volume access to Defaults
-                                        to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'rbd represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
                                       type: string
                                     image:
-                                      description: 'image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: 'keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     monitors:
-                                      description: 'monitors is a collection of Ceph
-                                        monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'pool is the rados pool name. Default
-                                        is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is the rados user name. Default
-                                        is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: storageMode indicates whether the
-                                        storage for a volume should be ThickProvisioned
-                                        or ThinProvisioned. Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the name of a volume
-                                        already created in the ScaleIO system that
-                                        is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -1784,63 +748,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -1848,85 +768,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the
-                                        secret in the pod''s namespace to use. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: volumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: volumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -1949,58 +820,36 @@ spec:
                   type: object
                 type: array
               networkAttachments:
-                description: NetworkAttachments is a list of NetworkAttachment resource
-                  names to expose the services to the given network
                 items:
                   type: string
                 type: array
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes running
-                  this service. Setting here overrides any global NodeSelector settings
-                  within the Manila CR.
                 type: object
               passwordSelectors:
                 default:
                   database: ManilaDatabasePassword
                   service: ManilaPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: ManilaDatabasePassword
-                    description: 'Database - Selector to get the manila database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                   service:
                     default: ManilaPassword
-                    description: Service - Selector to get the manila service password
-                      from the Secret
                     type: string
                 type: object
               replicas:
                 default: 1
-                description: Replicas - manila Volume Replicas
                 format: int32
                 maximum: 1
                 type: integer
               resources:
-                description: Resources - Compute Resources required by this service
-                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                 properties:
                   claims:
-                    description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable."
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: Name must match the name of one entry in pod.spec.resourceClaims
-                            of the Pod where this field is used. It makes that resource
-                            available inside a container.
                           type: string
                       required:
                       - name
@@ -2016,8 +865,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -2026,64 +873,33 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               secret:
-                description: Secret containing OpenStack password information for
-                  manilaDatabasePassword
                 type: string
               serviceUser:
                 default: manila
-                description: ServiceUser - optional username used for this service
-                  to register in manila
                 type: string
               transportURLSecret:
-                description: Secret containing RabbitMq transport URL
                 type: string
             type: object
           status:
-            description: ManilaShareStatus defines the observed state of ManilaShare
             properties:
               conditions:
-                description: Conditions
                 items:
-                  description: Condition defines an observation of a API resource
-                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase.
                       type: string
                     severity:
-                      description: Severity provides a classification of Reason code,
-                        so the current situation is immediately understandable and
-                        could act accordingly. It is meant for situations where Status=False
-                        and it should be indicated if it is just informational, warning
-                        (next reconciliation might fix it) or an error (e.g. DB create
-                        issue and no actions to automatically resolve the issue can/should
-                        be done). For conditions where Status=Unknown or Status=True
-                        the Severity should be SeverityNone.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase.
                       type: string
                   required:
                   - lastTransitionTime
@@ -2094,17 +910,14 @@ spec:
               hash:
                 additionalProperties:
                   type: string
-                description: Map of hashes to track e.g. job status
                 type: object
               networkAttachments:
                 additionalProperties:
                   items:
                     type: string
                   type: array
-                description: NetworkAttachments status of the deployment pods
                 type: object
               readyCount:
-                description: ReadyCount of ManilaShare instances
                 format: int32
                 type: integer
             type: object


### PR DESCRIPTION
This patch rebuilds the manila crd removing the description to avoid a potential issue when the manila bundle is deployed via OLM by the meta operator.