### PR TITLE
Change kuttl tests to run in arbitrary namespace

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -18,7 +18,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-manila
-namespace: openstack
+namespace: manila-kuttl-tests
 timeout: 180
 parallel: 1
 suppress:

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -10,7 +10,6 @@ apiVersion: manila.openstack.org/v1beta1
 kind: Manila
 metadata:
    name: manila
-   namespace: openstack
 spec:
    customServiceConfig: |
       [DEFAULT]

--- a/tests/kuttl/tests/deploy/01-deploy-manila.yaml
+++ b/tests/kuttl/tests/deploy/01-deploy-manila.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 commands:
    - script: |
         cp ../../../../config/samples/manila_v1beta1_manila.yaml deployment
-        oc kustomize deployment | oc apply -n openstack -f -
+        oc kustomize deployment | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/deploy/03-cleanup-manila.yaml
+++ b/tests/kuttl/tests/deploy/03-cleanup-manila.yaml
@@ -4,4 +4,3 @@ delete:
 - apiVersion: manila.openstack.org/v1beta1
   kind: Manila
   name: manila
-  namespace: openstack

--- a/tests/kuttl/tests/deploy/03-errors.yaml
+++ b/tests/kuttl/tests/deploy/03-errors.yaml
@@ -7,4 +7,3 @@ apiVersion: manila.openstack.org/v1beta1
 kind: Manila
 metadata:
    name: manila
-   namespace: openstack

--- a/tests/kuttl/tests/deploy/deployment/kustomization.yaml
+++ b/tests/kuttl/tests/deploy/deployment/kustomization.yaml
@@ -7,6 +7,9 @@ patches:
         - op: replace
           path: /spec/secret
           value: osp-secret
+        - op: replace
+          path: /metadata/namespace
+          value: manila-kuttl-tests
      target:
         kind: Manila
 patchesStrategicMerge:


### PR DESCRIPTION
This change is based on https://github.com/openstack-k8s-operators/manila-operator/pull/122 where the idea is to allow kuttl tests to run in any namespace.

Co-authored-by: Vida Haririan <vhariria@redhat.com>