### PR TITLE
Remove endpoint url and keystone service id from status

### DIFF
--- a/api/bases/manila.openstack.org_manilaapis.yaml
+++ b/api/bases/manila.openstack.org_manilaapis.yaml
@@ -920,12 +920,6 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                type: object
               conditions:
                 items:
                   properties:
@@ -961,10 +955,6 @@ spec:
               readyCount:
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                type: object
             type: object
         type: object
     served: true

--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -1090,12 +1090,6 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                type: object
               conditions:
                 items:
                   properties:
@@ -1134,10 +1128,6 @@ spec:
                 additionalProperties:
                   format: int32
                   type: integer
-                type: object
-              serviceIDs:
-                additionalProperties:
-                  type: string
                 type: object
               transportURLSecret:
                 type: string

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -106,12 +106,6 @@ type ManilaStatus struct {
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 
-	// API endpoints
-	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
-
-	// ServiceIDs
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
-
 	// ReadyCount of Manila API instance
 	ManilaAPIReadyCount int32 `json:"manilaAPIReadyCount,omitempty"`
 

--- a/api/v1beta1/manilaapi_types.go
+++ b/api/v1beta1/manilaapi_types.go
@@ -69,17 +69,11 @@ type ManilaAPIStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoints
-	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// ReadyCount of Manila API instances
 	ReadyCount int32 `json:"readyCount,omitempty"`
-
-	// ServiceIDs
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -147,35 +147,11 @@ func (in *ManilaAPIStatus) DeepCopyInto(out *ManilaAPIStatus) {
 			(*out)[key] = val
 		}
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]map[string]string, len(*in))
-		for key, val := range *in {
-			var outVal map[string]string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				in, out := &val, &outVal
-				*out = make(map[string]string, len(*in))
-				for key, val := range *in {
-					(*out)[key] = val
-				}
-			}
-			(*out)[key] = outVal
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 	if in.NetworkAttachments != nil {
@@ -716,30 +692,6 @@ func (in *ManilaStatus) DeepCopyInto(out *ManilaStatus) {
 		*out = make(condition.Conditions, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]map[string]string, len(*in))
-		for key, val := range *in {
-			var outVal map[string]string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				in, out := &val, &outVal
-				*out = make(map[string]string, len(*in))
-				for key, val := range *in {
-					(*out)[key] = val
-				}
-			}
-			(*out)[key] = outVal
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 	if in.ManilaSharesReadyCounts != nil {

--- a/config/crd/bases/manila.openstack.org_manilaapis.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaapis.yaml
@@ -920,12 +920,6 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                type: object
               conditions:
                 items:
                   properties:
@@ -961,10 +955,6 @@ spec:
               readyCount:
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                type: object
             type: object
         type: object
     served: true

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -1090,12 +1090,6 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                type: object
               conditions:
                 items:
                   properties:
@@ -1134,10 +1128,6 @@ spec:
                 additionalProperties:
                   format: int32
                   type: integer
-                type: object
-              serviceIDs:
-                additionalProperties:
-                  type: string
                 type: object
               transportURLSecret:
                 type: string

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -190,9 +190,6 @@ func (r *ManilaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]map[string]string{}
-	}
 	if instance.Status.ManilaSharesReadyCounts == nil {
 		instance.Status.ManilaSharesReadyCounts = map[string]int32{}
 	}
@@ -616,9 +613,7 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 		r.Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 
-	// Mirror ManilaAPI status' APIEndpoints and ReadyCount to this parent CR
-	instance.Status.APIEndpoints = manilaAPI.Status.APIEndpoints
-	instance.Status.ServiceIDs = manilaAPI.Status.ServiceIDs
+	// Mirror ManilaAPI status' ReadyCount to this parent CR
 	instance.Status.ManilaAPIReadyCount = manilaAPI.Status.ReadyCount
 
 	// Mirror ManilaAPI's condition status

--- a/tests/functional/manila_controller_test.go
+++ b/tests/functional/manila_controller_test.go
@@ -38,7 +38,6 @@ var _ = Describe("Manila controller", func() {
 				g.Expect(glance.Status.Conditions).To(HaveLen(12))
 
 				g.Expect(glance.Status.DatabaseHostname).To(Equal(""))
-				g.Expect(glance.Status.APIEndpoints).To(BeEmpty())
 			}, timeout*2, interval).Should(Succeed())
 		})
 
@@ -62,7 +61,6 @@ var _ = Describe("Manila controller", func() {
 			Expect(Manila.Status.Hash).To(BeEmpty())
 			Expect(Manila.Status.DatabaseHostname).To(Equal(""))
 			Expect(Manila.Status.TransportURLSecret).To(Equal(""))
-			Expect(Manila.Status.APIEndpoints).To(BeEmpty())
 			Expect(Manila.Status.ManilaAPIReadyCount).To(Equal(int32(0)))
 			Expect(Manila.Status.ManilaSchedulerReadyCount).To(Equal(int32(0)))
 		})


### PR DESCRIPTION
These items presented in CR status are not really used. Endpoints can be discovered using Keystone and we have no use case to require service id.