### PR TITLE
[tlse] TLS database connection

### DIFF
--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -51,6 +51,7 @@ import (
 	manilav1beta1 "github.com/openstack-k8s-operators/manila-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/manila-operator/pkg/manila"
 	"github.com/openstack-k8s-operators/manila-operator/pkg/manilashare"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 )
 
 // GetClient -
@@ -643,7 +644,19 @@ func (r *ManilaShareReconciler) generateServiceConfig(
 
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), serviceLabels)
 
-	customData := map[string]string{manila.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	db, err := mariadbv1.GetDatabaseByName(ctx, h, manila.DatabaseName)
+	if err != nil {
+		return err
+	}
+	var tlsCfg *tls.Service
+	if instance.Spec.TLS.CaBundleSecretName != "" {
+		tlsCfg = &tls.Service{}
+	}
+
+	customData := map[string]string{
+		manila.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+	}
 
 	customData[manila.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240224182407-3b6c02b195f6
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240224182407-3b6c02b195f6
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-00010101000000-000000000000
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240222094307-76fef735f093
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e
 	k8s.io/api v0.28.7
 	k8s.io/apimachinery v0.28.7
 	k8s.io/client-go v0.28.7

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.202402241
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240224182407-3b6c02b195f6/go.mod h1:Qg6DbOUHCzMCGhRikhN0XTWSOBOX9uB9z74jTbjyOUk=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240224182407-3b6c02b195f6 h1:8SbXBGb7qgvYTXF9WiaNg1esn2J7mVXkqcAC0pIZJe4=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240224182407-3b6c02b195f6/go.mod h1:82nzS+DbBe1tzaMvNHH8FctmZzQ14ZAJysFGsMJiivo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240222094307-76fef735f093 h1:gmm2o5bVYIeuAVHp7WsDIpQc8vh+/9tUUYY4Wfyus/o=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240222094307-76fef735f093/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e h1:6vqp5HZwcGvPH0MII/23iCd97T3/1HJZlONKW6LyNio=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e/go.mod h1:PDqfLbP4ZWqQHAu1OtbjfpOGQUKSzLqRJChvE/9pcyQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/manila/volumes.go
+++ b/pkg/manila/volumes.go
@@ -1,10 +1,11 @@
 package manila
 
 import (
+	"strconv"
+
 	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	manilav1 "github.com/openstack-k8s-operators/manila-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"strconv"
 )
 
 // GetVolumes -
@@ -84,6 +85,12 @@ func GetVolumeMounts(extraVol []manilav1.ManilaExtraVolMounts, svc []storage.Pro
 		{
 			Name:      "scripts",
 			MountPath: "/usr/local/bin/container-scripts",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "config-data",
+			MountPath: "/etc/my.cnf",
+			SubPath:   "my.cnf",
 			ReadOnly:  true,
 		},
 		/*{

--- a/test/functional/manila_test_data.go
+++ b/test/functional/manila_test_data.go
@@ -20,6 +20,7 @@ package functional
 import (
 	"fmt"
 
+	"github.com/openstack-k8s-operators/manila-operator/pkg/manila"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -47,6 +48,7 @@ type ManilaTestData struct {
 	ManilaRoleBinding           types.NamespacedName
 	ManilaTransportURL          types.NamespacedName
 	ManilaMemcached             types.NamespacedName
+	ManilaDatabaseName          types.NamespacedName
 	ManilaSA                    types.NamespacedName
 	ManilaDBSync                types.NamespacedName
 	ManilaKeystoneEndpoint      types.NamespacedName
@@ -80,6 +82,10 @@ func GetManilaTestData(manilaName types.NamespacedName) ManilaTestData {
 		Manila: types.NamespacedName{
 			Namespace: manilaName.Namespace,
 			Name:      manilaName.Name,
+		},
+		ManilaDatabaseName: types.NamespacedName{
+			Namespace: manilaName.Namespace,
+			Name:      manila.DatabaseName,
 		},
 		ManilaDBSync: types.NamespacedName{
 			Namespace: manilaName.Namespace,

--- a/test/functional/manilashare_controller_test.go
+++ b/test/functional/manilashare_controller_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -52,6 +53,10 @@ var _ = Describe("ManilaShare controller", func() {
 				},
 			),
 		)
+		mariadb.CreateMariaDBDatabase(manilaTest.Instance.Namespace, manilaTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
+		mariadb.CreateMariaDBAccount(manilaTest.Instance.Namespace, manilaTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
+		mariadb.SimulateMariaDBAccountCompleted(manilaTest.Instance)
+		mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
 	})
 
 	When("ManilaShare CR is created", func() {
@@ -117,6 +122,11 @@ var _ = Describe("ManilaShare controller", func() {
 			//Double check customServiceConfig has been applied
 			configData := string(secretDataMap.Data["03-config.conf"])
 			Expect(configData).Should(ContainSubstring("foo=bar"))
+
+			Expect(secretDataMap.Data).Should(HaveKey("my.cnf"))
+			configData = string(secretDataMap.Data["my.cnf"])
+			Expect(configData).To(
+				ContainSubstring("[client]\nssl=0"))
 		})
 
 		When("manila-share-config is ready", func() {
@@ -143,7 +153,7 @@ var _ = Describe("ManilaShare controller", func() {
 					Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 					container := ss.Spec.Template.Spec.Containers[1]
-					Expect(container.VolumeMounts).To(HaveLen(7))
+					Expect(container.VolumeMounts).To(HaveLen(8))
 					Expect(container.Image).To(Equal(manilaTest.ContainerImage))
 
 					// the input hash is stored in the current manilaShare.Status

--- a/test/kuttl/tests/manila-tls/03-assert.yaml
+++ b/test/kuttl/tests/manila-tls/03-assert.yaml
@@ -272,6 +272,10 @@ spec:
           name: config-data
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /etc/manila/manila.conf.d
           name: config-data-custom
           readOnly: true
@@ -365,6 +369,10 @@ spec:
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /etc/ceph
           name: ceph
           readOnly: true
@@ -397,6 +405,10 @@ spec:
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /etc/ceph
           name: ceph
           readOnly: true
@@ -475,6 +487,10 @@ spec:
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /etc/manila/manila.conf.d
           name: config-data-custom
           readOnly: true
@@ -503,6 +519,10 @@ spec:
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
+        - mountPath: /etc/my.cnf
+          name: config-data
+          readOnly: true
+          subPath: my.cnf
         - mountPath: /etc/manila/manila.conf.d
           name: config-data-custom
           readOnly: true


### PR DESCRIPTION
The my.cnf file gets added to the secret holding the service configs. The content of my.cnf is centrally managed in the mariadb-operator and retrieved calling db.GetDatabaseClientConfig(tlsCfg)

Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/190
Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/191

Jira: [OSPRH-4547](https://issues.redhat.com//browse/OSPRH-4547)