### PR TITLE
Improve NetworkAttachments check

### DIFF
--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -641,10 +641,15 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 	// Create ConfigMaps required as input for the Service and calculate an overall hash of hashes
 	//
 
+	serviceLabels := map[string]string{
+		common.AppSelector:       manila.ServiceName,
+		common.ComponentSelector: manilaapi.Component,
+	}
+
 	//
 	// create custom Configmap for this manila-api service
 	//
-	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars)
+	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars, serviceLabels)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -680,10 +685,6 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 	//
 	// TODO check when/if Init, Update, or Upgrade should/could be skipped
 	//
-
-	serviceLabels := map[string]string{
-		common.AppSelector: manila.ServiceName,
-	}
 
 	// networks to attach to
 	for _, netAtt := range instance.Spec.NetworkAttachments {
@@ -767,10 +768,22 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 	}
 	instance.Status.ReadyCount = depl.GetDeployment().Status.ReadyReplicas
 
-	// verify if network attachment matches expectations
-	networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(ctx, helper, instance.Spec.NetworkAttachments, serviceLabels, instance.Status.ReadyCount)
-	if err != nil {
-		return ctrl.Result{}, err
+	networkReady := false
+	networkAttachmentStatus := map[string][]string{}
+	if instance.Spec.Replicas > 0 {
+		// verify if network attachment matches expectations
+		networkReady, networkAttachmentStatus, err = nad.VerifyNetworkStatusFromAnnotation(
+			ctx,
+			helper,
+			instance.Spec.NetworkAttachments,
+			serviceLabels,
+			instance.Status.ReadyCount,
+		)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		networkReady = true
 	}
 
 	instance.Status.NetworkAttachments = networkAttachmentStatus
@@ -824,13 +837,14 @@ func (r *ManilaAPIReconciler) generateServiceConfigMaps(
 	h *helper.Helper,
 	instance *manilav1beta1.ManilaAPI,
 	envVars *map[string]env.Setter,
+	serviceLabels map[string]string,
 ) error {
 	//
 	// create custom Configmap for manila-api-specific config input
 	// - %-config-data configmap holding custom config for the service's manila.conf
 	//
 
-	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), map[string]string{})
+	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), serviceLabels)
 
 	// customData hold any customization for the service.
 	// custom.conf is going to be merged into /etc/manila/manila.conf

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -371,11 +371,14 @@ func (r *ManilaShareReconciler) reconcileNormal(ctx context.Context, instance *m
 	//
 	// Create ConfigMaps required as input for the Service and calculate an overall hash of hashes
 	//
-
+	serviceLabels := map[string]string{
+		common.AppSelector:       manila.ServiceName,
+		common.ComponentSelector: manilashare.Component,
+	}
 	//
 	// create custom Configmap for this manila-share service
 	//
-	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars)
+	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars, serviceLabels)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -411,10 +414,6 @@ func (r *ManilaShareReconciler) reconcileNormal(ctx context.Context, instance *m
 	//
 	// TODO check when/if Init, Update, or Upgrade should/could be skipped
 	//
-
-	serviceLabels := map[string]string{
-		common.AppSelector: manila.ServiceName,
-	}
 
 	// networks to attach to
 	for _, netAtt := range instance.Spec.NetworkAttachments {
@@ -499,9 +498,22 @@ func (r *ManilaShareReconciler) reconcileNormal(ctx context.Context, instance *m
 	instance.Status.ReadyCount = ss.GetStatefulSet().Status.ReadyReplicas
 
 	// verify if network attachment matches expectations
-	networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(ctx, helper, instance.Spec.NetworkAttachments, serviceLabels, instance.Status.ReadyCount)
-	if err != nil {
-		return ctrl.Result{}, err
+	networkReady := false
+	networkAttachmentStatus := map[string][]string{}
+	if instance.Spec.Replicas > 0 {
+		// verify if network attachment matches expectations
+		networkReady, networkAttachmentStatus, err = nad.VerifyNetworkStatusFromAnnotation(
+			ctx,
+			helper,
+			instance.Spec.NetworkAttachments,
+			serviceLabels,
+			instance.Status.ReadyCount,
+		)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		networkReady = true
 	}
 
 	instance.Status.NetworkAttachments = networkAttachmentStatus
@@ -555,13 +567,14 @@ func (r *ManilaShareReconciler) generateServiceConfigMaps(
 	h *helper.Helper,
 	instance *manilav1beta1.ManilaShare,
 	envVars *map[string]env.Setter,
+	serviceLabels map[string]string,
 ) error {
 	//
 	// create custom Configmap for manila-share-specific config input
 	// - %-config-data configmap holding custom config for the service's manila.conf
 	//
 
-	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), map[string]string{})
+	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), serviceLabels)
 
 	// customData hold any customization for the service.
 	// custom.conf is going to be merged into /etc/manila/manila.conf

--- a/pkg/manilaapi/const.go
+++ b/pkg/manilaapi/const.go
@@ -15,4 +15,6 @@ package manilaapi
 const (
 	// KollaConfig -
 	KollaConfig = "/var/lib/config-data/merged/manila-api-config.json"
+	// Component -
+	Component = "manila-api"
 )

--- a/pkg/manilaapi/deployment.go
+++ b/pkg/manilaapi/deployment.go
@@ -83,6 +83,7 @@ func Deployment(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      manila.ServiceName,
 			Namespace: instance.Namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/manilascheduler/const.go
+++ b/pkg/manilascheduler/const.go
@@ -15,4 +15,6 @@ package manilascheduler
 const (
 	// KollaConfig -
 	KollaConfig = "/var/lib/config-data/merged/manila-scheduler-config.json"
+	// Component -
+	Component = "manila-scheduler"
 )

--- a/pkg/manilascheduler/statefulset.go
+++ b/pkg/manilascheduler/statefulset.go
@@ -96,6 +96,7 @@ func StatefulSet(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/manilashare/const.go
+++ b/pkg/manilashare/const.go
@@ -15,4 +15,6 @@ package manilashare
 const (
 	// KollaConfig -
 	KollaConfig = "/var/lib/config-data/merged/manila-share-config.json"
+	// Component -
+	Component = "manila-share"
 )

--- a/pkg/manilashare/statefulset.go
+++ b/pkg/manilashare/statefulset.go
@@ -111,6 +111,7 @@ func StatefulSet(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
Only verify `networkAttachments` if `Replicas` > 0
In addition, `Network` validation is checking the pods if `IPs` are correct
reported for each of the requested networks. For this a label selector is
used to get only the pods for the sub manila component (`api`, `scheduler`
and `share`). Right now there is only the generic `manila app label` on the
deployment resources set. This adds a `component label` on all the `api`,
`scheduler` and `share` deployment resources which allows the check to only
get the wanted resource pods.