### PR TITLE
Do not add Ceph extraMounts in netapp backend sample

### DIFF
--- a/config/samples/backends/netapp/backend.yaml
+++ b/config/samples/backends/netapp/backend.yaml
@@ -33,20 +33,3 @@ spec:
           customServiceConfigSecrets:
             - osp-secret-manila-netapp
           replicas: 1
-  extraMounts:
-    - name: v1
-      region: r1
-      extraVol:
-        - propagation:
-          - Manila
-          extraVolType: Ceph
-          volumes:
-          - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files
-          mounts:
-          - name: ceph
-            mountPath: "/etc/ceph"
-            readOnly: true


### PR DESCRIPTION
ExtraMounts are not required for netapp backend, where a single secret containing the credentials is provided.
It uses the `customServiceConfigSecrets` interface, and it's referenced by name.