### PR TITLE
Fix manila-api pod name

### DIFF
--- a/pkg/manilaapi/deployment.go
+++ b/pkg/manilaapi/deployment.go
@@ -81,7 +81,7 @@ func Deployment(
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manila.ServiceName,
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},

--- a/tests/functional/manila_controller_test.go
+++ b/tests/functional/manila_controller_test.go
@@ -369,7 +369,7 @@ var _ = Describe("Manila controller", func() {
 		})
 		It("Check the resulting endpoints of the generated sub-CRs", func() {
 			th.SimulateDeploymentReadyWithPods(
-				manilaTest.Instance,
+				manilaTest.ManilaAPI,
 				map[string][]string{manilaName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)
 			th.SimulateStatefulSetReplicaReadyWithPods(


### PR DESCRIPTION
Right now the manila-api pod has no `-api` suffix in its name and it might result confusing for the human operator.
This patch updates the pod name using `instance.Name` where the `-api` suffix is actually present [1].

[1] https://github.com/openstack-k8s-operators/manila-operator/blob/main/controllers/manila_controller.go#L819