### PR TITLE
Move manila-api to StatefulSet

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,18 +30,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
   verbs:
   - create

--- a/test/functional/manila_controller_test.go
+++ b/test/functional/manila_controller_test.go
@@ -382,7 +382,7 @@ var _ = Describe("Manila controller", func() {
 			keystone.SimulateKeystoneServiceReady(manilaTest.Instance)
 		})
 		It("Check the resulting endpoints of the generated sub-CRs", func() {
-			th.SimulateDeploymentReadyWithPods(
+			th.SimulateStatefulSetReplicaReadyWithPods(
 				manilaTest.ManilaAPI,
 				map[string][]string{manilaName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)

--- a/test/kuttl/tests/deploy/02-assert.yaml
+++ b/test/kuttl/tests/deploy/02-assert.yaml
@@ -141,7 +141,7 @@ status:
    readyCount: 3
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
    labels:
       component: manila-api


### PR DESCRIPTION
As done for many operators, this patch moves `manila-api` to `statefulset` instead of deployment.