### PR TITLE
Do not update mergo module

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,7 @@
     },
     {
       "groupName": "misc",
-      "matchPackagePatterns": ["^github.com/operator-framework/api", "^github.com/ghodss", "^github.com/go-logr/logr", "^github.com/imdario/mergo", "^go.uber.org/zap"],
+      "matchPackagePatterns": ["^github.com/operator-framework/api", "^github.com/ghodss", "^github.com/go-logr/logr", "^go.uber.org/zap"],
       "enabled": true
     }
   ],


### PR DESCRIPTION
imdario/mergo is an indirect dependency that let our renovate patches fail. The module has been recently moved to a vanity url, and this caused a lot of issues w/ renovate.
Removing it here as an explicit dependency as it will be updated as part of other module updates.