### PR TITLE
Add Status.ObservedGeneration to Manila CR

### DIFF
--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -1137,6 +1137,9 @@ spec:
                   format: int32
                   type: integer
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               transportURLSecret:
                 type: string
             type: object

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -139,6 +139,12 @@ type ManilaStatus struct {
 
 	// ReadyCounts of Manila Share instances
 	ManilaSharesReadyCounts map[string]int32 `json:"manilaSharesReadyCounts,omitempty"`
+
+	// ObservedGeneration - the most recent generation observed for this
+	// service. If the observed generation is less than the spec generation,
+	// then the controller has not processed the latest changes injected by
+	// the opentack-operator in the top-level CR (e.g. the ContainerImage)
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -1137,6 +1137,9 @@ spec:
                   format: int32
                   type: integer
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               transportURLSecret:
                 type: string
             type: object

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -780,6 +780,7 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 
 	r.Log.Info(fmt.Sprintf("Reconciled Service '%s' successfully", instance.Name))
 	// update the overall status condition if service is ready
+	instance.Status.ObservedGeneration = instance.Generation
 	if instance.IsReady() {
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 	}


### PR DESCRIPTION
This field is used by minor updates to make sure we know, when a CR changes, if the requested generation matches with the last observed state, then we can check the IsReady because we're sure we're not looking at an outdated CR.

Jira: [OSPRH-5919](https://issues.redhat.com//browse/OSPRH-5919)