### PR TITLE
Add tempest api job using single HCI node

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -12,3 +12,11 @@
         MANILA_IMG: "{{ content_provider_registry_ip }}:5001/podified-antelope-centos9/manila-operator-index:{{ cifmw_repo_setup_full_hash }}"
       cifmw_kuttl_tests_operator_list:
         - manila
+
+- job:
+    name: manila-operator-tempest
+    parent: podified-multinode-hci-deployment-crc-1comp-backends
+    vars:
+      cifmw_test_operator_concurrency: 4
+      cifmw_test_operator_tempest_include_list: |
+        ^manila_tempest_tests.tests.api

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,3 +8,6 @@
             dependencies:
               - openstack-k8s-operators-content-provider
             voting: false
+        - manila-operator-tempest:
+            dependencies:
+              - openstack-k8s-operators-content-provider


### PR DESCRIPTION
This zuul job inherits from ci-framework single node HCI job, which already enables manila by default and configures a ceph backend for it.
This new job should replace the current Prow job which don't deploy EDPM and Ceph.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1604
