### PR TITLE
Fix Unstable functional test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ IMG ?= $(DEFAULT_IMG)
 ENVTEST_K8S_VERSION = 1.25.0
 GINKGO ?= $(LOCALBIN)/ginkgo
 
-PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)
+PROCS ?=$(shell expr $(shell nproc --ignore 2) / 4)
 PROC_CMD = --procs ${PROCS}
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/tests/functional/manila_controller_test.go
+++ b/tests/functional/manila_controller_test.go
@@ -31,12 +31,23 @@ var _ = Describe("Manila controller", func() {
 		BeforeEach(func() {
 			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
 		})
+
+		It("initializes the status fields", func() {
+			Eventually(func(g Gomega) {
+				glance := GetManila(manilaName)
+				g.Expect(glance.Status.Conditions).To(HaveLen(12))
+
+				g.Expect(glance.Status.DatabaseHostname).To(Equal(""))
+				g.Expect(glance.Status.APIEndpoints).To(BeEmpty())
+			}, timeout*2, interval).Should(Succeed())
+		})
+
 		It("is not Ready", func() {
 			th.ExpectCondition(
 				manilaTest.Instance,
 				ConditionGetterFunc(ManilaConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionUnknown,
+				corev1.ConditionFalse,
 			)
 		})
 		It("should have the Spec fields initialized", func() {


### PR DESCRIPTION
This patch improves the basic `envTests` and checks that the `Status` fields have been initialized, as well as the `Condition` that should be set to `False` because the `CR` has been created, the reconciliation loop has been triggered, but the deployment is not `Ready`.