### PR TITLE
Remove crudini dependency and unused scripts

### DIFF
--- a/api/bases/manila.openstack.org_manilaapis.yaml
+++ b/api/bases/manila.openstack.org_manilaapis.yaml
@@ -45,6 +45,10 @@ spec:
               customServiceConfig:
                 default: '# add your customization here'
                 type: string
+              customServiceConfigSecrets:
+                items:
+                  type: string
+                type: array
               databaseHostname:
                 type: string
               databaseUser:

--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -820,6 +820,10 @@ spec:
                   customServiceConfig:
                     default: '# add your customization here'
                     type: string
+                  customServiceConfigSecrets:
+                    items:
+                      type: string
+                    type: array
                   debug:
                     properties:
                       initContainer:
@@ -911,6 +915,10 @@ spec:
                   customServiceConfig:
                     default: '# add your customization here'
                     type: string
+                  customServiceConfigSecrets:
+                    items:
+                      type: string
+                    type: array
                   debug:
                     properties:
                       initContainer:
@@ -978,6 +986,10 @@ spec:
                     customServiceConfig:
                       default: '# add your customization here'
                       type: string
+                    customServiceConfigSecrets:
+                      items:
+                        type: string
+                      type: array
                     debug:
                       properties:
                         initContainer:

--- a/api/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/api/bases/manila.openstack.org_manilaschedulers.yaml
@@ -45,6 +45,10 @@ spec:
               customServiceConfig:
                 default: '# add your customization here'
                 type: string
+              customServiceConfigSecrets:
+                items:
+                  type: string
+                type: array
               databaseHostname:
                 type: string
               databaseUser:

--- a/api/bases/manila.openstack.org_manilashares.yaml
+++ b/api/bases/manila.openstack.org_manilashares.yaml
@@ -45,6 +45,10 @@ spec:
               customServiceConfig:
                 default: '# add your customization here'
                 type: string
+              customServiceConfigSecrets:
+                items:
+                  type: string
+                type: array
               databaseHostname:
                 type: string
               databaseUser:

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -76,6 +76,11 @@ type ManilaServiceTemplate struct {
 	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// CustomServiceConfigSecrets - customize the service config using this parameter to specify Secrets
+	// that contain sensitive service config data. The content of each Secret gets added to the
+	// /etc/<service>/<service>.conf.d directory as a custom config file.
+	CustomServiceConfigSecrets []string `json:"customServiceConfigSecrets,omitempty"`
+	// +kubebuilder:validation:Optional
 	// Resources - Compute Resources required by this service (Limits/Requests).
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -488,6 +488,11 @@ func (in *ManilaServiceTemplate) DeepCopyInto(out *ManilaServiceTemplate) {
 			(*out)[key] = val
 		}
 	}
+	if in.CustomServiceConfigSecrets != nil {
+		in, out := &in.CustomServiceConfigSecrets, &out.CustomServiceConfigSecrets
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.NetworkAttachments != nil {
 		in, out := &in.NetworkAttachments, &out.NetworkAttachments

--- a/config/crd/bases/manila.openstack.org_manilaapis.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaapis.yaml
@@ -45,6 +45,10 @@ spec:
               customServiceConfig:
                 default: '# add your customization here'
                 type: string
+              customServiceConfigSecrets:
+                items:
+                  type: string
+                type: array
               databaseHostname:
                 type: string
               databaseUser:

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -820,6 +820,10 @@ spec:
                   customServiceConfig:
                     default: '# add your customization here'
                     type: string
+                  customServiceConfigSecrets:
+                    items:
+                      type: string
+                    type: array
                   debug:
                     properties:
                       initContainer:
@@ -911,6 +915,10 @@ spec:
                   customServiceConfig:
                     default: '# add your customization here'
                     type: string
+                  customServiceConfigSecrets:
+                    items:
+                      type: string
+                    type: array
                   debug:
                     properties:
                       initContainer:
@@ -978,6 +986,10 @@ spec:
                     customServiceConfig:
                       default: '# add your customization here'
                       type: string
+                    customServiceConfigSecrets:
+                      items:
+                        type: string
+                      type: array
                     debug:
                       properties:
                         initContainer:

--- a/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
@@ -45,6 +45,10 @@ spec:
               customServiceConfig:
                 default: '# add your customization here'
                 type: string
+              customServiceConfigSecrets:
+                items:
+                  type: string
+                type: array
               databaseHostname:
                 type: string
               databaseUser:

--- a/config/crd/bases/manila.openstack.org_manilashares.yaml
+++ b/config/crd/bases/manila.openstack.org_manilashares.yaml
@@ -45,6 +45,10 @@ spec:
               customServiceConfig:
                 default: '# add your customization here'
                 type: string
+              customServiceConfigSecrets:
+                items:
+                  type: string
+                type: array
               databaseHostname:
                 type: string
               databaseUser:

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -727,12 +727,11 @@ func (r *ManilaReconciler) generateServiceConfigMaps(
 	cms := []util.Template{
 		// ScriptsConfigMap
 		{
-			Name:               fmt.Sprintf("%s-scripts", instance.Name),
-			Namespace:          instance.Namespace,
-			Type:               util.TemplateTypeScripts,
-			InstanceType:       instance.Kind,
-			AdditionalTemplate: map[string]string{"common.sh": "/common/common.sh"},
-			Labels:             cmLabels,
+			Name:         fmt.Sprintf("%s-scripts", instance.Name),
+			Namespace:    instance.Namespace,
+			Type:         util.TemplateTypeScripts,
+			InstanceType: instance.Kind,
+			Labels:       cmLabels,
 		},
 		// ConfigMap
 		{

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -169,6 +169,39 @@ func (r *ManilaShareReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // SetupWithManager sets up the controller with the Manager.
 func (r *ManilaShareReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
+	// Watch for changes to any CustomServiceConfigSecrets. Global secrets
+	// (e.g. TransportURLSecret) are handled by the top Manila controller.
+	svcSecretFn := func(o client.Object) []reconcile.Request {
+		var namespace string = o.GetNamespace()
+		var secretName string = o.GetName()
+		result := []reconcile.Request{}
+
+		// get all API CRs
+		apis := &manilav1beta1.ManilaShareList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(namespace),
+		}
+		if err := r.Client.List(context.Background(), apis, listOpts...); err != nil {
+			r.Log.Error(err, "Unable to retrieve API CRs %v")
+			return nil
+		}
+		for _, cr := range apis.Items {
+			for _, v := range cr.Spec.CustomServiceConfigSecrets {
+				if v == secretName {
+					name := client.ObjectKey{
+						Namespace: namespace,
+						Name:      cr.Name,
+					}
+					r.Log.Info(fmt.Sprintf("Secret %s is used by Manila CR %s", secretName, cr.Name))
+					result = append(result, reconcile.Request{NamespacedName: name})
+				}
+			}
+		}
+		if len(result) > 0 {
+			return result
+		}
+		return nil
+	}
 	// watch for configmap where the CM owner label AND the CR.Spec.ManagingCrName label matches
 	configMapFn := func(o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
@@ -210,6 +243,9 @@ func (r *ManilaShareReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&manilav1beta1.ManilaShare{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Secret{}).
+		// watch the secrets we don't own
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(svcSecretFn)).
 		// watch the config CMs we don't own
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(configMapFn)).

--- a/pkg/manila/volumes.go
+++ b/pkg/manila/volumes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	manilav1 "github.com/openstack-k8s-operators/manila-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"strconv"
 )
 
 // GetVolumes -
@@ -126,4 +127,33 @@ func GetVolumeMounts(extraVol []manilav1.ManilaExtraVolMounts, svc []storage.Pro
 		}
 	}
 	return res
+}
+
+// GetConfigSecretVolumes - Returns a list of volumes associated with a list of Secret names
+func GetConfigSecretVolumes(secretNames []string) ([]corev1.Volume, []corev1.VolumeMount) {
+	var config0640AccessMode int32 = 0640
+	secretVolumes := []corev1.Volume{}
+	secretMounts := []corev1.VolumeMount{}
+
+	for idx, secretName := range secretNames {
+		secretVol := corev1.Volume{
+			Name: secretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  secretName,
+					DefaultMode: &config0640AccessMode,
+				},
+			},
+		}
+		secretMount := corev1.VolumeMount{
+			Name: secretName,
+			// Each secret needs its own MountPath
+			MountPath: "/var/lib/config-data/secret-" + strconv.Itoa(idx),
+			ReadOnly:  true,
+		}
+		secretVolumes = append(secretVolumes, secretVol)
+		secretMounts = append(secretMounts, secretMount)
+	}
+
+	return secretVolumes, secretMounts
 }

--- a/pkg/manilaapi/deployment.go
+++ b/pkg/manilaapi/deployment.go
@@ -119,7 +119,12 @@ func Deployment(
 			},
 		},
 	}
-	deployment.Spec.Template.Spec.Volumes = GetVolumes(manila.GetOwningManilaName(instance), instance.Name, instance.Spec.ExtraMounts)
+	deployment.Spec.Template.Spec.Volumes = GetVolumes(
+		manila.GetOwningManilaName(instance),
+		instance.Name,
+		instance.Spec.CustomServiceConfigSecrets,
+		instance.Spec.ExtraMounts,
+	)
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible
 	// the get still created on the same worker node.
@@ -143,8 +148,11 @@ func Deployment(
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         GetInitVolumeMounts(instance.Spec.ExtraMounts),
-		Debug:                instance.Spec.Debug.InitContainer,
+		VolumeMounts: GetInitVolumeMounts(
+			instance.Spec.CustomServiceConfigSecrets,
+			instance.Spec.ExtraMounts,
+		),
+		Debug: instance.Spec.Debug.InitContainer,
 	}
 	deployment.Spec.Template.Spec.InitContainers = manila.InitContainer(initContainerDetails)
 

--- a/pkg/manilascheduler/statefulset.go
+++ b/pkg/manilascheduler/statefulset.go
@@ -142,7 +142,12 @@ func StatefulSet(
 			},
 		},
 	}
-	statefulset.Spec.Template.Spec.Volumes = GetVolumes(manila.GetOwningManilaName(instance), instance.Name, instance.Spec.ExtraMounts)
+	statefulset.Spec.Template.Spec.Volumes = GetVolumes(
+		manila.GetOwningManilaName(instance),
+		instance.Name,
+		instance.Spec.CustomServiceConfigSecrets,
+		instance.Spec.ExtraMounts,
+	)
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible
 	// the get still created on the same worker node.
@@ -166,8 +171,11 @@ func StatefulSet(
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         GetInitVolumeMounts(instance.Spec.ExtraMounts),
-		Debug:                instance.Spec.Debug.InitContainer,
+		VolumeMounts: GetInitVolumeMounts(
+			instance.Spec.CustomServiceConfigSecrets,
+			instance.Spec.ExtraMounts,
+		),
+		Debug: instance.Spec.Debug.InitContainer,
 	}
 
 	statefulset.Spec.Template.Spec.InitContainers = manila.InitContainer(initContainerDetails)

--- a/pkg/manilashare/statefulset.go
+++ b/pkg/manilashare/statefulset.go
@@ -101,7 +101,11 @@ func StatefulSet(
 	envVars["MALLOC_MMAP_THRESHOLD_"] = env.SetValue("131072")
 	envVars["MALLOC_TRIM_THRESHOLD_"] = env.SetValue("262144")
 
-	volumeMounts := GetVolumeMounts(instance.Name, instance.Spec.ExtraMounts)
+	volumeMounts := GetVolumeMounts(
+		instance.Name,
+		instance.Spec.CustomServiceConfigSecrets,
+		instance.Spec.ExtraMounts,
+	)
 
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -154,7 +158,12 @@ func StatefulSet(
 			},
 		},
 	}
-	statefulset.Spec.Template.Spec.Volumes = GetVolumes(manila.GetOwningManilaName(instance), instance.Name, instance.Spec.ExtraMounts)
+	statefulset.Spec.Template.Spec.Volumes = GetVolumes(
+		manila.GetOwningManilaName(instance),
+		instance.Name,
+		instance.Spec.CustomServiceConfigSecrets,
+		instance.Spec.ExtraMounts,
+	)
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible
 	// the get still created on the same worker node.
@@ -178,8 +187,12 @@ func StatefulSet(
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         GetInitVolumeMounts(instance.Name, instance.Spec.ExtraMounts),
-		Debug:                instance.Spec.Debug.InitContainer,
+		VolumeMounts: GetInitVolumeMounts(
+			instance.Name,
+			instance.Spec.CustomServiceConfigSecrets,
+			instance.Spec.ExtraMounts,
+		),
+		Debug: instance.Spec.Debug.InitContainer,
 	}
 
 	statefulset.Spec.Template.Spec.InitContainers = manila.InitContainer(initContainerDetails)

--- a/templates/common/common.sh
+++ b/templates/common/common.sh
@@ -1,4 +1,5 @@
-#!/bin//bash
+#!/bin/bash
+
 #
 # Copyright 2022 Red Hat Inc.
 #
@@ -18,13 +19,13 @@ set -e
 
 function merge_config_dir {
     echo merge config dir $1
-    for conf in $(find $1 -type f); do
+    for conf in $(find $1 -type f);do
         conf_base=$(basename $conf)
 
         # If CFG already exist in ../merged and is not a json file,
         # we expect for now it can be merged using crudini.
         # Else, just copy the full file.
-        if [[ -f /var/lib/config-data/merged/${conf_base} && ${conf_base} != *.json ]]; then
+        if [[ -f /var/lib/config-data/merged/${conf_base} && ${conf_base} != *.json && ${conf_base} != nfs_shares ]]; then
             echo merging ${conf} into /var/lib/config-data/merged/${conf_base}
             crudini --merge /var/lib/config-data/merged/${conf_base} < ${conf}
         else

--- a/templates/manila/config/db-sync-config.json
+++ b/templates/manila/config/db-sync-config.json
@@ -2,10 +2,10 @@
   "command": "/usr/local/bin/container-scripts/bootstrap.sh",
   "config_files": [
     {
-      "source": "/var/lib/config-data/merged/manila.conf",
-      "dest": "/etc/manila/manila.conf",
+      "source": "/var/lib/config-data/merged/manila.conf.d",
+      "dest": "/etc/manila/manila.conf.d",
       "owner": "manila",
-      "perm": "0600"
+      "perm": "0700"
     }
   ]
 }

--- a/templates/manila/config/manila-api-config.json
+++ b/templates/manila/config/manila-api-config.json
@@ -2,10 +2,10 @@
   "command": "/usr/sbin/httpd -DFOREGROUND",
   "config_files": [
     {
-      "source": "/var/lib/config-data/merged/manila.conf",
-      "dest": "/etc/manila/manila.conf",
+      "source": "/var/lib/config-data/merged/manila.conf.d",
+      "dest": "/etc/manila/manila.conf.d",
       "owner": "root:manila",
-      "perm": "0640"
+      "perm": "0755"
     },
     {
       "source": "/var/lib/config-data/merged/httpd.conf",

--- a/templates/manila/config/manila-scheduler-config.json
+++ b/templates/manila/config/manila-scheduler-config.json
@@ -1,11 +1,11 @@
 {
-  "command": "/usr/bin/manila-scheduler --config-file /usr/share/manila/manila-dist.conf --config-file /etc/manila/manila.conf",
+  "command": "/usr/bin/manila-scheduler --config-dir /etc/manila/manila.conf.d",
   "config_files": [
     {
-      "source": "/var/lib/config-data/merged/manila.conf",
-      "dest": "/etc/manila/manila.conf",
+      "source": "/var/lib/config-data/merged/manila.conf.d",
+      "dest": "/etc/manila/manila.conf.d",
       "owner": "root:manila",
-      "perm": "0640"
+      "perm": "0750"
     }
   ]
 }

--- a/templates/manila/config/manila-share-config.json
+++ b/templates/manila/config/manila-share-config.json
@@ -1,11 +1,11 @@
 {
-  "command": "/usr/bin/manila-share --config-file /usr/share/manila/manila-dist.conf --config-file /etc/manila/manila.conf",
+  "command": "/usr/bin/manila-share --config-dir /etc/manila/manila.conf.d",
   "config_files": [
-    {
-      "source": "/var/lib/config-data/merged/manila.conf",
-      "dest": "/etc/manila/manila.conf",
+   {
+      "source": "/var/lib/config-data/merged/manila.conf.d",
+      "dest": "/etc/manila/manila.conf.d",
       "owner": "root:manila",
-      "perm": "0640"
+      "perm": "0750"
     }
   ]
 }


### PR DESCRIPTION
This change is part of a series that aim to remove the crudini dependency and be consistent with what we've done in `Cinder` `PR#108`. In particular, secret snippets can be rendered in the config exposing `customServiceConfigSecrets` and processed by the `init` script. The `customServiceConfigSecrets` parameter is used to define a list of secrets (by name) that are processed by the operator and the `init` script and propagated to the `Manila` services.