### PR TITLE
Add the new CronJob to the deployed resources that kuttl asserts

### DIFF
--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -46,6 +46,9 @@ spec:
                 type: string
               debug:
                 properties:
+                  dbPurge:
+                    default: false
+                    type: boolean
                   dbSync:
                     default: false
                     type: boolean

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -121,6 +121,10 @@ type ManilaDebug struct {
 	// +kubebuilder:default=false
 	// dbSync enable debug
 	DBSync bool `json:"dbSync,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// dbPurge enable debug on the DBPurge CronJob
+	DBPurge bool `json:"dbPurge,omitempty"`
 }
 
 // ManilaServiceDebug indicates whether certain stages of Manila service

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -46,6 +46,9 @@ spec:
                 type: string
               debug:
                 properties:
+                  dbPurge:
+                    default: false
+                    type: boolean
                   dbSync:
                     default: false
                     type: boolean

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -121,6 +121,45 @@ status:
       share1: 1
    transportURLSecret: rabbitmq-transport-url-manila-manila-transport
 ---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: manila-cron
+spec:
+  jobTemplate:
+    metadata:
+      labels:
+        service: manila
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        spec:
+          containers:
+          - args:
+            - -c
+            - /usr/bin/manila-manage --config-dir /etc/manila/manila.conf.d
+              db purge 30
+            command:
+            - /bin/bash
+            name: manila-cron
+            volumeMounts:
+            - mountPath: /etc/manila/manila.conf.d
+              name: db-purge-config-data
+              readOnly: true
+          serviceAccount: manila-manila
+          serviceAccountName: manila-manila
+          volumes:
+          - name: db-purge-config-data
+            secret:
+              defaultMode: 420
+              items:
+              - key: 00-config.conf
+                path: 00-config.conf
+              secretName: manila-config-data
+  schedule: 1 0 * * *
+  suspend: false
+---
 # when using image digests the containerImage URLs are SHA's so we verify them with a script
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert


### PR DESCRIPTION
We are able to run the `DBPurge` `CronJob` using the `--debug` option. 
This PR reworks the way the `DBPurgeCommand` is built, adding the debug option only if the `dbPurge` boolean is set.
In addition, the resulting `CronJob` will be tested at deployment time with an additional kuttl assert.
