### PR TITLE
Log to stdout by default

### DIFF
--- a/templates/manila/config/manila.conf
+++ b/templates/manila/config/manila.conf
@@ -9,6 +9,7 @@ auth_strategy=keystone
 log_dir=/var/log/manila
 control_exchange=openstack
 api_paste_config=/etc/manila/api-paste.ini
+log_file = /dev/stdout
 
 [cinder]
 [cors]


### PR DESCRIPTION
We need the manila-scheduler and
manila-share containers to write
logs to stdout so these logs
can be gathered by kubectl/oc log
commands.