### PR TITLE
Replace RabbitMqTransportURLReady by common condition

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -19,9 +19,6 @@ import (
 // Manila Condition Types used by API objects.
 const (
 
-	// ManilaRabbitMqTransportURLReadyCondition Status=True condition which indicates if the RabbitMQ TransportURLUrl is ready
-	ManilaRabbitMqTransportURLReadyCondition condition.Type = "ManilaRabbitMqTransportURLReady"
-
 	// ManilaAPIReadyCondition Status=True condition which indicates if the ManilaAPI is configured and operational
 	ManilaAPIReadyCondition condition.Type = "ManilaAPIReady"
 
@@ -30,24 +27,6 @@ const (
 
 	// ManilaShareReadyCondition Status=True condition which indicates if the ManilaShare is configured and operational
 	ManilaShareReadyCondition condition.Type = "ManilaShareReady"
-)
-
-// Manila Reasons used by API objects.
-const (
-
-	// ManilaRabbitMqTransportURLReady condition messages
-	//
-	// ManilaRabbitMqTransportURLReadyInitMessage
-	ManilaRabbitMqTransportURLReadyInitMessage = "ManilaRabbitMqTransportURL not started"
-
-	// ManilaRabbitMqTransportURLReadyRunningMessage
-	ManilaRabbitMqTransportURLReadyRunningMessage = "ManilaRabbitMqTransportURL creation in progress"
-
-	// ManilaRabbitMqTransportURLReadyMessage
-	ManilaRabbitMqTransportURLReadyMessage = "ManilaRabbitMqTransportURL successfully created"
-
-	// ManilaRabbitMqTransportURLReadyErrorMessage
-	ManilaRabbitMqTransportURLReadyErrorMessage = "ManilaRabbitMqTransportURL error occured %s"
 )
 
 // Common Messages used by API objects.

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -170,7 +170,7 @@ func (r *ManilaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		cl := condition.CreateList(
 			condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
 			condition.UnknownCondition(condition.DBSyncReadyCondition, condition.InitReason, condition.DBSyncReadyInitMessage),
-			condition.UnknownCondition(manilav1beta1.ManilaRabbitMqTransportURLReadyCondition, condition.InitReason, manilav1beta1.ManilaRabbitMqTransportURLReadyInitMessage),
+			condition.UnknownCondition(condition.RabbitMqTransportURLReadyCondition, condition.InitReason, condition.RabbitMqTransportURLReadyInitMessage),
 			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 			condition.UnknownCondition(manilav1beta1.ManilaAPIReadyCondition, condition.InitReason, manilav1beta1.ManilaAPIReadyInitMessage),
 			condition.UnknownCondition(manilav1beta1.ManilaSchedulerReadyCondition, condition.InitReason, manilav1beta1.ManilaSchedulerReadyInitMessage),
@@ -439,10 +439,10 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			manilav1beta1.ManilaRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			manilav1beta1.ManilaRabbitMqTransportURLReadyErrorMessage,
+			condition.RabbitMqTransportURLReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
 	}
@@ -456,14 +456,14 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 	if instance.Status.TransportURLSecret == "" {
 		r.Log.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			manilav1beta1.ManilaRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
-			manilav1beta1.ManilaRabbitMqTransportURLReadyRunningMessage))
+			condition.RabbitMqTransportURLReadyRunningMessage))
 		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 
-	instance.Status.Conditions.MarkTrue(manilav1beta1.ManilaRabbitMqTransportURLReadyCondition, manilav1beta1.ManilaRabbitMqTransportURLReadyMessage)
+	instance.Status.Conditions.MarkTrue(condition.RabbitMqTransportURLReadyCondition, condition.RabbitMqTransportURLReadyMessage)
 
 	// end transportURL
 


### PR DESCRIPTION
We have added the common RabbitMqTransportURLReady to lib-common to reduce duplicate implementations.

Depends-on: https://github.com/openstack-k8s-operators/lib-common/pull/300