### PR TITLE
Remove DefaultConfigOverwrite from CRD

### DIFF
--- a/api/bases/manila.openstack.org_manilaapis.yaml
+++ b/api/bases/manila.openstack.org_manilaapis.yaml
@@ -60,10 +60,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:

--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -53,10 +53,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:
@@ -830,10 +826,6 @@ spec:
                         default: false
                         type: boolean
                     type: object
-                  defaultConfigOverwrite:
-                    additionalProperties:
-                      type: string
-                    type: object
                   networkAttachments:
                     items:
                       type: string
@@ -950,10 +942,6 @@ spec:
                         default: false
                         type: boolean
                     type: object
-                  defaultConfigOverwrite:
-                    additionalProperties:
-                      type: string
-                    type: object
                   networkAttachments:
                     items:
                       type: string
@@ -1019,10 +1007,6 @@ spec:
                         service:
                           default: false
                           type: boolean
-                      type: object
-                    defaultConfigOverwrite:
-                      additionalProperties:
-                        type: string
                       type: object
                     networkAttachments:
                       items:

--- a/api/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/api/bases/manila.openstack.org_manilaschedulers.yaml
@@ -60,10 +60,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:

--- a/api/bases/manila.openstack.org_manilashares.yaml
+++ b/api/bases/manila.openstack.org_manilashares.yaml
@@ -60,10 +60,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -82,11 +82,6 @@ type ManilaServiceTemplate struct {
 	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
-	// But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
-	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// CustomServiceConfigSecrets - customize the service config using this parameter to specify Secrets
 	// that contain sensitive service config data. The content of each Secret gets added to the
 	// /etc/<service>/<service>.conf.d directory as a custom config file.

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -63,12 +63,6 @@ type ManilaSpec struct {
 	// to /etc/<service>/<service>.conf.d directory a custom config file.
 	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
-	// +kubebuilder:validation:Optional
-	// ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
-	// But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
-	// TODO: -> implement
-	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
-
 	// +kubebuilder:validation:Required
 	// ManilaAPI - Spec definition for the API service of this Manila deployment
 	ManilaAPI ManilaAPITemplate `json:"manilaAPI"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -484,13 +484,6 @@ func (in *ManilaServiceTemplate) DeepCopyInto(out *ManilaServiceTemplate) {
 		}
 	}
 	out.Debug = in.Debug
-	if in.DefaultConfigOverwrite != nil {
-		in, out := &in.DefaultConfigOverwrite, &out.DefaultConfigOverwrite
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.CustomServiceConfigSecrets != nil {
 		in, out := &in.CustomServiceConfigSecrets, &out.CustomServiceConfigSecrets
 		*out = make([]string, len(*in))
@@ -667,13 +660,6 @@ func (in *ManilaSpec) DeepCopyInto(out *ManilaSpec) {
 	*out = *in
 	out.ManilaTemplate = in.ManilaTemplate
 	out.Debug = in.Debug
-	if in.DefaultConfigOverwrite != nil {
-		in, out := &in.DefaultConfigOverwrite, &out.DefaultConfigOverwrite
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	in.ManilaAPI.DeepCopyInto(&out.ManilaAPI)
 	in.ManilaScheduler.DeepCopyInto(&out.ManilaScheduler)
 	if in.ManilaShares != nil {

--- a/config/crd/bases/manila.openstack.org_manilaapis.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaapis.yaml
@@ -60,10 +60,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -53,10 +53,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:
@@ -830,10 +826,6 @@ spec:
                         default: false
                         type: boolean
                     type: object
-                  defaultConfigOverwrite:
-                    additionalProperties:
-                      type: string
-                    type: object
                   networkAttachments:
                     items:
                       type: string
@@ -950,10 +942,6 @@ spec:
                         default: false
                         type: boolean
                     type: object
-                  defaultConfigOverwrite:
-                    additionalProperties:
-                      type: string
-                    type: object
                   networkAttachments:
                     items:
                       type: string
@@ -1019,10 +1007,6 @@ spec:
                         service:
                           default: false
                           type: boolean
-                      type: object
-                    defaultConfigOverwrite:
-                      additionalProperties:
-                        type: string
                       type: object
                     networkAttachments:
                       items:

--- a/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
@@ -60,10 +60,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:

--- a/config/crd/bases/manila.openstack.org_manilashares.yaml
+++ b/config/crd/bases/manila.openstack.org_manilashares.yaml
@@ -60,10 +60,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -762,10 +762,6 @@ func (r *ManilaReconciler) generateServiceConfig(
 	// all other files get placed into /etc/<service> to allow overwrite of e.g. policy.json
 	customData := map[string]string{manila.CustomConfigFileName: instance.Spec.CustomServiceConfig}
 
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
-
 	keystoneAPI, err := keystonev1.GetKeystoneAPI(ctx, h, instance.Namespace, map[string]string{})
 	if err != nil {
 		return err

--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -802,10 +802,6 @@ func (r *ManilaAPIReconciler) generateServiceConfig(
 	// customData hold any customization for the service.
 	customData := map[string]string{manila.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
 
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
-
 	customData[manila.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 
 	// Fetch the two service config snippets (DefaultsConfigFileName and

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -534,7 +534,6 @@ func (r *ManilaSchedulerReconciler) getSecret(
 }
 
 // generateServiceConfig - create Secret to hold service-specific config
-// TODO add DefaultConfigOverwrite
 func (r *ManilaSchedulerReconciler) generateServiceConfig(
 	ctx context.Context,
 	h *helper.Helper,
@@ -550,10 +549,6 @@ func (r *ManilaSchedulerReconciler) generateServiceConfig(
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), serviceLabels)
 
 	customData := map[string]string{manila.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
-
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
 
 	customData[manila.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -531,7 +531,6 @@ func (r *ManilaShareReconciler) getSecret(
 }
 
 // generateServiceConfig - create custom Secret to hold service-specific config
-// TODO add DefaultConfigOverwrite
 func (r *ManilaShareReconciler) generateServiceConfig(
 	ctx context.Context,
 	h *helper.Helper,
@@ -547,10 +546,6 @@ func (r *ManilaShareReconciler) generateServiceConfig(
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), serviceLabels)
 
 	customData := map[string]string{manila.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
-
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
 
 	customData[manila.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 


### PR DESCRIPTION
As done in Cinder via [1], this patch removes the `DefaultConfigOverwrite` parameter from the `CRD`.
The feature was never fully implemented, and it's superseded by the `ExtraMounts` feature.

[1] https://github.com/openstack-k8s-operators/cinder-operator/pull/297