### PR TITLE
Support disconnected network environments

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,67 +1,13 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/manila-operator.clusterserviceversion.yaml"
-
 echo "Creating manila operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-    digest_image=""
-    echo "CSV line: ${csv_image}"
-
-    # case where @ is in the csv_image image
-    if [[ "$csv_image" =~ .*"@".* ]]; then
-        delimeter='@'
-    else
-        delimeter=':'
-    fi
-
-    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-    if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-        echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-        sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-    else
-        digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-        echo "Base image: $base_image"
-        if [ -n "$digest_image" ]; then
-            echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-            sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-        else
-            echo "$base_image${delimeter}$tag_image not changed"
-        fi
-    fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -174,9 +174,9 @@ type MetalLBConfig struct {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Manila defaults with them
 	manilaDefaults := ManilaDefaults{
-		APIContainerImageURL:       util.GetEnvVar("MANILA_API_IMAGE_URL_DEFAULT", ManilaAPIContainerImage),
-		SchedulerContainerImageURL: util.GetEnvVar("MANILA_SCHEDULER_IMAGE_URL_DEFAULT", ManilaSchedulerContainerImage),
-		ShareContainerImageURL:     util.GetEnvVar("MANILA_SHARE_IMAGE_URL_DEFAULT", ManilaShareContainerImage),
+		APIContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_MANILA_API_IMAGE_URL_DEFAULT", ManilaAPIContainerImage),
+		SchedulerContainerImageURL: util.GetEnvVar("RELATED_IMAGE_MANILA_SCHEDULER_IMAGE_URL_DEFAULT", ManilaSchedulerContainerImage),
+		ShareContainerImageURL:     util.GetEnvVar("RELATED_IMAGE_MANILA_SHARE_IMAGE_URL_DEFAULT", ManilaShareContainerImage),
 	}
 
 	SetupManilaDefaults(manilaDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,9 +11,9 @@ spec:
       containers:
       - name: manager
         env:
-        - name: MANILA_API_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_MANILA_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-manila-api:current-podified
-        - name: MANILA_SCHEDULER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_MANILA_SCHEDULER_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-manila-scheduler:current-podified
-        - name: MANILA_SHARE_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_MANILA_SHARE_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-manila-share:current-podified

--- a/config/manifests/bases/manila-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/manila-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     operators.operatorframework.io/operator-type: non-standalone
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: manila-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/tests/functional/manila_controller_test.go
+++ b/tests/functional/manila_controller_test.go
@@ -213,10 +213,10 @@ var _ = Describe("Manila controller", func() {
 		})
 		It("has the expected container image defaults", func() {
 			manilaDefault := GetManila(manilaTest.Instance)
-			Expect(manilaDefault.Spec.ManilaAPI.ManilaServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("MANILA_API_IMAGE_URL_DEFAULT", manilav1.ManilaAPIContainerImage)))
-			Expect(manilaDefault.Spec.ManilaScheduler.ManilaServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("MANILA_SCHEDULER_IMAGE_URL_DEFAULT", manilav1.ManilaSchedulerContainerImage)))
+			Expect(manilaDefault.Spec.ManilaAPI.ManilaServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_MANILA_API_IMAGE_URL_DEFAULT", manilav1.ManilaAPIContainerImage)))
+			Expect(manilaDefault.Spec.ManilaScheduler.ManilaServiceTemplate.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_MANILA_SCHEDULER_IMAGE_URL_DEFAULT", manilav1.ManilaSchedulerContainerImage)))
 			for _, share := range manilaDefault.Spec.ManilaShares {
-				Expect(share.ContainerImage).To(Equal(util.GetEnvVar("MANILA_SHARE_IMAGE_URL_DEFAULT", manilav1.ManilaShareContainerImage)))
+				Expect(share.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_MANILA_SHARE_IMAGE_URL_DEFAULT", manilav1.ManilaShareContainerImage)))
 			}
 		})
 	})

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -21,7 +21,6 @@ spec:
       dbInitContainer: false
       dbSync: false
    manilaAPI:
-      containerImage: quay.io/podified-antelope-centos9/openstack-manila-api:current-podified
       customServiceConfig: |
          [DEFAULT]
          enabled_share_protocols = cephfs
@@ -31,7 +30,6 @@ spec:
       replicas: 1
       resources: {}
    manilaScheduler:
-      containerImage: quay.io/podified-antelope-centos9/openstack-manila-scheduler:current-podified
       customServiceConfig: '# add your customization here'
       debug:
          initContainer: false
@@ -40,7 +38,6 @@ spec:
       resources: {}
    manilaShares:
       share1:
-         containerImage: quay.io/podified-antelope-centos9/openstack-manila-share:current-podified
          replicas: 1
          resources: {}
          customServiceConfig: |
@@ -124,3 +121,36 @@ status:
    manilaSharesReadyCounts:
       share1: 1
    transportURLSecret: rabbitmq-transport-url-manila-manila-transport
+---
+# when using image digests the containerImage URLs are SHA's so we verify them with a script
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
+      imageTuples=$(oc get -n openstack-operators deployment manila-operator-controller-manager -o go-template="$tupleTemplate")
+      # format of imageTuple is: RELATED_IMAGE_MANILA_<service>#<image URL with SHA> separated by newlines
+      for ITEM in $(echo $imageTuples); do
+        # it is an image
+        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+          NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_MANILA_\([^_]*\)_.*|\1|')
+          IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
+          template='{{.spec.containerImage}}'
+          case $NAME in
+            API)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE manilaapi manila-api -o go-template="$template")
+              ;;
+            SHARE)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE manilashares manila-share-share1 -o go-template="$template")
+              ;;
+            SCHEDULER)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE manilascheduler manila-scheduler -o go-template="$template")
+              ;;
+          esac
+          if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
+            echo "$NAME image does not equal $VALUE"
+            exit 1
+          fi
+        fi
+      done
+      exit 0


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure registry)