### PR TITLE
migrate from databaseUsername to databaseAccount and fully use MariaDBAccount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ $(GINKGO): $(LOCALBIN)
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
 	go test -v ./pkg/.. ./controllers/.. ./api/.. -coverprofile cover.out
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	OPERATOR_TEMPLATES="$(shell pwd)/templates" \
 	$(GINKGO) --trace --cover --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./test/functional/...
 .PHONY: gowork
 gowork: export GOWORK=

--- a/api/bases/manila.openstack.org_manilaapis.yaml
+++ b/api/bases/manila.openstack.org_manilaapis.yaml
@@ -49,10 +49,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: manila
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -871,12 +871,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: ManilaDatabasePassword
                   service: ManilaPassword
                 properties:
-                  database:
-                    default: ManilaDatabasePassword
-                    type: string
                   service:
                     default: ManilaPassword
                     type: string

--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -39,10 +39,10 @@ spec:
               customServiceConfig:
                 default: '# add your customization here'
                 type: string
-              databaseInstance:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: manila
+                type: string
+              databaseInstance:
                 type: string
               dbPurge:
                 properties:
@@ -1072,12 +1072,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: ManilaDatabasePassword
                   service: ManilaPassword
                 properties:
-                  database:
-                    default: ManilaDatabasePassword
-                    type: string
                   service:
                     default: ManilaPassword
                     type: string

--- a/api/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/api/bases/manila.openstack.org_manilaschedulers.yaml
@@ -49,10 +49,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: manila
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -820,12 +820,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: ManilaDatabasePassword
                   service: ManilaPassword
                 properties:
-                  database:
-                    default: ManilaDatabasePassword
-                    type: string
                   service:
                     default: ManilaPassword
                     type: string

--- a/api/bases/manila.openstack.org_manilashares.yaml
+++ b/api/bases/manila.openstack.org_manilashares.yaml
@@ -49,10 +49,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: manila
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -820,12 +820,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: ManilaDatabasePassword
                   service: ManilaPassword
                 properties:
-                  database:
-                    default: ManilaDatabasePassword
-                    type: string
                   service:
                     default: ManilaPassword
                     type: string

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -45,17 +45,16 @@ type ManilaTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=manila
-	// DatabaseUser - optional username used for manila DB, defaults to manila
-	// TODO: -> implement needs work in mariadb-operator, right now only manila
-	DatabaseUser string `json:"databaseUser,omitempty"`
+	// DatabaseAccount - optional MariaDBAccount CR name used for manila DB, defaults to manila
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Optional
-	// Secret containing OpenStack password information for ManilaDatabasePassword, AdminPassword
+	// Secret containing OpenStack password information for AdminPassword
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: ManilaDatabasePassword, service: ManilaPassword}
-	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
+	// +kubebuilder:default={service: ManilaPassword}
+	// PasswordSelectors - Selectors to identify the ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 }
 
@@ -92,11 +91,6 @@ type ManilaServiceTemplate struct {
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret
 type PasswordSelector struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="ManilaDatabasePassword"
-	// Database - Selector to get the manila database user password from the Secret
-	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="ManilaPassword"
 	// Service - Selector to get the manila service password from the Secret

--- a/config/crd/bases/manila.openstack.org_manilaapis.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaapis.yaml
@@ -49,10 +49,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: manila
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -871,12 +871,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: ManilaDatabasePassword
                   service: ManilaPassword
                 properties:
-                  database:
-                    default: ManilaDatabasePassword
-                    type: string
                   service:
                     default: ManilaPassword
                     type: string

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -39,10 +39,10 @@ spec:
               customServiceConfig:
                 default: '# add your customization here'
                 type: string
-              databaseInstance:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: manila
+                type: string
+              databaseInstance:
                 type: string
               dbPurge:
                 properties:
@@ -1072,12 +1072,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: ManilaDatabasePassword
                   service: ManilaPassword
                 properties:
-                  database:
-                    default: ManilaDatabasePassword
-                    type: string
                   service:
                     default: ManilaPassword
                     type: string

--- a/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
+++ b/config/crd/bases/manila.openstack.org_manilaschedulers.yaml
@@ -49,10 +49,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: manila
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -820,12 +820,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: ManilaDatabasePassword
                   service: ManilaPassword
                 properties:
-                  database:
-                    default: ManilaDatabasePassword
-                    type: string
                   service:
                     default: ManilaPassword
                     type: string

--- a/config/crd/bases/manila.openstack.org_manilashares.yaml
+++ b/config/crd/bases/manila.openstack.org_manilashares.yaml
@@ -49,10 +49,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: manila
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -820,12 +820,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: ManilaDatabasePassword
                   service: ManilaPassword
                 properties:
-                  database:
-                    default: ManilaDatabasePassword
-                    type: string
                   service:
                     default: ManilaPassword
                     type: string

--- a/config/samples/manila_v1beta1_manila.yaml
+++ b/config/samples/manila_v1beta1_manila.yaml
@@ -10,7 +10,7 @@ spec:
     debug = true
   databaseInstance: openstack
   secret: osp-secret
-  databaseUser: manila
+  databaseAccount: manila
   rabbitMqClusterName: rabbitmq
   manilaAPI: {}
   manilaScheduler: {}

--- a/config/samples/manila_v1beta1_manila_tls.yaml
+++ b/config/samples/manila_v1beta1_manila_tls.yaml
@@ -10,7 +10,7 @@ spec:
     debug = true
   databaseInstance: openstack
   secret: osp-secret
-  databaseUser: manila
+  databaseAccount: manila
   rabbitMqClusterName: rabbitmq
   manilaAPI:
     tls:

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -336,7 +336,7 @@ func (r *ManilaReconciler) reconcileDelete(ctx context.Context, instance *manila
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' delete", instance.Name))
 
 	// remove db finalizer first
-	db, err := mariadbv1.GetDatabaseByName(ctx, helper, manila.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, helper, manila.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -664,6 +664,14 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 		r.Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 
+	// remove finalizers from unused MariaDBAccount records
+	err = mariadbv1.DeleteUnusedMariaDBAccountFinalizers(
+		ctx, helper, manila.DatabaseCRName,
+		instance.Spec.DatabaseAccount, instance.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Mirror ManilaAPI status' ReadyCount to this parent CR
 	instance.Status.ManilaAPIReadyCount = manilaAPI.Status.ReadyCount
 
@@ -843,6 +851,9 @@ func (r *ManilaReconciler) generateServiceConfig(
 		return err
 	}
 
+	databaseAccount := db.GetAccount()
+	databaseSecret := db.GetSecret()
+
 	// templateParameters := make(map[string]interface{})
 	templateParameters := map[string]interface{}{
 		"ServiceUser":         instance.Spec.ServiceUser,
@@ -851,10 +862,10 @@ func (r *ManilaReconciler) generateServiceConfig(
 		"KeystoneInternalURL": keystoneInternalURL,
 		"TransportURL":        string(transportURLSecret.Data["transport_url"]),
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
-			instance.Spec.DatabaseUser,
-			string(ospSecret.Data[instance.Spec.PasswordSelectors.Database]),
+			databaseAccount.Spec.UserName,
+			string(databaseSecret.Data[mariadbv1.DatabasePasswordSelector]),
 			instance.Status.DatabaseHostname,
-			manila.DatabaseName),
+			manila.DatabaseCRName),
 		"MemcachedServersWithInet": strings.Join(memcached.Status.ServerListWithInet, ","),
 	}
 
@@ -1073,24 +1084,45 @@ func (r *ManilaReconciler) ensureDB(
 	h *helper.Helper,
 	instance *manilav1beta1.Manila,
 ) (*mariadbv1.Database, ctrl.Result, error) {
+	// ensure MariaDBAccount exists.  This account record may be created by
+	// openstack-operator or the cloud operator up front without a specific
+	// MariaDBDatabase configured yet.   Otherwise, a MariaDBAccount CR is
+	// created here with a generated username as well as a secret with
+	// generated password.   The MariaDBAccount is created without being
+	// yet associated with any MariaDBDatabase.
+	_, _, err := mariadbv1.EnsureMariaDBAccount(
+		ctx, h, instance.Spec.DatabaseAccount,
+		instance.Namespace, false, manila.DatabaseUsernamePrefix,
+	)
+
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			mariadbv1.MariaDBAccountReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			mariadbv1.MariaDBAccountNotReadyMessage,
+			err.Error()))
+
+		return nil, ctrl.Result{}, err
+	}
+	instance.Status.Conditions.MarkTrue(
+		mariadbv1.MariaDBAccountReadyCondition,
+		mariadbv1.MariaDBAccountReadyMessage)
+
 	//
 	// create service DB instance
 	//
-	db := mariadbv1.NewDatabase(
-		manila.DatabaseName,
-		instance.Spec.DatabaseUser,
-		instance.Spec.Secret,
-		map[string]string{
-			"dbName": instance.Spec.DatabaseInstance,
-		},
+	db := mariadbv1.NewDatabaseForAccount(
+		instance.Spec.DatabaseInstance, // mariadb/galera service to target
+		manila.DatabaseName,            // name used in CREATE DATABASE in mariadb
+		manila.DatabaseCRName,          // CR name for MariaDBDatabase
+		instance.Spec.DatabaseAccount,  // CR name for MariaDBAccount
+		instance.Namespace,             // namespace
 	)
 
 	// create or patch the DB
-	ctrlResult, err := db.CreateOrPatchDBByName(
-		ctx,
-		h,
-		instance.Spec.DatabaseInstance,
-	)
+	ctrlResult, err := db.CreateOrPatchAll(ctx, h)
+
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DBReadyCondition,

--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -941,7 +941,7 @@ func (r *ManilaAPIReconciler) generateServiceConfig(
 
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), serviceLabels)
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, manila.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, manila.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -647,7 +647,7 @@ func (r *ManilaSchedulerReconciler) generateServiceConfig(
 
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), serviceLabels)
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, manila.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, manila.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -644,7 +644,7 @@ func (r *ManilaShareReconciler) generateServiceConfig(
 
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(manila.ServiceName), serviceLabels)
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, manila.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, manila.DatabaseCRName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240224182407-3b6c02b195f6
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240224182407-3b6c02b195f6
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-00010101000000-000000000000
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3
 	k8s.io/api v0.28.7
 	k8s.io/apimachinery v0.28.7
 	k8s.io/client-go v0.28.7

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.202402241
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240224182407-3b6c02b195f6/go.mod h1:Qg6DbOUHCzMCGhRikhN0XTWSOBOX9uB9z74jTbjyOUk=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240224182407-3b6c02b195f6 h1:8SbXBGb7qgvYTXF9WiaNg1esn2J7mVXkqcAC0pIZJe4=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240224182407-3b6c02b195f6/go.mod h1:82nzS+DbBe1tzaMvNHH8FctmZzQ14ZAJysFGsMJiivo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e h1:6vqp5HZwcGvPH0MII/23iCd97T3/1HJZlONKW6LyNio=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e/go.mod h1:PDqfLbP4ZWqQHAu1OtbjfpOGQUKSzLqRJChvE/9pcyQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3 h1:fwb+GvvnN9Mhkgg5pBksZ8W5+hLCcNOorHsUTQYA1Lg=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/manila/const.go
+++ b/pkg/manila/const.go
@@ -25,8 +25,14 @@ const (
 	ServiceNameV2 = "manilav2"
 	// ServiceTypeV2 - API V2 service type, supported
 	ServiceTypeV2 = "sharev2"
-	// DatabaseName -
+
+	// DatabaseName - Name of the database used in CREATE DATABASE statement
 	DatabaseName = "manila"
+	// DatabaseCRName - Name of the MariaDBDatabase CR
+	DatabaseCRName = "manila"
+	// DatabaseUsernamePrefix - used by EnsureMariaDBAccount when a new username
+	// is to be generated, e.g. "manila_e5a4", "manila_78bc", etc
+	DatabaseUsernamePrefix = "manila"
 
 	// ManilaPublicPort -
 	ManilaPublicPort int32 = 8786

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -33,9 +33,8 @@ func CreateManilaSecret(namespace string, name string) *corev1.Secret {
 	return th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"ManilaPassword":         []byte(manilaTest.ManilaPassword),
-			"ManilaDatabasePassword": []byte(manilaTest.ManilaPassword),
-			"MetadataSecret":         []byte(manilaTest.ManilaPassword),
+			"ManilaPassword": []byte(manilaTest.ManilaPassword),
+			"MetadataSecret": []byte(manilaTest.ManilaPassword),
 		},
 	)
 }

--- a/test/functional/manila_test_data.go
+++ b/test/functional/manila_test_data.go
@@ -40,7 +40,6 @@ type ManilaTestData struct {
 	RabbitmqClusterName         string
 	RabbitmqSecretName          string
 	MemcachedInstance           string
-	ManilaDataBaseUser          string
 	ManilaPassword              string
 	ManilaServiceUser           string
 	Instance                    types.NamespacedName
@@ -49,6 +48,7 @@ type ManilaTestData struct {
 	ManilaTransportURL          types.NamespacedName
 	ManilaMemcached             types.NamespacedName
 	ManilaDatabaseName          types.NamespacedName
+	ManilaDatabaseAccount       types.NamespacedName
 	ManilaSA                    types.NamespacedName
 	ManilaDBSync                types.NamespacedName
 	ManilaKeystoneEndpoint      types.NamespacedName
@@ -85,7 +85,11 @@ func GetManilaTestData(manilaName types.NamespacedName) ManilaTestData {
 		},
 		ManilaDatabaseName: types.NamespacedName{
 			Namespace: manilaName.Namespace,
-			Name:      manila.DatabaseName,
+			Name:      manila.DatabaseCRName,
+		},
+		ManilaDatabaseAccount: types.NamespacedName{
+			Namespace: manilaName.Namespace,
+			Name:      "manila",
 		},
 		ManilaDBSync: types.NamespacedName{
 			Namespace: manilaName.Namespace,
@@ -170,8 +174,7 @@ func GetManilaTestData(manilaName types.NamespacedName) ManilaTestData {
 		RabbitmqClusterName: "rabbitmq",
 		RabbitmqSecretName:  "rabbitmq-secret",
 		MemcachedInstance:   MemcachedInstance,
-		ManilaDataBaseUser:  "manila",
-		// Password used for both db and service
+		// Password used for service
 		ManilaPassword:    "12345678",
 		ManilaServiceUser: "manila",
 		ContainerImage:    "test://manila",

--- a/test/functional/manilaapi_controller_test.go
+++ b/test/functional/manilaapi_controller_test.go
@@ -51,10 +51,14 @@ var _ = Describe("ManilaAPI controller", func() {
 				},
 			),
 		)
-		mariadb.CreateMariaDBDatabase(manilaTest.Instance.Namespace, manilaTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-		mariadb.CreateMariaDBAccount(manilaTest.Instance.Namespace, manilaTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-		mariadb.SimulateMariaDBAccountCompleted(manilaTest.Instance)
-		mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
+		mariadb.CreateMariaDBDatabase(manilaTest.ManilaDatabaseName.Namespace, manilaTest.ManilaDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+
+		dbAccount, dbSecret := mariadb.CreateMariaDBAccountAndSecret(manilaTest.ManilaDatabaseAccount, mariadbv1.MariaDBAccountSpec{})
+		DeferCleanup(k8sClient.Delete, ctx, dbAccount)
+		DeferCleanup(k8sClient.Delete, ctx, dbSecret)
+
+		mariadb.SimulateMariaDBAccountCompleted(manilaTest.ManilaDatabaseAccount)
+		mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.ManilaDatabaseName)
 	})
 
 	When("ManilaAPI CR is created", func() {
@@ -98,8 +102,6 @@ var _ = Describe("ManilaAPI controller", func() {
 			infra.SimulateTransportURLReady(manilaTest.ManilaTransportURL)
 			infra.SimulateMemcachedReady(manilaTest.ManilaMemcached)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
-			mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
-			mariadb.SimulateMariaDBAccountCompleted(manilaTest.Instance)
 			th.SimulateJobSuccess(manilaTest.ManilaDBSync)
 			keystone.SimulateKeystoneEndpointReady(manilaTest.ManilaKeystoneEndpoint)
 		})
@@ -124,8 +126,6 @@ var _ = Describe("ManilaAPI controller", func() {
 		When("manila-api-config is ready", func() {
 			BeforeEach(func() {
 				DeferCleanup(th.DeleteInstance, CreateManilaAPI(manilaTest.Instance, GetDefaultManilaAPISpec()))
-				mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
-				mariadb.SimulateMariaDBAccountCompleted(manilaTest.Instance)
 				th.SimulateJobSuccess(manilaTest.ManilaDBSync)
 				keystone.SimulateKeystoneEndpointReady(manilaTest.ManilaKeystoneEndpoint)
 				keystone.SimulateKeystoneEndpointReady(manilaTest.Instance)

--- a/test/functional/manilashare_controller_test.go
+++ b/test/functional/manilashare_controller_test.go
@@ -53,10 +53,14 @@ var _ = Describe("ManilaShare controller", func() {
 				},
 			),
 		)
-		mariadb.CreateMariaDBDatabase(manilaTest.Instance.Namespace, manilaTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-		mariadb.CreateMariaDBAccount(manilaTest.Instance.Namespace, manilaTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-		mariadb.SimulateMariaDBAccountCompleted(manilaTest.Instance)
-		mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
+		mariadb.CreateMariaDBDatabase(manilaTest.ManilaDatabaseName.Namespace, manilaTest.ManilaDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+
+		dbAccount, dbSecret := mariadb.CreateMariaDBAccountAndSecret(manilaTest.ManilaDatabaseAccount, mariadbv1.MariaDBAccountSpec{})
+		DeferCleanup(k8sClient.Delete, ctx, dbAccount)
+		DeferCleanup(k8sClient.Delete, ctx, dbSecret)
+
+		mariadb.SimulateMariaDBAccountCompleted(manilaTest.ManilaDatabaseAccount)
+		mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.ManilaDatabaseName)
 	})
 
 	When("ManilaShare CR is created", func() {
@@ -106,8 +110,6 @@ var _ = Describe("ManilaShare controller", func() {
 			infra.SimulateTransportURLReady(manilaTest.ManilaTransportURL)
 			infra.SimulateMemcachedReady(manilaTest.ManilaMemcached)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
-			mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
-			mariadb.SimulateMariaDBAccountCompleted(manilaTest.Instance)
 			th.SimulateJobSuccess(manilaTest.ManilaDBSync)
 			keystone.SimulateKeystoneEndpointReady(manilaTest.ManilaKeystoneEndpoint)
 		})
@@ -134,8 +136,6 @@ var _ = Describe("ManilaShare controller", func() {
 				infra.SimulateTransportURLReady(manilaTest.ManilaTransportURL)
 				infra.SimulateMemcachedReady(manilaTest.ManilaMemcached)
 				DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
-				mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
-				mariadb.SimulateMariaDBAccountCompleted(manilaTest.Instance)
 				th.SimulateJobSuccess(manilaTest.ManilaDBSync)
 				keystone.SimulateKeystoneEndpointReady(manilaTest.ManilaKeystoneEndpoint)
 			})
@@ -178,8 +178,6 @@ var _ = Describe("ManilaShare controller", func() {
 				infra.SimulateTransportURLReady(manilaTest.ManilaTransportURL)
 				infra.SimulateMemcachedReady(manilaTest.ManilaMemcached)
 				DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
-				mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.Instance)
-				mariadb.SimulateMariaDBAccountCompleted(manilaTest.Instance)
 				th.SimulateJobSuccess(manilaTest.ManilaDBSync)
 				keystone.SimulateKeystoneEndpointReady(manilaTest.ManilaKeystoneEndpoint)
 			})

--- a/test/kuttl/tests/manila-basic/01-assert.yaml
+++ b/test/kuttl/tests/manila-basic/01-assert.yaml
@@ -15,7 +15,7 @@ spec:
       [DEFAULT]
       debug = true
    databaseInstance: openstack
-   databaseUser: manila
+   databaseAccount: manila
    manilaAPI:
       customServiceConfig: |
          [DEFAULT]
@@ -42,7 +42,6 @@ spec:
             cephfs_cluster_name=ceph
             cephfs_protocol_helper_type=CEPHFS
    passwordSelectors:
-      database: ManilaDatabasePassword
       service: ManilaPassword
    preserveJobs: false
    rabbitMqClusterName: rabbitmq
@@ -82,6 +81,10 @@ status:
         reason: Ready
         status: "True"
         type: ManilaShareReady
+      - message: MariaDBAccount creation complete
+        reason: Ready
+        status: "True"
+        type: MariaDBAccountReady
       - message: " Memcached instance has been provisioned"
         reason: Ready
         status: "True"

--- a/test/kuttl/tests/manila-basic/02-assert.yaml
+++ b/test/kuttl/tests/manila-basic/02-assert.yaml
@@ -15,7 +15,7 @@ spec:
       [DEFAULT]
       debug = true
    databaseInstance: openstack
-   databaseUser: manila
+   databaseAccount: manila
    manilaAPI:
       customServiceConfig: |
          [DEFAULT]
@@ -41,7 +41,6 @@ spec:
             cephfs_cluster_name=ceph
             cephfs_protocol_helper_type=CEPHFS
    passwordSelectors:
-      database: ManilaDatabasePassword
       service: ManilaPassword
    preserveJobs: false
    rabbitMqClusterName: rabbitmq
@@ -81,6 +80,10 @@ status:
         reason: Ready
         status: "True"
         type: ManilaShareReady
+      - message: MariaDBAccount creation complete
+        reason: Ready
+        status: "True"
+        type: MariaDBAccountReady
       - message: " Memcached instance has been provisioned"
         reason: Ready
         status: "True"
@@ -124,9 +127,8 @@ metadata:
    name: manila-api
 spec:
    databaseHostname: openstack.manila-kuttl-tests.svc
-   databaseUser: manila
+   databaseAccount: manila
    passwordSelectors:
-      database: ManilaDatabasePassword
       service: ManilaPassword
    replicas: 3
    resources: {}

--- a/test/kuttl/tests/manila-basic/03-assert.yaml
+++ b/test/kuttl/tests/manila-basic/03-assert.yaml
@@ -15,7 +15,7 @@ spec:
       [DEFAULT]
       debug = true
    databaseInstance: openstack
-   databaseUser: manila
+   databaseAccount: manila
    manilaAPI:
       customServiceConfig: |
          [DEFAULT]
@@ -42,7 +42,6 @@ spec:
             cephfs_cluster_name=ceph
             cephfs_protocol_helper_type=CEPHFS
    passwordSelectors:
-      database: ManilaDatabasePassword
       service: ManilaPassword
    preserveJobs: false
    rabbitMqClusterName: rabbitmq
@@ -82,6 +81,10 @@ status:
         reason: Ready
         status: "True"
         type: ManilaShareReady
+      - message: MariaDBAccount creation complete
+        reason: Ready
+        status: "True"
+        type: MariaDBAccountReady
       - message: " Memcached instance has been provisioned"
         reason: Ready
         status: "True"

--- a/test/kuttl/tests/manila-multibackend/01-assert.yaml
+++ b/test/kuttl/tests/manila-multibackend/01-assert.yaml
@@ -13,7 +13,7 @@ spec:
       [DEFAULT]
       debug = true
    databaseInstance: openstack
-   databaseUser: manila
+   databaseAccount: manila
    manilaAPI:
        customServiceConfig: |
           [DEFAULT]
@@ -52,7 +52,6 @@ spec:
            cephfs_protocol_helper_type=NFS
        replicas: 0
    passwordSelectors:
-      database: ManilaDatabasePassword
       service: ManilaPassword
    preserveJobs: false
    rabbitMqClusterName: rabbitmq
@@ -92,6 +91,10 @@ status:
         reason: Ready
         status: "True"
         type: ManilaShareReady
+      - message: MariaDBAccount creation complete
+        reason: Ready
+        status: "True"
+        type: MariaDBAccountReady
       - message: " Memcached instance has been provisioned"
         reason: Ready
         status: "True"
@@ -173,9 +176,8 @@ metadata:
   name: manila-share-share0
 spec:
   databaseHostname: openstack.manila-kuttl-tests.svc
-  databaseUser: manila
+  databaseAccount: manila
   passwordSelectors:
-    database: ManilaDatabasePassword
     service: ManilaPassword
   replicas: 1
   resources: {}

--- a/test/kuttl/tests/manila-multibackend/02-assert.yaml
+++ b/test/kuttl/tests/manila-multibackend/02-assert.yaml
@@ -15,7 +15,7 @@ spec:
       [DEFAULT]
       debug = true
    databaseInstance: openstack
-   databaseUser: manila
+   databaseAccount: manila
    manilaAPI:
       customServiceConfig: |
          [DEFAULT]
@@ -54,7 +54,6 @@ spec:
             cephfs_protocol_helper_type=NFS
         replicas: 1
    passwordSelectors:
-      database: ManilaDatabasePassword
       service: ManilaPassword
    preserveJobs: false
    rabbitMqClusterName: rabbitmq
@@ -94,6 +93,10 @@ status:
         reason: Ready
         status: "True"
         type: ManilaShareReady
+      - message: MariaDBAccount creation complete
+        reason: Ready
+        status: "True"
+        type: MariaDBAccountReady
       - message: " Memcached instance has been provisioned"
         reason: Ready
         status: "True"
@@ -136,9 +139,8 @@ metadata:
       - ManilaAPI
    name: manila-api
 spec:
-   databaseUser: manila
+   databaseAccount: manila
    passwordSelectors:
-      database: ManilaDatabasePassword
       service: ManilaPassword
    replicas: 1
    resources: {}
@@ -179,9 +181,8 @@ kind: ManilaShare
 metadata:
   name: manila-share-share0
 spec:
-  databaseUser: manila
+  databaseAccount: manila
   passwordSelectors:
-    database: ManilaDatabasePassword
     service: ManilaPassword
   replicas: 1
   resources: {}
@@ -222,9 +223,8 @@ kind: ManilaShare
 metadata:
   name: manila-share-share1
 spec:
-  databaseUser: manila
+  databaseAccount: manila
   passwordSelectors:
-    database: ManilaDatabasePassword
     service: ManilaPassword
   replicas: 1
   resources: {}

--- a/test/kuttl/tests/manila-multibackend/03-assert.yaml
+++ b/test/kuttl/tests/manila-multibackend/03-assert.yaml
@@ -15,7 +15,7 @@ spec:
       [DEFAULT]
       debug = true
    databaseInstance: openstack
-   databaseUser: manila
+   databaseAccount: manila
    manilaAPI:
       customServiceConfig: |
          [DEFAULT]
@@ -55,7 +55,6 @@ spec:
             cephfs_nfs_cluster_id=cephfs
             cephfs_protocol_helper_type=NFS
    passwordSelectors:
-      database: ManilaDatabasePassword
       service: ManilaPassword
    preserveJobs: false
    rabbitMqClusterName: rabbitmq
@@ -95,6 +94,10 @@ status:
         reason: Ready
         status: "True"
         type: ManilaShareReady
+      - message: MariaDBAccount creation complete
+        reason: Ready
+        status: "True"
+        type: MariaDBAccountReady
       - message: " Memcached instance has been provisioned"
         reason: Ready
         status: "True"
@@ -175,9 +178,8 @@ kind: ManilaShare
 metadata:
   name: manila-share-share1
 spec:
-  databaseUser: manila
+  databaseAccount: manila
   passwordSelectors:
-    database: ManilaDatabasePassword
     service: ManilaPassword
   replicas: 1
   resources: {}

--- a/test/kuttl/tests/manila-tls/03-assert.yaml
+++ b/test/kuttl/tests/manila-tls/03-assert.yaml
@@ -8,7 +8,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: manila
+  databaseAccount: manila
   dbPurge:
     age: 30
     schedule: 1 0 * * *
@@ -64,7 +64,6 @@ spec:
       resources: {}
   memcachedInstance: memcached
   passwordSelectors:
-    database: ManilaDatabasePassword
     service: ManilaPassword
   preserveJobs: false
   rabbitMqClusterName: rabbitmq
@@ -104,6 +103,10 @@ status:
     reason: Ready
     status: "True"
     type: ManilaShareReady
+  - message: MariaDBAccount creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
   - message: " Memcached instance has been provisioned"
     reason: Ready
     status: "True"
@@ -191,9 +194,8 @@ metadata:
   name: manila-share-share0
 spec:
   databaseHostname: openstack.manila-kuttl-tests.svc
-  databaseUser: manila
+  databaseAccount: manila
   passwordSelectors:
-    database: ManilaDatabasePassword
     service: ManilaPassword
   replicas: 1
   resources: {}


### PR DESCRIPTION
Lead Jira: [OSPRH-4095](https://issues.redhat.com/browse/OSPRH-4095)

1. [x] controller calls EnsureMariaDBAccount up front to make sure MariaDBAccount is present
2. [x] error code from EnsureMariaDBAccount is handled, Conditions are amended when error is returned
3. [x] controller calls NewDatabaseForAccount instead of NewDatabase
4. [x]  GetAccountAndSecret is used to retrieve account /secret to populate template
5. [x]  GetDatabaseByName() , normally used for delete finalizers, replaced with GetDatabaseByNameAndAccount
6. [x]  CreateOrPatchAll() used to patch the Database, replacing CreateOrPatchDB / CreateOrPatchDBByName
7. [x]  controller calls DeleteUnusedMariaDBAccountFinalizers when launched pods are definitely running on a new MariaDBAccount, returns error code if present
8. [x]  PasswordSelectors that refer to database are removed
9. [x]  all databaseUser replaced with databaseAccount inside of all XYZ_types.go
10. [x] all databaseUser replaced with databaseAccount inside of all `kuttl/*.yaml`
11. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all XYZ_types.go
12. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all `kuttl/*.yaml`
13. [x] MariaDBAccountSuiteTests are used in controller ginkgo tests if it has them
14. [x] [184](https://github.com/openstack-k8s-operators/mariadb-operator/pull/184) is merged and replaces from go.mod are removed


