### PR TITLE
Validate input for Replicas spec

### DIFF
--- a/api/bases/manila.openstack.org_manilaapis.yaml
+++ b/api/bases/manila.openstack.org_manilaapis.yaml
@@ -871,6 +871,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 32
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -873,6 +873,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 32
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -943,6 +945,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 32
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -1014,6 +1018,8 @@ spec:
                     replicas:
                       default: 1
                       format: int32
+                      maximum: 32
+                      minimum: 0
                       type: integer
                     resources:
                       properties:

--- a/api/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/api/bases/manila.openstack.org_manilaschedulers.yaml
@@ -846,6 +846,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 32
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/api/bases/manila.openstack.org_manilashares.yaml
+++ b/api/bases/manila.openstack.org_manilashares.yaml
@@ -846,6 +846,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 32
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/api/v1beta1/manilaapi_types.go
+++ b/api/v1beta1/manilaapi_types.go
@@ -29,6 +29,8 @@ type ManilaAPITemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Maximum=32
+	// +kubebuilder:validation:Minimum=0
 	// Replicas - Manila API Replicas
 	Replicas int32 `json:"replicas"`
 

--- a/api/v1beta1/manilascheduler_types.go
+++ b/api/v1beta1/manilascheduler_types.go
@@ -32,6 +32,8 @@ type ManilaSchedulerTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Maximum=32
+	// +kubebuilder:validation:Minimum=0
 	// Replicas - Manila API Replicas
 	Replicas int32 `json:"replicas"`
 }

--- a/api/v1beta1/manilashare_types.go
+++ b/api/v1beta1/manilashare_types.go
@@ -32,6 +32,8 @@ type ManilaShareTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Maximum=32
+	// +kubebuilder:validation:Minimum=0
 	// Replicas - Manila API Replicas
 	Replicas int32 `json:"replicas"`
 }

--- a/config/crd/bases/manila.openstack.org_manilaapis.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaapis.yaml
@@ -871,6 +871,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 32
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -873,6 +873,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 32
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -943,6 +945,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 32
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -1014,6 +1018,8 @@ spec:
                     replicas:
                       default: 1
                       format: int32
+                      maximum: 32
+                      minimum: 0
                       type: integer
                     resources:
                       properties:

--- a/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
@@ -846,6 +846,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 32
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/config/crd/bases/manila.openstack.org_manilashares.yaml
+++ b/config/crd/bases/manila.openstack.org_manilashares.yaml
@@ -846,6 +846,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 32
+                minimum: 0
                 type: integer
               resources:
                 properties:


### PR DESCRIPTION
This adds minimum/maximum value for Replicas spec to avoid accepting a negative number or a too large number. The maximum number follows what is used in keystone-operator.