### PR TITLE
Ensure required spec fields are given

### DIFF
--- a/api/bases/manila.openstack.org_manilaapis.yaml
+++ b/api/bases/manila.openstack.org_manilaapis.yaml
@@ -916,8 +916,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/api/bases/manila.openstack.org_manilaapis.yaml
+++ b/api/bases/manila.openstack.org_manilaapis.yaml
@@ -916,6 +916,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -1087,6 +1087,7 @@ spec:
             - manilaAPI
             - manilaScheduler
             - rabbitMqClusterName
+            - secret
             type: object
           status:
             properties:

--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -1084,6 +1084,7 @@ spec:
                 default: manila
                 type: string
             required:
+            - databaseInstance
             - manilaAPI
             - manilaScheduler
             - rabbitMqClusterName

--- a/api/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/api/bases/manila.openstack.org_manilaschedulers.yaml
@@ -891,6 +891,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/api/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/api/bases/manila.openstack.org_manilaschedulers.yaml
@@ -891,8 +891,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/api/bases/manila.openstack.org_manilashares.yaml
+++ b/api/bases/manila.openstack.org_manilashares.yaml
@@ -891,6 +891,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/api/bases/manila.openstack.org_manilashares.yaml
+++ b/api/bases/manila.openstack.org_manilashares.yaml
@@ -891,8 +891,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -47,9 +47,9 @@ type ManilaTemplate struct {
 	// TODO: -> implement needs work in mariadb-operator, right now only manila
 	DatabaseUser string `json:"databaseUser,omitempty"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for ManilaDatabasePassword, AdminPassword
-	Secret string `json:"secret,omitempty"`
+	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: ManilaDatabasePassword, service: ManilaPassword}

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -38,7 +38,7 @@ type ManilaSpec struct {
 	// MariaDB instance name
 	// Right now required by the maridb-operator to get the credentials from the instance to create the DB
 	// Might not be required in future
-	DatabaseInstance string `json:"databaseInstance,omitempty"`
+	DatabaseInstance string `json:"databaseInstance"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=rabbitmq

--- a/api/v1beta1/manilaapi_types.go
+++ b/api/v1beta1/manilaapi_types.go
@@ -48,12 +48,13 @@ type ManilaAPISpec struct {
 	// Input parameters for the ManilaAPI service
 	ManilaAPITemplate `json:",inline"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// DatabaseHostname - Manila Database Hostname
-	DatabaseHostname string `json:"databaseHostname,omitempty"`
+	DatabaseHostname string `json:"databaseHostname"`
 
+	// +kubebuilder:validation:Required
 	// Secret containing RabbitMq transport URL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+	TransportURLSecret string `json:"transportURLSecret"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/api/v1beta1/manilascheduler_types.go
+++ b/api/v1beta1/manilascheduler_types.go
@@ -47,12 +47,13 @@ type ManilaSchedulerSpec struct {
 	// Input parameters for the ManilaScheduler service
 	ManilaSchedulerTemplate `json:",inline"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// DatabaseHostname - manila Database Hostname
-	DatabaseHostname string `json:"databaseHostname,omitempty"`
+	DatabaseHostname string `json:"databaseHostname"`
 
+	// +kubebuilder:validation:Required
 	// Secret containing RabbitMq transport URL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+	TransportURLSecret string `json:"transportURLSecret"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/api/v1beta1/manilashare_types.go
+++ b/api/v1beta1/manilashare_types.go
@@ -47,12 +47,13 @@ type ManilaShareSpec struct {
 	// Input parameters for the ManilaScheduler service
 	ManilaShareTemplate `json:",inline"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// DatabaseHostname - manila Database Hostname
-	DatabaseHostname string `json:"databaseHostname,omitempty"`
+	DatabaseHostname string `json:"databaseHostname"`
 
+	// +kubebuilder:validation:Required
 	// Secret containing RabbitMq transport URL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+	TransportURLSecret string `json:"transportURLSecret"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/config/crd/bases/manila.openstack.org_manilaapis.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaapis.yaml
@@ -916,8 +916,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/config/crd/bases/manila.openstack.org_manilaapis.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaapis.yaml
@@ -916,6 +916,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -1087,6 +1087,7 @@ spec:
             - manilaAPI
             - manilaScheduler
             - rabbitMqClusterName
+            - secret
             type: object
           status:
             properties:

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -1084,6 +1084,7 @@ spec:
                 default: manila
                 type: string
             required:
+            - databaseInstance
             - manilaAPI
             - manilaScheduler
             - rabbitMqClusterName

--- a/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
@@ -891,6 +891,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
@@ -891,8 +891,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/config/crd/bases/manila.openstack.org_manilashares.yaml
+++ b/config/crd/bases/manila.openstack.org_manilashares.yaml
@@ -891,6 +891,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/config/crd/bases/manila.openstack.org_manilashares.yaml
+++ b/config/crd/bases/manila.openstack.org_manilashares.yaml
@@ -891,8 +891,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/config/samples/manila_v1beta1_manilaapi.yaml
+++ b/config/samples/manila_v1beta1_manilaapi.yaml
@@ -3,4 +3,5 @@ kind: ManilaAPI
 metadata:
   name: manilaapi-sample
 spec:
-  # TODO(user): Add fields here
+  databaseHostname: openstack
+  transportURLSecret: rabbitmq-transport-url-manila-manila-transport

--- a/config/samples/manila_v1beta1_manilascheduler.yaml
+++ b/config/samples/manila_v1beta1_manilascheduler.yaml
@@ -3,4 +3,5 @@ kind: ManilaScheduler
 metadata:
   name: manilascheduler-sample
 spec:
-  # TODO(user): Add fields here
+  databaseHostname: openstack
+  transportURLSecret: rabbitmq-transport-url-manila-manila-transport

--- a/config/samples/manila_v1beta1_manilashare.yaml
+++ b/config/samples/manila_v1beta1_manilashare.yaml
@@ -3,4 +3,5 @@ kind: ManilaShare
 metadata:
   name: manilashare-sample
 spec:
-  # TODO(user): Add fields here
+  databaseHostname: openstack
+  transportURLSecret: rabbitmq-transport-url-manila-manila-transport

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.1
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230712110258-e79c738676c9
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	k8s.io/api v0.26.7
 	k8s.io/apimachinery v0.26.7
 	k8s.io/client-go v0.26.7
@@ -24,7 +25,6 @@ require (
 require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/tools v0.9.3 // indirect
 )

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -15,6 +15,8 @@ package functional
 
 import (
 	"fmt"
+	"golang.org/x/exp/maps"
+
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,37 +71,64 @@ func GetDefaultManilaSpec() map[string]interface{} {
 	return map[string]interface{}{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
-		"manilaAPI":        GetDefaultManilaAPISpec(),
-		"manilaScheduler":  GetDefaultManilaSchedulerSpec(),
-		"manilaShare":      GetDefaultManilaShareSpec(),
+		"manilaAPI":        GetDefaultManilaAPITemplate(),
+		"manilaScheduler":  GetDefaultManilaSchedulerTemplate(),
+		"manilaShare":      GetDefaultManilaShareTemplate(),
+	}
+}
+
+func GetDefaultManilaAPITemplate() map[string]interface{} {
+	return map[string]interface{}{
+		"replicas":       1,
+		"containerImage": manilaTest.ContainerImage,
 	}
 }
 
 func GetDefaultManilaAPISpec() map[string]interface{} {
+	spec := GetDefaultManilaAPITemplate()
+	maps.Copy(spec, map[string]interface{}{
+		"databaseHostname":   "openstack",
+		"secret":             SecretName,
+		"serviceAccount":     manilaTest.ManilaSA.Name,
+		"transportURLSecret": "rabbitmq-transport-url-manila-manila-transport",
+	})
+	return spec
+}
+
+func GetDefaultManilaSchedulerTemplate() map[string]interface{} {
 	return map[string]interface{}{
-		"secret":         SecretName,
 		"replicas":       1,
 		"containerImage": manilaTest.ContainerImage,
-		"serviceAccount": manilaTest.ManilaSA.Name,
 	}
 }
 
 func GetDefaultManilaSchedulerSpec() map[string]interface{} {
+	spec := GetDefaultManilaSchedulerTemplate()
+	maps.Copy(spec, map[string]interface{}{
+		"databaseHostname":   "openstack",
+		"secret":             SecretName,
+		"serviceAccount":     manilaTest.ManilaSA.Name,
+		"transportURLSecret": "rabbitmq-transport-url-manila-manila-transport",
+	})
+	return spec
+}
+
+func GetDefaultManilaShareTemplate() map[string]interface{} {
 	return map[string]interface{}{
-		"secret":         SecretName,
 		"replicas":       1,
 		"containerImage": manilaTest.ContainerImage,
-		"serviceAccount": manilaTest.ManilaSA.Name,
 	}
 }
 
 func GetDefaultManilaShareSpec() map[string]interface{} {
-	return map[string]interface{}{
-		"secret":         SecretName,
-		"replicas":       1,
-		"containerImage": manilaTest.ContainerImage,
-		"serviceAccount": manilaTest.ManilaSA.Name,
-	}
+	spec := GetDefaultManilaShareTemplate()
+	maps.Copy(spec, map[string]interface{}{
+		"databaseHostname":   "openstack",
+		"secret":             SecretName,
+		"serviceAccount":     manilaTest.ManilaSA.Name,
+		"transportURLSecret": "rabbitmq-transport-url-manila-manila-transport",
+	})
+	return spec
 }
 
 func GetManila(name types.NamespacedName) *manilav1.Manila {


### PR DESCRIPTION
Several spec fields with optional mark are in fact required to deploy services.

This ensures these spec fields are required so that the proper validation failure is returned early.