### PR TITLE
Do not run cronJobs as privileged containers

### DIFF
--- a/pkg/manila/cronjob.go
+++ b/pkg/manila/cronjob.go
@@ -34,7 +34,6 @@ func CronJob(
 	labels map[string]string,
 	annotations map[string]string,
 ) *batchv1.CronJob {
-	runAsUser := int64(0)
 	var config0644AccessMode int32 = 0644
 	var DBPurgeCommand []string = DBPurgeCommandBase[:]
 	args := []string{"-c"}
@@ -103,11 +102,9 @@ func CronJob(
 									Command: []string{
 										"/bin/bash",
 									},
-									Args:         args,
-									VolumeMounts: cronJobVolumeMounts,
-									SecurityContext: &corev1.SecurityContext{
-										RunAsUser: &runAsUser,
-									},
+									Args:            args,
+									VolumeMounts:    cronJobVolumeMounts,
+									SecurityContext: GetManilaSecurityContext(),
 								},
 							},
 							Volumes:            cronJobVolume,

--- a/pkg/manila/funcs.go
+++ b/pkg/manila/funcs.go
@@ -1,6 +1,9 @@
 package manila
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // GetOwningManilaName - Given a ManilaAPI, ManilaScheduler, ManilaBackup or ManilaVolume
 // object, returning the parent Manila object that created it (if any)
@@ -10,6 +13,28 @@ func GetOwningManilaName(instance client.Object) string {
 			return ownerRef.Name
 		}
 	}
-
 	return ""
+}
+
+// GetManilaSecurityContext - Returns the right set of SecurityContext that
+// does not violate the k8s requirements
+func GetManilaSecurityContext() *corev1.SecurityContext {
+	falseVal := false
+	trueVal := true
+	runAsUser := int64(42429)
+	runAsGroup := int64(42429)
+	return &corev1.SecurityContext{
+		RunAsUser:                &runAsUser,
+		RunAsGroup:               &runAsGroup,
+		RunAsNonRoot:             &trueVal,
+		AllowPrivilegeEscalation: &falseVal,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
 }


### PR DESCRIPTION
When kolla is not required there's no need to run containers as `privileged` (especially if we run commands that are supposed to interact with DB).
This change removes the root user from the Manila `cronJobs` pod and pass a `SecurityContext` that doesn't violate the `k8s` requirements.