### PR TITLE
Return true from IsReady only when replicas are ready to serve requests

### DIFF
--- a/api/v1beta1/manilaapi_types.go
+++ b/api/v1beta1/manilaapi_types.go
@@ -130,7 +130,8 @@ func init() {
 	SchemeBuilder.Register(&ManilaAPI{}, &ManilaAPIList{})
 }
 
-// IsReady - returns true if ManilaAPI is reconciled successfully
+// IsReady - returns true if ManilaAPI is reconciled successfully and is ready to
+// serve requests
 func (instance ManilaAPI) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
+	return instance.Status.ReadyCount == *instance.Spec.Replicas
 }

--- a/api/v1beta1/manilascheduler_types.go
+++ b/api/v1beta1/manilascheduler_types.go
@@ -121,7 +121,8 @@ func init() {
 	SchemeBuilder.Register(&ManilaScheduler{}, &ManilaSchedulerList{})
 }
 
-// IsReady - returns true if ManilaScheduler is reconciled successfully
+// IsReady - returns true if ManilaScheduler is reconciled successfully and is
+// ready to serve requests
 func (instance ManilaScheduler) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
+	return instance.Status.ReadyCount == *instance.Spec.Replicas
 }

--- a/api/v1beta1/manilashare_types.go
+++ b/api/v1beta1/manilashare_types.go
@@ -123,7 +123,8 @@ func init() {
 	SchemeBuilder.Register(&ManilaShare{}, &ManilaShareList{})
 }
 
-// IsReady - returns true if ManilaShare is reconciled successfully
+// IsReady - returns true if ManilaShare is reconciled successfully and is ready
+// to serve requests
 func (instance ManilaShare) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
+	return instance.Status.ReadyCount == *instance.Spec.Replicas
 }


### PR DESCRIPTION
The current code is not re-initializing the conditions, which means that the Service is set as Ready even if replicas are not marked as Ready.