### PR TITLE
Remove config/manager/kustomization.yaml from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ testbin/*
 #Operator SDK generated files
 /bundle/
 bundle.Dockerfile
-config/manager/kustomization.yaml
 
 # Common CI tools repository
 CI_TOOLS_REPO


### PR DESCRIPTION
This file is required to build a bundle image. The file is actually maintained in the repository.