### PR TITLE
Add logging.conf to log to /dev/stdout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230525130454-a7f0f8afe772
-	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230615172650-7d7aa98bc08c
+	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230622141005-e9220a4b3dfe
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230524134507-696d321a942e
 	github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230524134507-696d321a942e
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230524134507-696d321a942e

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDD
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230525130454-a7f0f8afe772 h1:MqVwDuzLCnXJ1g+OCcLy/LsjuB8jRZaqR55Vi7ASkKU=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230525130454-a7f0f8afe772/go.mod h1:BuIOgl+UMgzRLUQFmfwvKFuLQIyOVAEJKyjUTnis7ZM=
-github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230615172650-7d7aa98bc08c h1:3D0wn7IDBhNzW79BqYHF3iMups3l/W6BNQUIWhgAmfU=
-github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230615172650-7d7aa98bc08c/go.mod h1:LtZ8b3DYLvX0a89RKbmJgd1q8GcxcOVf7N+bH47a9HU=
+github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230622141005-e9220a4b3dfe h1:NHbwjF+CqxdCKx1rY+/EjMqGr56lMoWsahzkYfTRtbk=
+github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230622141005-e9220a4b3dfe/go.mod h1:LtZ8b3DYLvX0a89RKbmJgd1q8GcxcOVf7N+bH47a9HU=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230524134507-696d321a942e h1:jVpp4uqYhIPKwK6H1gSCgk7t0WGsM0Qcfd/SNvU0gQs=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230524134507-696d321a942e/go.mod h1:r8cMUoS+gnBTrGbmLLECafzhZBh6P9rMwgnrGVspbqE=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20230524134507-696d321a942e h1:CvJiX4Wt1R8rkrXDIJxE2pjnlEFVgz5YFd+bxgAAxSE=

--- a/pkg/manila/dbsync.go
+++ b/pkg/manila/dbsync.go
@@ -79,6 +79,7 @@ func DbSyncJob(instance *manilav1.Manila, labels map[string]string, annotations 
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         GetInitVolumeMounts(dbSyncExtraMounts, DbsyncPropagation),
 		Debug:                instance.Spec.Debug.DBInitContainer,
+		LoggingConf:          false,
 	}
 	job.Spec.Template.Spec.InitContainers = InitContainer(initContainerDetails)
 

--- a/pkg/manila/initcontainer.go
+++ b/pkg/manila/initcontainer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 
 	corev1 "k8s.io/api/core/v1"
+	"strconv"
 )
 
 // APIDetails information
@@ -31,6 +32,7 @@ type APIDetails struct {
 	VolumeMounts         []corev1.VolumeMount
 	Privileged           bool
 	Debug                bool
+	LoggingConf          bool
 }
 
 const (
@@ -66,6 +68,7 @@ func InitContainer(init APIDetails) []corev1.Container {
 	envVars["DatabaseHost"] = env.SetValue(init.DatabaseHost)
 	envVars["DatabaseUser"] = env.SetValue(init.DatabaseUser)
 	envVars["DatabaseName"] = env.SetValue(init.DatabaseName)
+	envVars["LoggingConf"] = env.SetValue(strconv.FormatBool(init.LoggingConf))
 
 	envs := []corev1.EnvVar{
 		{

--- a/pkg/manilaapi/deployment.go
+++ b/pkg/manilaapi/deployment.go
@@ -153,7 +153,8 @@ func Deployment(
 			instance.Spec.CustomServiceConfigSecrets,
 			instance.Spec.ExtraMounts,
 		),
-		Debug: instance.Spec.Debug.InitContainer,
+		Debug:       instance.Spec.Debug.InitContainer,
+		LoggingConf: false,
 	}
 	deployment.Spec.Template.Spec.InitContainers = manila.InitContainer(initContainerDetails)
 

--- a/pkg/manilascheduler/statefulset.go
+++ b/pkg/manilascheduler/statefulset.go
@@ -176,7 +176,8 @@ func StatefulSet(
 			instance.Spec.CustomServiceConfigSecrets,
 			instance.Spec.ExtraMounts,
 		),
-		Debug: instance.Spec.Debug.InitContainer,
+		Debug:       instance.Spec.Debug.InitContainer,
+		LoggingConf: true,
 	}
 
 	statefulset.Spec.Template.Spec.InitContainers = manila.InitContainer(initContainerDetails)

--- a/pkg/manilashare/statefulset.go
+++ b/pkg/manilashare/statefulset.go
@@ -193,7 +193,8 @@ func StatefulSet(
 			instance.Spec.CustomServiceConfigSecrets,
 			instance.Spec.ExtraMounts,
 		),
-		Debug: instance.Spec.Debug.InitContainer,
+		Debug:       instance.Spec.Debug.InitContainer,
+		LoggingConf: true,
 	}
 
 	statefulset.Spec.Template.Spec.InitContainers = manila.InitContainer(initContainerDetails)

--- a/templates/manila/bin/init.sh
+++ b/templates/manila/bin/init.sh
@@ -25,6 +25,7 @@ export DBUSER=${DatabaseUser:-"manila"}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export PASSWORD=${ManilaPassword:?"Please specify a ManilaPassword variable."}
 export TRANSPORTURL=${TransportURL:-""}
+export LOGGINGCONF=${LoggingConf:-"false"}
 
 export CUSTOMCONF=${CustomConf:-""}
 
@@ -34,6 +35,7 @@ MERGED_DIR=/var/lib/config-data/merged
 SVC_CFG=/etc/manila/manila.conf
 SVC_CFG_MERGED=/var/lib/config-data/merged/manila.conf
 SVC_CFG_MERGED_DIR=${MERGED_DIR}/manila.conf.d
+SVC_CFG_LOGGING=/etc/manila/logging.conf
 
 mkdir -p ${SVC_CFG_MERGED_DIR}
 
@@ -80,6 +82,14 @@ fi
 
 if [ -f ${CUSTOM_DIR}/custom.conf ]; then
     cp ${CUSTOM_DIR}/custom.conf ${SVC_CFG_MERGED_DIR}/03-service.conf
+fi
+
+if [ "$LOGGINGCONF" == "true" ]; then
+cat <<EOF >> ${SVC_CFG_MERGED_DIR}/03-service.conf
+
+[DEFAULT]
+log_config_append=${SVC_CFG_LOGGING}
+EOF
 fi
 
 SECRET_FILES="$(ls /var/lib/config-data/secret-*/* 2>/dev/null || true)"

--- a/templates/manila/config/logging.conf
+++ b/templates/manila/config/logging.conf
@@ -1,0 +1,34 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=stdout
+
+[formatters]
+keys=normal
+
+
+###########
+# Loggers #
+###########
+
+[logger_root]
+level=WARNING
+handlers=stdout
+
+################
+# Log Handlers #
+################
+
+[handler_stdout]
+class=StreamHandler
+level=WARNING
+formatter=normal
+args=(sys.stdout,)
+
+##################
+# Log Formatters #
+##################
+
+[formatter_normal]
+format=(%(name)s): %(asctime)s %(levelname)s %(message)s

--- a/templates/manila/config/manila-scheduler-config.json
+++ b/templates/manila/config/manila-scheduler-config.json
@@ -6,6 +6,12 @@
       "dest": "/etc/manila/manila.conf.d",
       "owner": "root:manila",
       "perm": "0750"
+    },
+    {
+      "source": "/var/lib/config-data/merged/logging.conf",
+      "dest": "/etc/manila/logging.conf",
+      "owner": "root:manila",
+      "perm": "0600"
     }
   ]
 }

--- a/templates/manila/config/manila-share-config.json
+++ b/templates/manila/config/manila-share-config.json
@@ -6,6 +6,12 @@
       "dest": "/etc/manila/manila.conf.d",
       "owner": "root:manila",
       "perm": "0750"
+    },
+    {
+      "source": "/var/lib/config-data/merged/logging.conf",
+      "dest": "/etc/manila/logging.conf",
+      "owner": "root:manila",
+      "perm": "0600"
     }
   ]
 }


### PR DESCRIPTION
Due to the recent failures with the new crc/sno versions, Pods are not allowed to log directly in /dev/stdout.
For this reason, like we've done in glance-operator, this patch imports a minimal logging.conf that is referenced in the main config file.