### PR TITLE
Set up the v1 API endpoint

### DIFF
--- a/pkg/manila/const.go
+++ b/pkg/manila/const.go
@@ -17,11 +17,13 @@ import (
 )
 
 const (
-	// ServiceName -
+	// ServiceName - API V1 service name, deprecated
 	ServiceName = "manila"
-	// ServiceNameV2 -
+	// ServiceType - API V1 service type, deprecated
+	ServiceType = "share"
+	// ServiceNameV2 - API V2 service name, supported
 	ServiceNameV2 = "manilav2"
-	// ServiceTypeV2 -
+	// ServiceTypeV2 - API V2 service type, supported
 	ServiceTypeV2 = "sharev2"
 	// DatabaseName -
 	DatabaseName = "manila"


### PR DESCRIPTION
Manila's deprecated its v1 API, but hasn't removed it yet. Manila's tempest plugin
has a hard dependency on this endpoint. So, we can re-introduce this endpoint for
the sake of the tests and drop it when the upstream community removes it entirely.