### PR TITLE
Relax the liveness and readinessProbe

### DIFF
--- a/pkg/manilaapi/statefulset.go
+++ b/pkg/manilaapi/statefulset.go
@@ -40,14 +40,14 @@ func StatefulSet(
 	runAsUser := int64(0)
 
 	livenessProbe := &corev1.Probe{
-		TimeoutSeconds:      5,
-		PeriodSeconds:       3,
-		InitialDelaySeconds: 5,
+		TimeoutSeconds:      10,
+		PeriodSeconds:       10,
+		InitialDelaySeconds: 10,
 	}
 	readinessProbe := &corev1.Probe{
-		TimeoutSeconds:      5,
-		PeriodSeconds:       5,
-		InitialDelaySeconds: 5,
+		TimeoutSeconds:      10,
+		PeriodSeconds:       10,
+		InitialDelaySeconds: 10,
 	}
 
 	args := []string{"-c", ServiceCommand}

--- a/pkg/manilascheduler/statefulset.go
+++ b/pkg/manilascheduler/statefulset.go
@@ -43,16 +43,16 @@ func StatefulSet(
 
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
-		TimeoutSeconds:      5,
-		PeriodSeconds:       3,
-		InitialDelaySeconds: 3,
+		TimeoutSeconds:      20,
+		PeriodSeconds:       20,
+		InitialDelaySeconds: 10,
 	}
 
 	startupProbe := &corev1.Probe{
-		TimeoutSeconds:      5,
+		TimeoutSeconds:      10,
 		FailureThreshold:    12,
-		PeriodSeconds:       5,
-		InitialDelaySeconds: 5,
+		PeriodSeconds:       10,
+		InitialDelaySeconds: 10,
 	}
 
 	args := []string{"-c", ServiceCommand}

--- a/pkg/manilashare/statefulset.go
+++ b/pkg/manilashare/statefulset.go
@@ -45,16 +45,16 @@ func StatefulSet(
 	// TODO until we determine how to properly query for these
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
-		TimeoutSeconds:      5,
-		PeriodSeconds:       3,
-		InitialDelaySeconds: 3,
+		TimeoutSeconds:      20,
+		PeriodSeconds:       20,
+		InitialDelaySeconds: 10,
 	}
 
 	startupProbe := &corev1.Probe{
-		TimeoutSeconds:      5,
+		TimeoutSeconds:      10,
 		FailureThreshold:    12,
-		PeriodSeconds:       5,
-		InitialDelaySeconds: 5,
+		PeriodSeconds:       10,
+		InitialDelaySeconds: 10,
 	}
 
 	args := []string{"-c", ServiceCommand}


### PR DESCRIPTION
On big environments, where resources are problematic to properly size the OCP cluster, we experienced a lot of restart for both the scheduler and the manilaShare. The config was correct, but kubernetes wasn't able to check the health of the service within the context deadline, causing a periodi Pod restart.
This patch represents an attempt to relax the Timeouts at the operator level and see if we can be more flexible in particular cirumnstances.

Jira: [OSPRH-5915](https://issues.redhat.com/browse/OSPRH-5915)