### PR TITLE
Move the sidecar containers to dumb-init

### DIFF
--- a/pkg/manilaapi/statefulset.go
+++ b/pkg/manilaapi/statefulset.go
@@ -50,7 +50,6 @@ func StatefulSet(
 		InitialDelaySeconds: 10,
 	}
 
-	args := []string{"-c", ServiceCommand}
 	//
 	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 	//
@@ -145,9 +144,15 @@ func StatefulSet(
 						{
 							Name: ComponentName,
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  args,
+							Args: []string{
+								"--single-child",
+								"--",
+								"/bin/bash",
+								"-c",
+								string(ServiceCommand),
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,

--- a/pkg/manilascheduler/statefulset.go
+++ b/pkg/manilascheduler/statefulset.go
@@ -55,7 +55,6 @@ func StatefulSet(
 		InitialDelaySeconds: 10,
 	}
 
-	args := []string{"-c", ServiceCommand}
 	var probeCommand []string
 	livenessProbe.HTTPGet = &corev1.HTTPGetAction{
 		Port: intstr.FromInt(8080),
@@ -105,9 +104,15 @@ func StatefulSet(
 						{
 							Name: ComponentName,
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  args,
+							Args: []string{
+								"--single-child",
+								"--",
+								"/bin/bash",
+								"-c",
+								string(ServiceCommand),
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &rootUser,

--- a/pkg/manilashare/statefulset.go
+++ b/pkg/manilashare/statefulset.go
@@ -57,7 +57,6 @@ func StatefulSet(
 		InitialDelaySeconds: 10,
 	}
 
-	args := []string{"-c", ServiceCommand}
 	var probeCommand []string
 	livenessProbe.HTTPGet = &corev1.HTTPGetAction{
 		Port: intstr.FromInt(8080),
@@ -119,9 +118,15 @@ func StatefulSet(
 						{
 							Name: ComponentName,
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  args,
+							Args: []string{
+								"--single-child",
+								"--",
+								"/bin/bash",
+								"-c",
+								string(ServiceCommand),
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  &rootUser,

--- a/test/kuttl/tests/manila-tls/03-assert.yaml
+++ b/test/kuttl/tests/manila-tls/03-assert.yaml
@@ -261,8 +261,13 @@ spec:
         - name: logs
           mountPath: /var/log/manila
       - args:
-          - -c
-          - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        - --single-child
+        - --
+        - /bin/bash
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /usr/bin/dumb-init
         volumeMounts:
         - mountPath: /etc/machine-id
           name: etc-machine-id
@@ -357,8 +362,13 @@ spec:
       serviceAccountName: manila-manila
       containers:
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /usr/bin/dumb-init
         volumeMounts:
         - mountPath: /etc/machine-id
           name: etc-machine-id
@@ -475,8 +485,13 @@ spec:
       serviceAccountName: manila-manila
       containers:
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /usr/bin/dumb-init
         volumeMounts:
         - mountPath: /etc/machine-id
           name: etc-machine-id


### PR DESCRIPTION
As noticed in other operators and for the log sidecar container, `SIGTERM` is ignored on delete. This patch moves the `manila-operator` to entirely use `dumb-init` to make sure the `SIGTERM` is handled properly. In addition, this helps to recreate quickly the containers when tls-e is enabled at `Pod` level.

Jira: [OSPRH-3277](https://issues.redhat.com/browse/OSPRH-3277)