### PR TITLE
Mirror ReadyCondition with the actual current condition

### DIFF
--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -156,7 +156,12 @@ func (r *ManilaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
+		condition.RestoreLastTransitionTimes(
+			&instance.Status.Conditions, savedConditions)
+		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
+		}
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err
@@ -165,9 +170,8 @@ func (r *ManilaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}()
 
 	// Always initialize conditions used later as Status=Unknown
-	// except ReadyCondition which is False unless proven otherwise
 	cl := condition.CreateList(
-		condition.FalseCondition(condition.ReadyCondition, condition.InitReason, condition.SeverityInfo, condition.ReadyInitMessage),
+		condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
 		condition.UnknownCondition(condition.ExposeServiceReadyCondition, condition.InitReason, condition.ExposeServiceReadyInitMessage),
 		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 		condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),


### PR DESCRIPTION
This patch covers two things:

- `Mirror()` relies on sorting conditions in each condition group by their `LastTransitionTime`, so it swaps the `RestoreLastTransitionTimes()` call with the `Mirror()` call in the defer function

- It setup `ReadyCondition` as `Unknown` instead of `False`, so we can avoid it to be the only one mirrored in
  the instance `Status`: this allows the other conditions to compete for mirroring