### PR TITLE
Configure renovate to pin k8s and controller-runtime for dev preview

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -70,3 +70,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+// mschuppert: map to latest commit from release-4.13 tag
+// must consistent within modules and service operators
+replace github.com/openshift/api => github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 //allow-merging

--- a/api/go.sum
+++ b/api/go.sum
@@ -221,8 +221,8 @@ github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
-github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
-github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230714104628-12cc1e43cccd h1:4/eFA2XpvsjnGkKgLHtfvA1Wpb6YaNvFL6wjdOdEJ2k=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230714104628-12cc1e43cccd/go.mod h1:v6ZQBtTtQi7OMvOHGbScOLyyfM70is5mu0ZM0IsIJKE=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230714104628-12cc1e43cccd h1:C0O5xg81rRF4juVzajY1izQTf8UGhIgMk5AWI8Cxk4A=

--- a/go.mod
+++ b/go.mod
@@ -92,3 +92,7 @@ require (
 replace github.com/openstack-k8s-operators/manila-operator/api => ./api
 
 replace sigs.k8s.io/structured-merge-diff/v4 v4.2.2 => sigs.k8s.io/structured-merge-diff/v4 v4.2.1
+
+// mschuppert: map to latest commit from release-4.13 tag
+// must consistent within modules and service operators
+replace github.com/openshift/api => github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 //allow-merging

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
-github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
-github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230717054643-27820dc98d9b h1:PyoDPkMtoyONKTF1YNDBRMtDgidAOBwSs3FLEbic300=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230717054643-27820dc98d9b/go.mod h1:uuwrYRvdp5VwsWJpA47MnDT+UQjX1UWixagit7FzwV8=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230717135919-f75717ebcf92 h1:79eF+ZMI+/Ax7oVaNDTOSYsOxz80eRU1DG0HmO2Ukzk=

--- a/renovate.json
+++ b/renovate.json
@@ -26,9 +26,16 @@
     },
     {
       "groupName": "k8s.io",
-      "matchPackagePatterns": ["^k8s.io", "^sigs.k8s.io"],
-      "allowedVersions": "< 1.0.0",
+      "matchPackagePatterns": ["^k8s.io"],
+      "excludePackagePatterns": ["^k8s.io/kube-openapi"],
+      "allowedVersions": "< 0.27.0",
       "enabled": true
+    },
+    {
+       "groupName": "sigs.k8s.io/controller-runtime",
+       "matchPackagePatterns": ["^sigs.k8s.io/controller-runtime"],
+       "allowedVersions": "< 0.15.0",
+       "enabled": true
     },
     {
       "groupName": "misc",


### PR DESCRIPTION
- pin k8s and controller runtime to be in sync with lib-common and configure renovate to keep the pin
- pin ocp api version to a hash in sync with lib-common instead of the nonexistent v3.9.0+incompatible tag
