### PR TITLE
Fix pre-commit in renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
   ],
   "postUpgradeTasks": {
     "commands": ["make gowork", "make tidy", "make manifests generate"],
-    "fileFilters": ["go.mod", "go.sum", "**/*.go", "**/*.yaml"],
+    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
     "executionMode": "update"
   }
 }


### PR DESCRIPTION
Renovate PRs where a module is updated in both api/ and go.mod present in the root of the projects keep failing because of the missing filter in api/go.{mod,sum} (e.g., see [1])
This patch fixes that behavior and [1] should be unblocked.

[1] https://github.com/openstack-k8s-operators/manila-operator/pull/82