### PR TITLE
Move -log sidecar container to dumb-init

### DIFF
--- a/pkg/manilaapi/deployment.go
+++ b/pkg/manilaapi/deployment.go
@@ -100,9 +100,16 @@ func Deployment(
 						{
 							Name: instance.Name + "-log",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  []string{"-c", "tail -n+1 -F " + LogFile},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/usr/bin/tail",
+								"-n+1",
+								"-F",
+								LogFile,
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,


### PR DESCRIPTION
As noticed in other operators, the -log sidecar ignores SIGTERM on delete. This patch moves the manila-operator to the dumb-init usage to make sure the SIGTERM is handled properly by the sidecar.

Fixes: [OSPRH-770](https://issues.redhat.com//browse/OSPRH-770)