### PR TITLE
Disable log file and use stderr for log output

### DIFF
--- a/templates/manila/config/manila.conf
+++ b/templates/manila/config/manila.conf
@@ -6,7 +6,7 @@ storage_availability_zone=nova
 default_share_type=default
 rootwrap_config=/etc/manila/rootwrap.conf
 auth_strategy=keystone
-log_dir=/var/log/manila
+use_stderr=true
 control_exchange=openstack
 api_paste_config=/etc/manila/api-paste.ini
 


### PR DESCRIPTION
This change disables usage of log file and makes all log outputs sent to stderr. The file is created inside pod and can fill up container file system.