### PR TITLE
Recalculate deployment status

### DIFF
--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -715,6 +715,12 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 
 	if instance.Status.ReadyCount > 0 {
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+	} else {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DeploymentReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DeploymentReadyRunningMessage))
 	}
 	// create Deployment - end
 

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -466,6 +466,12 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 
 	if instance.Status.ReadyCount > 0 {
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+	} else {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DeploymentReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DeploymentReadyRunningMessage))
 	}
 	// create StatefulSet - end
 

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -461,8 +461,14 @@ func (r *ManilaShareReconciler) reconcileNormal(ctx context.Context, instance *m
 		return ctrl.Result{}, err
 	}
 
-	if instance.Status.ReadyCount > 0 {
+	if instance.Status.ReadyCount > 0 || *instance.Spec.Replicas == 0 {
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+	} else {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DeploymentReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DeploymentReadyRunningMessage))
 	}
 	// create StatefulSet - end
 


### PR DESCRIPTION
If we don't have any `Manila` instance in the deployment, we should mark the deployment condition to False. If `Manila` is enabled in the `OpenStack` control plane, we always need at least 1 replica of API and scheduler, while the `manilaShare` service can be rolled out later in time (according to the backends, hence we should progress even if `ReadyCount` in the `Spec` is zero).
As we've done in `GlanceAPI` through [1], this patch adds the same behavior to the Manila operator.

[1] https://github.com/openstack-k8s-operators/glance-operator/pull/311