### PR TITLE
Set pod affinity to spread services across OCP workers

### DIFF
--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -700,7 +700,7 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 	//
 	serviceLabels := map[string]string{
 		common.AppSelector:       manila.ServiceName,
-		common.ComponentSelector: manilaapi.Component,
+		common.ComponentSelector: manilaapi.ComponentName,
 	}
 	//
 	// create custom config for this manila service

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -409,7 +409,7 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	//
 	serviceLabels := map[string]string{
 		common.AppSelector:       manila.ServiceName,
-		common.ComponentSelector: manilascheduler.Component,
+		common.ComponentSelector: manilascheduler.ComponentName,
 	}
 	//
 	// create custom Secrets for manila-scheduler service

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -405,7 +405,7 @@ func (r *ManilaShareReconciler) reconcileNormal(ctx context.Context, instance *m
 
 	serviceLabels := map[string]string{
 		common.AppSelector:       manila.ServiceName,
-		common.ComponentSelector: manilashare.Component,
+		common.ComponentSelector: manilashare.ComponentName,
 	}
 	//
 	// create service Secrets for manila-share service

--- a/pkg/manila/funcs.go
+++ b/pkg/manila/funcs.go
@@ -1,6 +1,9 @@
 package manila
 
 import (
+	common "github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
+
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,4 +40,18 @@ func GetManilaSecurityContext() *corev1.SecurityContext {
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
 	}
+}
+
+// GetPodAffinity - Returns a corev1.Affinity reference for the specified component.
+func GetPodAffinity(componentName string) *corev1.Affinity {
+	// If possible two pods of the same component (e.g manila-share) should not
+	// run on the same worker node. If this is not possible they get still
+	// created on the same worker node.
+	return affinity.DistributePods(
+		common.ComponentSelector,
+		[]string{
+			componentName,
+		},
+		corev1.LabelHostname,
+	)
 }

--- a/pkg/manilaapi/const.go
+++ b/pkg/manilaapi/const.go
@@ -13,8 +13,8 @@ limitations under the License.
 package manilaapi
 
 const (
-	// Component -
-	Component = "manila-api"
+	// ComponentName -
+	ComponentName = "manila-api"
 
 	//LogFile -
 	LogFile = "/var/log/manila/manila-api.log"

--- a/pkg/manilaapi/statefulset.go
+++ b/pkg/manilaapi/statefulset.go
@@ -13,8 +13,6 @@ limitations under the License.
 package manilaapi
 
 import (
-	common "github.com/openstack-k8s-operators/lib-common/modules/common"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
@@ -144,7 +142,7 @@ func StatefulSet(
 							Resources:    instance.Spec.Resources,
 						},
 						{
-							Name: manila.ServiceName + "-api",
+							Name: ComponentName,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -160,25 +158,12 @@ func StatefulSet(
 							LivenessProbe:  livenessProbe,
 						},
 					},
+					Affinity:     manila.GetPodAffinity(ComponentName),
 					NodeSelector: instance.Spec.NodeSelector,
 					Volumes:      volumes,
 				},
 			},
 		},
-	}
-
-	// If possible two pods of the same service should not
-	// run on the same worker node. If this is not possible
-	// the get still created on the same worker node.
-	statefulset.Spec.Template.Spec.Affinity = affinity.DistributePods(
-		common.AppSelector,
-		[]string{
-			manila.ServiceName,
-		},
-		corev1.LabelHostname,
-	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		statefulset.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
 	}
 
 	return statefulset, nil

--- a/pkg/manilascheduler/const.go
+++ b/pkg/manilascheduler/const.go
@@ -13,6 +13,6 @@ limitations under the License.
 package manilascheduler
 
 const (
-	// Component -
-	Component = "manila-scheduler"
+	// ComponentName -
+	ComponentName = "manila-scheduler"
 )

--- a/pkg/manilashare/const.go
+++ b/pkg/manilashare/const.go
@@ -13,6 +13,6 @@ limitations under the License.
 package manilashare
 
 const (
-	// Component -
-	Component = "manila-share"
+	// ComponentName -
+	ComponentName = "manila-share"
 )

--- a/pkg/manilashare/statefulset.go
+++ b/pkg/manilashare/statefulset.go
@@ -13,8 +13,6 @@ limitations under the License.
 package manilashare
 
 import (
-	common "github.com/openstack-k8s-operators/lib-common/modules/common"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	manilav1 "github.com/openstack-k8s-operators/manila-operator/api/v1beta1"
 	manila "github.com/openstack-k8s-operators/manila-operator/pkg/manila"
@@ -119,7 +117,7 @@ func StatefulSet(
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					Containers: []corev1.Container{
 						{
-							Name: manila.ServiceName + "-share",
+							Name: ComponentName,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -146,25 +144,12 @@ func StatefulSet(
 							VolumeMounts: volumeMounts,
 						},
 					},
+					Affinity:     manila.GetPodAffinity(ComponentName),
 					NodeSelector: instance.Spec.NodeSelector,
 					Volumes:      volumes,
 				},
 			},
 		},
-	}
-
-	// If possible two pods of the same service should not
-	// run on the same worker node. If this is not possible
-	// the get still created on the same worker node.
-	statefulset.Spec.Template.Spec.Affinity = affinity.DistributePods(
-		common.AppSelector,
-		[]string{
-			manila.ServiceName,
-		},
-		corev1.LabelHostname,
-	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		statefulset.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
 	}
 
 	return statefulset


### PR DESCRIPTION
Pod affinity is actually an anti-affinity rule intended to spread pods across all OCP workers. However, we don't want this rule to apply to all manila pods in general. The anti-affinity rule now applies to each specific manila service (api, scheduler, share).