### PR TITLE
Add 'omitempty' to manilaShare map field

### DIFF
--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -79,7 +79,7 @@ type ManilaSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// ManilaShares - Map of chosen names to spec definitions for the Share(s) service(s) of this Manila deployment
-	ManilaShares map[string]ManilaShareTemplate `json:"manilaShares"`
+	ManilaShares map[string]ManilaShareTemplate `json:"manilaShares,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials


### PR DESCRIPTION
Fixes an error in the context of an OpenStack operator `OpenStackControlPlane` deployment where the Manila section is left blank.  Without this change we encounter:

```
The OpenStackControlPlane "openstack-collapsed-cell" is invalid: spec.manila.template.manilaShares: Invalid value: "null": spec.manila.template.manilaShares in body must be of type object: "null"
```