### PR TITLE
[envtest]Use database helpers from mariadb-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/manila-operator/api v0.1.1-0.20230817135608-41dee07f5847
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230927094006-890f79149df4
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4
 	k8s.io/api v0.26.9
 	k8s.io/apimachinery v0.26.9
 	k8s.io/client-go v0.26.9

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.202309270
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20230927082538-4f614f333d17/go.mod h1:kKFAr7wZw3mX83hlQVbf2hV7TGhNNxVgMSNt9YtUPzI=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17 h1:zJguNin+9IwRnGKy1A7ranxASKO1vTvWxoXwkCz8MWw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17/go.mod h1:YOFHrNK/QqCvZUPlDJYmDyaCkbKIB98V04uyofiC9a8=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230927094006-890f79149df4 h1:NVvdjUKCVdwf/rboYM7mqZaBX7g65q1yw7tOJTxfT7g=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230927094006-890f79149df4/go.mod h1:xXHF/R/L0XamRHR/UkzlgzSTocBQ6GSQ2U16Q9Mf/bA=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4 h1:37bbJ9XzpCvB+zZckdweJEEH3pqM6Q88OHH8eHFvlpI=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/functional/manila_controller_test.go
+++ b/test/functional/manila_controller_test.go
@@ -117,8 +117,8 @@ var _ = Describe("Manila controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					namespace,
 					GetManila(manilaTest.Instance).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -130,7 +130,7 @@ var _ = Describe("Manila controller", func() {
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
 		})
 		It("Should set DBReady Condition and set DatabaseHostname Status when DB is Created", func() {
-			th.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
 			th.SimulateJobSuccess(manilaTest.ManilaDBSync)
 			Manila := GetManila(manilaTest.Instance)
 			Expect(Manila.Status.DatabaseHostname).To(Equal("hostname-for-openstack"))
@@ -148,7 +148,7 @@ var _ = Describe("Manila controller", func() {
 			)
 		})
 		It("Should fail if db-sync job fails when DB is Created", func() {
-			th.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
 			th.SimulateJobFailure(manilaTest.ManilaDBSync)
 			th.ExpectCondition(
 				manilaTest.Instance,
@@ -177,7 +177,7 @@ var _ = Describe("Manila controller", func() {
 		BeforeEach(func() {
 			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
-			DeferCleanup(th.DeleteDBService, th.CreateDBService(
+			DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(
 				manilaTest.Instance.Namespace,
 				GetManila(manilaName).Spec.DatabaseInstance,
 				corev1.ServiceSpec{
@@ -221,8 +221,8 @@ var _ = Describe("Manila controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateManilaScheduler(manilaTest.Instance, GetDefaultManilaSchedulerSpec()))
 			DeferCleanup(th.DeleteInstance, CreateManilaShare(manilaTest.Instance, GetDefaultManilaShareSpec()))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					manilaTest.Instance.Namespace,
 					GetManila(manilaName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -232,7 +232,7 @@ var _ = Describe("Manila controller", func() {
 			)
 			th.SimulateTransportURLReady(manilaTest.ManilaTransportURL)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(manilaTest.Instance.Namespace))
-			th.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
 			th.SimulateJobSuccess(manilaTest.ManilaDBSync)
 			keystone.SimulateKeystoneServiceReady(manilaTest.Instance)
 			keystone.SimulateKeystoneEndpointReady(manilaTest.ManilaKeystoneEndpoint)
@@ -256,8 +256,8 @@ var _ = Describe("Manila controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					manilaTest.Instance.Namespace,
 					GetManila(manilaTest.Instance).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -267,18 +267,18 @@ var _ = Describe("Manila controller", func() {
 			)
 			th.SimulateTransportURLReady(manilaTest.ManilaTransportURL)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(manilaTest.Instance.Namespace))
-			th.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
 			th.SimulateJobSuccess(manilaTest.ManilaDBSync)
 		})
 		It("removes the finalizers from the Manila DB", func() {
 			keystone.SimulateKeystoneServiceReady(manilaTest.Instance)
 
-			mDB := th.GetMariaDBDatabase(manilaTest.Instance)
+			mDB := mariadb.GetMariaDBDatabase(manilaTest.Instance)
 			Expect(mDB.Finalizers).To(ContainElement("Manila"))
 
 			th.DeleteInstance(GetManila(manilaTest.Instance))
 
-			mDB = th.GetMariaDBDatabase(manilaTest.Instance)
+			mDB = mariadb.GetMariaDBDatabase(manilaTest.Instance)
 			Expect(mDB.Finalizers).NotTo(ContainElement("Manila"))
 		})
 	})
@@ -329,8 +329,8 @@ var _ = Describe("Manila controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					manilaTest.Instance.Namespace,
 					GetManila(manilaTest.Instance).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -346,7 +346,7 @@ var _ = Describe("Manila controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
-			th.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
 			th.SimulateJobSuccess(manilaTest.ManilaDBSync)
 			keystone.SimulateKeystoneServiceReady(manilaTest.Instance)
 		})

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -50,6 +50,7 @@ import (
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/test"
 	common_test "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
+	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 
 	"github.com/openstack-k8s-operators/manila-operator/controllers"
@@ -68,6 +69,7 @@ var (
 	logger     logr.Logger
 	th         *common_test.TestHelper
 	keystone   *keystone_test.TestHelper
+	mariadb    *mariadb_test.TestHelper
 	namespace  string
 	manilaName types.NamespacedName
 	manilaTest ManilaTestData
@@ -156,7 +158,9 @@ var _ = BeforeSuite(func() {
 	th = common_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(th).NotTo(BeNil())
 	keystone = keystone_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
-	Expect(th).NotTo(BeNil())
+	Expect(keystone).NotTo(BeNil())
+	mariadb = mariadb_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
+	Expect(mariadb).NotTo(BeNil())
 
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{


### PR DESCRIPTION
This is necessary to remove a dependency cycle from lib-common