### PR TITLE
Add the missing fips-compliant annotation to the manifest

### DIFF
--- a/config/manifests/bases/manila-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/manila-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: manila-operator.v0.0.0


### PR DESCRIPTION
As per [1] we should have the fips-compliant annotation in the manila-operator clusterserviceversion manifest. This patch adds the missing annotation.

[1] https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html