### PR TITLE
Fix inconsistent package name for functional tests

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -1,17 +1,19 @@
 /*
 Copyright 2023.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-package functional
+package functional_test
 
 import (
 	"fmt"

--- a/tests/functional/manila_controller_test.go
+++ b/tests/functional/manila_controller_test.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package functional
+package functional_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/tests/functional/manila_test_data.go
+++ b/tests/functional/manila_test_data.go
@@ -13,9 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-// Package functional implements the envTest coverage for manila-operator
-package functional
+package functional_test
 
 import (
 	"fmt"

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package functional
+package functional_test
 
 import (
 	"context"


### PR DESCRIPTION
The package name for functional tests is functional_test instead of functional in most of our operators. Let's use the consistent name.