### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/workflows/build-manila-operator.yaml
+++ b/.github/workflows/build-manila-operator.yaml
@@ -35,8 +35,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -109,8 +109,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -146,8 +146,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 


### PR DESCRIPTION
We have issues deploying the manila-operator via openstack-operator because the script which is supposed to run the `github action` that pushes the new bundle has "master" instead of "main".
This results in having a "main-latest" [1][2][3] tag instead of just "latest" and the meta-operator is not able to resolve the right manila container! 

[1] https://quay.io/repository/openstack-k8s-operators/manila-operator?tab=tags
[2] https://quay.io/repository/openstack-k8s-operators/manila-operator-index?tab=tags
[3] https://quay.io/repository/openstack-k8s-operators/manila-operator-bundle?tab=tags