### PR TITLE
Remove unused constant for admin endpoint

### DIFF
--- a/pkg/manila/const.go
+++ b/pkg/manila/const.go
@@ -28,8 +28,6 @@ const (
 	// ServiceAccount -
 	ServiceAccount = "manila-operator-manila"
 
-	// ManilaAdminPort -
-	ManilaAdminPort int32 = 8786
 	// ManilaPublicPort -
 	ManilaPublicPort int32 = 8786
 	// ManilaInternalPort -

--- a/pkg/manilaapi/const.go
+++ b/pkg/manilaapi/const.go
@@ -22,8 +22,6 @@ const (
 	// DatabaseName -
 	DatabaseName = "manila"
 
-	// ManilaAdminPort -
-	ManilaAdminPort int32 = 8786
 	// ManilaPublicPort -
 	ManilaPublicPort int32 = 8786
 	// ManilaInternalPort -

--- a/pkg/manilaapi/const.go
+++ b/pkg/manilaapi/const.go
@@ -13,20 +13,6 @@ limitations under the License.
 package manilaapi
 
 const (
-	// ServiceName -
-	ServiceName = "manila"
-	// ServiceAccount -
-	ServiceAccount = "manila-operator-manila"
-	// ServiceType -
-	ServiceType = "manila"
-	// DatabaseName -
-	DatabaseName = "manila"
-
-	// ManilaPublicPort -
-	ManilaPublicPort int32 = 8786
-	// ManilaInternalPort -
-	ManilaInternalPort int32 = 8786
-
 	// KollaConfig -
 	KollaConfig = "/var/lib/config-data/merged/manila-api-config.json"
 )


### PR DESCRIPTION
The constant has not been used since we stopped creating admin endpoint.

This also removes a few more unused constants as well.