### PR TITLE
Add revive to golanci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,18 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errorlint
+    - revive
+    - ginkgolinter
+    - gofmt
+    - govet
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: true
+run:
+  timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,6 @@
 repos:
 - repo: local
   hooks:
-    - id: golangci-lint
-      name: golangci-lint
-      language: golang
-      types: [go]
-      entry: make
-      args: ["golangci-lint"]
-      pass_filenames: false
-    - id: gofmt
-      name: gofmt
-      language: system
-      entry: make
-      args: ["fmt"]
-      pass_filenames: false
-    - id: govet
-      name: govet
-      language: system
-      entry: make
-      args: ["vet"]
-      pass_filenames: false
     - id: gotidy
       name: gotidy
       language: system
@@ -73,3 +54,9 @@ repos:
   hooks:
     - id: bashate
       entry: bashate --error . --ignore=E006,E040,E011,E020,E012
+
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.52.2
+  hooks:
+    - id: golangci-lint
+      args: ["-v"]

--- a/Makefile
+++ b/Makefile
@@ -343,11 +343,9 @@ operator-lint: $(LOCALBIN) gowork
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/..
 
 .PHONY: tidy
-tidy: fmt
-	go mod tidy; \
-	pushd "$(LOCALBIN)/../api"; \
-	go mod tidy; \
-	popd;
+tidy: ## Run go mod tidy on every mod file in the repo
+	go mod tidy
+	cd ./api && go mod tidy
 
 .PHONY: golangci-lint
 golangci-lint:


### PR DESCRIPTION
This PR replace deprecated go-linter using
revive (https://golangci-lint.run/usage/linters/#revive).

This patch also Remove fmt dependency from make tidy as per [1]:

The fmt dependency cannot be run if the go.mod file needs an update:
```
 $ make tidy
 go fmt ./...
 go: updates to go.mod needed; to update it:
        go mod tidy
 make: *** [Makefile:103: fmt] Error 1
```

I have also made some changes as per the comment given here [2]

[1]: https://github.com/openstack-k8s-operators/placement-operator/pull/153
[2]: https://github.com/openstack-k8s-operators/cinder-operator/pull/147#discussion_r1158504341