### PR TITLE
[envtest] Improve the Make target

### DIFF
--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -156,6 +156,9 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// This allows parallel execution, otherwise it fails
+		// trying to bind to the same metrics port
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
As done for `dataplane-operator` [1], this patch improves the `Make` target using  `ginkgo` cli, while `go test` is still used to run regular unit tests. This is very useful especially for development purposes, where we would like to focus on the single test that is going to be written and get a more verbose log.

```
e.g.

make test GINKGO_ARGS="-v --focus \
  "'Should fail if db-sync job fails when DB is Created'"
```

Other than that, it's easier to run tests in parallel and produce reports [2].

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/204
[2] https://onsi.github.io/ginkgo/#the-ginkgo-cli-vs-go-test