### PR TITLE
Run make gowork as part of the postUpgrade tasks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
     }
   ],
   "postUpgradeTasks": {
-    "commands": ["go mod tidy", "make manifests generate"],
+    "commands": ["make gowork", "make tidy", "make manifests generate"],
     "fileFilters": ["go.mod", "go.sum", "**/*.go", "**/*.yaml"],
     "executionMode": "update"
   }


### PR DESCRIPTION
`precommit-check` seems to fail on multiple renovate related `PRs` due to the fact that `make gowork` is missing. 
By adding this target we can make sure to update both modules in the root of the project and in the `api/`.