### PR TITLE
Correct order of csv annotation

### DIFF
--- a/config/manifests/bases/manila-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/manila-operator.clusterserviceversion.yaml
@@ -4,8 +4,8 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    operators.operatorframework.io/operator-type: non-standalone
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.operatorframework.io/operator-type: non-standalone
   name: manila-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
operator-sdk will re-order the csv annotations on local bundle creations This aligns the committed order with what is generated