### PR TITLE
Update Kustomize configuration for Manila resources

### DIFF
--- a/config/samples/backends/bases/openstack/kustomization.yaml
+++ b/config/samples/backends/bases/openstack/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
-  - openstack.yaml
+- openstack.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/backends/ceph-nfs/kustomization.yaml
+++ b/config/samples/backends/ceph-nfs/kustomization.yaml
@@ -1,4 +1,6 @@
 resources:
-  - ../bases/openstack
+- ../bases/openstack
 patches:
-  - backend.yaml
+- path: backend.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/backends/cephfs/kustomization.yaml
+++ b/config/samples/backends/cephfs/kustomization.yaml
@@ -1,4 +1,6 @@
 resources:
-  - ../bases/openstack
+- ../bases/openstack
 patches:
-  - backend.yaml
+- path: backend.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/backends/dhss-netapp/kustomization.yaml
+++ b/config/samples/backends/dhss-netapp/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
-  - ../bases/openstack
-  - ./osp-secret-netapp.yaml
+- ../bases/openstack
+- ./osp-secret-netapp.yaml
 
 patches:
-  - dhss.yaml
+- path: dhss.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/backends/multibackend/kustomization.yaml
+++ b/config/samples/backends/multibackend/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
   - ../bases/openstack
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/netapp/kustomization.yaml
+++ b/config/samples/backends/netapp/kustomization.yaml
@@ -1,4 +1,6 @@
 resources:
-  - ../bases/openstack
+- ../bases/openstack
 patches:
-  - backend.yaml
+- path: backend.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/layout/bases/manila/kustomization.yaml
+++ b/config/samples/layout/bases/manila/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
-  - manila_v1beta1_manila.yaml
+- manila_v1beta1_manila.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/layout/cephfs/kustomization.yaml
+++ b/config/samples/layout/cephfs/kustomization.yaml
@@ -1,16 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-   - ../bases/manila
+- ../bases/manila
 patches:
-   - patch: |-
-        - op: replace
-          path: /spec/secret
-          value: osp-secret
-        - op: replace
-          path: /metadata/namespace
-          value: manila-kuttl-tests
-     target:
-        kind: Manila
-patchesStrategicMerge:
-  - cephfs.yaml
+- patch: |-
+    - op: replace
+      path: /spec/secret
+      value: osp-secret
+    - op: replace
+      path: /metadata/namespace
+      value: manila-kuttl-tests
+  target:
+    kind: Manila
+- path: cephfs.yaml

--- a/config/samples/layout/multibackend/kustomization.yaml
+++ b/config/samples/layout/multibackend/kustomization.yaml
@@ -1,19 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-   - ../bases/manila
+- ../bases/manila
 patches:
-   - patch: |-
-        - op: replace
-          path: /spec/secret
-          value: osp-secret
-        - op: replace
-          path: /metadata/namespace
-          value: manila-kuttl-tests
-        - op: replace
-          path: /spec/manilaShares/share1/replicas
-          value: 0
-     target:
-        kind: Manila
-patchesStrategicMerge:
-  - multibackend.yaml
+- path: multibackend.yaml
+- patch: |-
+    - op: replace
+      path: /spec/secret
+      value: osp-secret
+    - op: replace
+      path: /metadata/namespace
+      value: manila-kuttl-tests
+    - op: replace
+      path: /spec/manilaShares/share1/replicas
+      value: 0
+  target:
+    kind: Manila


### PR DESCRIPTION
- Updated the Kustomize configuration for best practice using 'kustomize edit fix'
- Introduced a Kustomization object with path specified to fix the errors breaking prow jobs while testing OCP 4.14