### PR TITLE
Add DHSS related example

### DIFF
--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -16,9 +16,10 @@ credentials in a different yaml file, to having to create secrets.
 
 Currently available samples are:
 
+- native cephfs
 - ceph-nfs
-- cephfs
 - netapp
+- netapp-dhss
 - multibackend (a combination of the above)
 
 ## CephFS example

--- a/config/samples/backends/bases/openstack/kustomization.yaml
+++ b/config/samples/backends/bases/openstack/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - openstack.yaml

--- a/config/samples/backends/bases/openstack/openstack.yaml
+++ b/config/samples/backends/bases/openstack/openstack.yaml
@@ -1,0 +1,146 @@
+# Modified version of https://github.com/openstack-k8s-operators/openstack-operator/blob/main/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+# with some changes relevant for Manila
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: local-storage
+  keystone:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  mariadb:
+    enabled: false
+    templates:
+      openstack:
+        storageRequest: 500M
+      openstack-cell1:
+        storageRequest: 500M
+  galera:
+    enabled: true
+    templates:
+      openstack:
+        storageRequest: 500M
+        secret: osp-secret
+        replicas: 1
+      openstack-cell1:
+        storageRequest: 500M
+        secret: osp-secret
+        replicas: 1
+  rabbitmq:
+    templates:
+      rabbitmq:
+        replicas: 1
+      rabbitmq-cell1:
+        replicas: 1
+  memcached:
+    templates:
+      memcached:
+        replicas: 1
+  placement:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  glance:
+    template:
+      databaseInstance: openstack
+      storageClass: ""
+      storageRequest: 10G
+  cinder:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+      cinderAPI:
+        replicas: 1
+      cinderScheduler:
+        replicas: 1
+      cinderBackup:
+        replicas: 0 # backend needs to be configured
+      cinderVolumes:
+        volume1:
+          replicas: 0 # backend needs to be configured
+  manila:
+    template:
+      manilaAPI:
+        replicas: 1
+      manilaScheduler:
+        replicas: 1
+      manilaShares:
+        share1:
+          replicas: 1
+  ovn:
+    template:
+      ovnDBCluster:
+        ovndbcluster-nb:
+          replicas: 1
+          dbType: NB
+          storageRequest: 10G
+        ovndbcluster-sb:
+          replicas: 1
+          dbType: SB
+          storageRequest: 10G
+      ovnNorthd:
+        replicas: 1
+      ovnController:
+        external-ids:
+          system-id: "random"
+          ovn-bridge: "br-int"
+          ovn-encap-type: "geneve"
+  neutron:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  horizon:
+    template:
+      replicas: 1
+      secret: osp-secret
+  nova:
+    template:
+      secret: osp-secret
+  heat:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      heatAPI:
+        replicas: 1
+      heatEngine:
+        replicas: 1
+      secret: osp-secret
+  ironic:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      ironicAPI:
+        replicas: 1
+      ironicConductors:
+      - replicas: 1
+        storageRequest: 10G
+      ironicInspector:
+        replicas: 1
+      ironicNeutronAgent:
+        replicas: 1
+      secret: osp-secret
+  ceilometer:
+    template:
+      passwordSelector:
+        service: CeilometerPassword
+      secret: osp-secret
+      serviceUser: ceilometer
+  swift:
+    enabled: true
+    template:
+      swiftRing:
+        ringReplicas: 1
+      swiftStorage:
+        replicas: 1
+      swiftProxy:
+        replicas: 1
+  octavia:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      octaviaAPI:
+        replicas: 1
+      secret: osp-secret

--- a/config/samples/backends/dhss-netapp/dhss.yaml
+++ b/config/samples/backends/dhss-netapp/dhss.yaml
@@ -1,0 +1,42 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: local-storage
+  manila:
+    enabled: true
+    template:
+      manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          debug = true
+          enabled_share_protocols=nfs,cifs
+        replicas: 1
+      manilaScheduler:
+        replicas: 1
+      manilaShares:
+        share1:
+          replicas: 1
+          customServiceConfig: |
+            [DEFAULT]
+            debug = true
+            enabled_share_backends=netapp-dhss
+            [netapp-dhss]
+            driver_handles_share_servers=True
+            share_backend_name=netapp
+            share_driver=manila.share.drivers.netapp.common.NetAppDriver
+            netapp_storage_family=ontap_cluster
+            netapp_transport_type=http
+            network_config_group = membernet
+            [membernet]
+            standalone_network_plugin_segmentation_id = 1010
+            standalone_network_plugin_network_type = vlan
+            standalone_network_plugin_mask = 24
+            standalone_network_plugin_gateway = 10.0.0.1
+            standalone_network_plugin_allowed_ip_ranges = 10.0.0.10-10.0.0.209
+            network_plugin_ipv4_enabled = True
+            network_api_class = manila.network.standalone_network_plugin.StandaloneNetworkPlugin
+          customServiceConfigSecrets:
+            - osp-secret-manila-netapp-dhss

--- a/config/samples/backends/dhss-netapp/kustomization.yaml
+++ b/config/samples/backends/dhss-netapp/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - ../bases/openstack
+  - ./osp-secret-netapp.yaml
+
+patches:
+  - dhss.yaml

--- a/config/samples/backends/dhss-netapp/osp-secret-netapp.yaml
+++ b/config/samples/backends/dhss-netapp/osp-secret-netapp.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: osp-secret-manila-netapp-dhss
+  namespace: openstack
+stringData:
+  netapp-secrets.conf : |
+    [netapp-dhss]
+    netapp_server_hostname = 1.2.3.4
+    netapp_login = fancy_netapp_user
+    netapp_password = secret_netapp_password
+    netapp_root_volume_aggr = example_aggr1


### PR DESCRIPTION
This patch improves the backends section adding the netapp-dhss one. In addition, it fixes the whole samples by adding the missing bases/openstack sample referenced everywhere.