### PR TITLE
Add new samples based on tested backends

### DIFF
--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -1,0 +1,60 @@
+# Manila Backend Samples
+
+This directory includes a set of manila Backend configuration samples that use
+the `kustomize` configuration management tool available through the `oc
+kustomize` command.
+
+These samples are not meant to serve as deployment recommendations, just as
+working examples to serve as reference.
+
+For each backend there will be a `backend.yaml` file containing an overlay for
+the `OpenStackControlPlane` with just the storage related information.
+
+Backend pre-requirements will be listed in that same `backend.yaml` file.
+These can range from having to replace the storage system's address and
+credentials in a different yaml file, to having to create secrets.
+
+Currently available samples are:
+
+- ceph-nfs
+- cephfs
+- netapp
+- multibackend (a combination of the above)
+
+## CephFS example
+
+Once the OpenStack operators are running in your OpenShift cluster and
+the secret `osp-secret` is present, one can deploy OpenStack with a
+specific storage backend with single command.  For example for Ceph we can do:
+`oc kustomize cephfs | oc apply -f -`.
+
+The result of the `oc kustomize ceph` command is a complete
+`OpenStackControlPlane` manifest, and we can see its contents by redirecting it
+to a file or just piping it to `less`: `oc kustomize cephfs | less`.
+
+Creating the basic secret that our samples require can be done using the
+`install_yamls` target called `input`.
+
+A complete example when we already have CRC running would be:
+
+```
+$ cd install_yamls
+$ make ceph TIMEOUT=90
+$ make crc_storage openstack input
+$ cd ../manila-operator
+$ oc kustomize config/samples/backends/cephfs | oc apply -f -
+```
+
+## Adding new samples
+
+We are open to PRs adding new samples for other backends.
+
+Most backends will require credentials to access the storage, usually there are
+2 types of credentials:
+
+- Configuration options in `manila.conf`
+- External files
+
+You can find the right approach to each of them in the 'netapp' sample (for
+configuration parameters) and the `cephfs` (or ceph-nfs) sample (for providing
+files).

--- a/config/samples/backends/ceph-nfs/backend.yaml
+++ b/config/samples/backends/ceph-nfs/backend.yaml
@@ -1,0 +1,49 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: ""
+  manila:
+    enabled: true
+    template:
+      manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          debug = true
+          enabled_share_protocols=nfs
+        replicas: 1
+      manilaScheduler:
+        replicas: 1
+      manilaShares:
+        share1:
+          customServiceConfig: |
+              [DEFAULT]
+              enabled_share_backends=cephfsnfs
+              [cephfsnfs]
+              driver_handles_share_servers=False
+              share_backend_name=cephfs
+              share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
+              cephfs_auth_id=openstack
+              cephfs_cluster_name=ceph
+              cephfs_nfs_cluster_id=cephfs
+              cephfs_protocol_helper_type=NFS
+          replicas: 1
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+          - Manila
+          extraVolType: Ceph
+          volumes:
+          - name: ceph
+            projected:
+              sources:
+              - secret:
+                  name: ceph-conf-files
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true

--- a/config/samples/backends/ceph-nfs/ceph-secret.yaml
+++ b/config/samples/backends/ceph-nfs/ceph-secret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ceph-client-conf
+  namespace: openstack
+stringData:
+  ceph.client.openstack.keyring: |
+    [client.openstack]
+        key = <secret key>
+        caps mgr = "allow *"
+        caps mon = "profile rbd"
+        caps osd = "profile rbd pool=cephfs.metadata, pool=cephfs.data"
+  ceph.conf: |
+    [global]
+    fsid = 7a1719e8-9c59-49e2-ae2b-d7eb08c695d4
+    mon_host = 10.1.1.2,10.1.1.3,10.1.1.4

--- a/config/samples/backends/ceph-nfs/kustomization.yaml
+++ b/config/samples/backends/ceph-nfs/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../bases/openstack
+patches:
+  - backend.yaml

--- a/config/samples/backends/cephfs/backend.yaml
+++ b/config/samples/backends/cephfs/backend.yaml
@@ -1,0 +1,52 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: ""
+  manila:
+    enabled: true
+    template:
+      manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          debug = true
+          enabled_share_protocols=cephfs
+        replicas: 1
+      manilaScheduler:
+        replicas: 1
+      manilaShares:
+        share1:
+          customServiceConfig: |
+              [DEFAULT]
+              enabled_share_backends=cephfs
+              [cephfs]
+              driver_handles_share_servers=False
+              share_backend_name=cephfs
+              share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
+              cephfs_conf_path=/etc/ceph/ceph.conf
+              cephfs_auth_id=openstack
+              cephfs_cluster_name=ceph
+              cephfs_enable_snapshots=True
+              cephfs_ganesha_server_is_remote=False
+              cephfs_volume_mode=0755
+              cephfs_protocol_helper_type=CEPHFS
+          replicas: 1
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+          - Manila
+          extraVolType: Ceph
+          volumes:
+          - name: ceph
+            projected:
+              sources:
+              - secret:
+                  name: ceph-conf-files
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true

--- a/config/samples/backends/cephfs/ceph-secret.yaml
+++ b/config/samples/backends/cephfs/ceph-secret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ceph-client-conf
+  namespace: openstack
+stringData:
+  ceph.client.openstack.keyring: |
+    [client.openstack]
+        key = <secret key>
+        caps mgr = "allow *"
+        caps mon = "profile rbd"
+        caps osd = "profile rbd pool=cephfs.metadata, pool=cephfs.data"
+  ceph.conf: |
+    [global]
+    fsid = 7a1719e8-9c59-49e2-ae2b-d7eb08c695d4
+    mon_host = 10.1.1.2,10.1.1.3,10.1.1.4

--- a/config/samples/backends/cephfs/kustomization.yaml
+++ b/config/samples/backends/cephfs/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../bases/openstack
+patches:
+  - backend.yaml

--- a/config/samples/backends/multibackend/backend.yaml
+++ b/config/samples/backends/multibackend/backend.yaml
@@ -1,0 +1,84 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: ""
+  manila:
+    enabled: true
+    template:
+      manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          debug = true
+          enabled_share_protocols=nfs,cephfs,cifs
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-manila-api:current-tripleo
+      manilaScheduler:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-manila-scheduler:current-tripleo
+      manilaShares:
+        share1:
+          customServiceConfig: |
+              [DEFAULT]
+              enabled_share_backends=cephfsnfs
+              [cephfsnfs]
+              driver_handles_share_servers=False
+              share_backend_name=cephfs
+              share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
+              cephfs_auth_id=openstack
+              cephfs_cluster_name=ceph
+              cephfs_nfs_cluster_id=cephfs
+              cephfs_protocol_helper_type=NFS
+          containerImage: quay.io/tripleozedcentos9/openstack-manila-share:current-tripleo
+          replicas: 1
+        share2:
+          customServiceConfig: |
+              [DEFAULT]
+              enabled_share_backends=cephfs
+              [cephfs]
+              driver_handles_share_servers=False
+              share_backend_name=cephfs
+              share_driver=manila.share.drivers.cephfs.driver.CephFSDriver
+              cephfs_conf_path=/etc/ceph/ceph.conf
+              cephfs_auth_id=openstack
+              cephfs_cluster_name=ceph
+              cephfs_enable_snapshots=True
+              cephfs_ganesha_server_is_remote=False
+              cephfs_volume_mode=0755
+              cephfs_protocol_helper_type=CEPHFS
+          containerImage: quay.io/tripleozedcentos9/openstack-manila-share:current-tripleo
+          replicas: 1
+        share3:
+          customServiceConfig: |
+            [DEFAULT]
+            debug = true
+            enabled_share_backends=netapp
+            [netapp]
+            driver_handles_share_servers=False
+            share_backend_name=netapp
+            share_driver=manila.share.drivers.netapp.common.NetAppDriver
+            netapp_storage_family=ontap_cluster
+            netapp_transport_type=http
+          customServiceConfigSecrets:
+            - osp-secret-manila-netapp
+          containerImage: quay.io/tripleozedcentos9/openstack-manila-share:current-tripleo
+          replicas: 1
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+          - Manila
+          extraVolType: Ceph
+          volumes:
+          - name: ceph
+            projected:
+              sources:
+              - secret:
+                  name: ceph-conf-files
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true

--- a/config/samples/backends/multibackend/kustomization.yaml
+++ b/config/samples/backends/multibackend/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../bases/openstack
+patches:
+  - backend.yaml

--- a/config/samples/backends/netapp/backend.yaml
+++ b/config/samples/backends/netapp/backend.yaml
@@ -1,0 +1,50 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: ""
+  manila:
+    enabled: true
+    template:
+      manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          debug = true
+          enabled_share_protocols=cifs
+        replicas: 1
+      manilaScheduler:
+        replicas: 1
+      manilaShares:
+        share1:
+          customServiceConfig: |
+            [DEFAULT]
+            debug = true
+            enabled_share_backends=netapp
+            [netapp]
+            driver_handles_share_servers=False
+            share_backend_name=netapp
+            share_driver=manila.share.drivers.netapp.common.NetAppDriver
+            netapp_storage_family=ontap_cluster
+            netapp_transport_type=http
+          customServiceConfigSecrets:
+            - osp-secret-manila-netapp
+          replicas: 1
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+          - Manila
+          extraVolType: Ceph
+          volumes:
+          - name: ceph
+            projected:
+              sources:
+              - secret:
+                  name: ceph-conf-files
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true

--- a/config/samples/backends/netapp/kustomization.yaml
+++ b/config/samples/backends/netapp/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../bases/openstack
+patches:
+  - backend.yaml

--- a/config/samples/backends/netapp/osp_secret_napp.yaml
+++ b/config/samples/backends/netapp/osp_secret_napp.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: osp-secret-manila-netapp
+  namespace: openstack
+stringData:
+  netapp-secrets.conf : |
+    [netapp]
+    netapp_server_hostname = 1.2.3.4
+    netapp_login = fancy_netapp_user
+    netapp_password = secret_netapp_password
+    netapp_vserver = mydatavserver


### PR DESCRIPTION
This patch improves the manila-operator `samples/` providing a few `per-backend` related `ctlplane` examples, as well as combining them together to show how `multibackend` can be configured.