### PR TITLE
Add configurable API Timeouts

### DIFF
--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -36,6 +36,10 @@ spec:
             type: object
           spec:
             properties:
+              apiTimeout:
+                default: 60
+                minimum: 10
+                type: integer
               customServiceConfig:
                 default: '# add your customization here'
                 type: string

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -115,6 +115,12 @@ type ManilaSpecBase struct {
 	// +kubebuilder:validation:Optional
 	// DBPurge parameters -
 	DBPurge DBPurge `json:"dbPurge,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=10
+	// APITimeout for HAProxy, Apache, and rpc_response_timeout
+	APITimeout int `json:"apiTimeout"`
 }
 
 // ManilaStatus defines the observed state of Manila

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -36,6 +36,10 @@ spec:
             type: object
           spec:
             properties:
+              apiTimeout:
+                default: 60
+                minimum: 10
+                type: integer
               customServiceConfig:
                 default: '# add your customization here'
                 type: string

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -893,6 +893,7 @@ func (r *ManilaReconciler) generateServiceConfig(
 			instance.Status.DatabaseHostname,
 			manila.DatabaseCRName),
 		"MemcachedServersWithInet": memcached.GetMemcachedServerListWithInetString(),
+		"TimeOut":                  instance.Spec.APITimeout,
 	}
 
 	// create httpd  vhost template parameters

--- a/templates/manila/config/00-config.conf
+++ b/templates/manila/config/00-config.conf
@@ -10,6 +10,9 @@ auth_strategy=keystone
 control_exchange=openstack
 api_paste_config=/etc/manila/api-paste.ini
 
+# Keep the RPC call timeout in sync with HAProxy and Apache timeouts
+rpc_response_timeout = {{ .TimeOut }}
+
 [cinder]
 [cors]
 

--- a/templates/manila/config/10-manila_wsgi.conf
+++ b/templates/manila/config/10-manila_wsgi.conf
@@ -14,6 +14,8 @@
     Require all granted
   </Directory>
 
+  Timeout {{ $.TimeOut }}
+
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off


### PR DESCRIPTION
Multiple limitations exist with existing code:

- Human operator cannot configure Apache Timeout, so it's fixed at the defaults of 60 seconds.

  This is not a big issue since there's only 1 sync operation, but for consistency we adopt the same approach as Cinder and Glance.

- Default HAProxy timeout is 30 seconds, which is different than the default in OSP17 (60 seconds)

- Human operators would need to sync values between 3 places: HAProxy, Apache, oslo.messaging sync RPC (call).

This patch adds an `apiTimeout` field to the `ManilaSpecBase` to allow human operators to simultaneously configure the timeouts for HAProxy, Apache, and the `rpc_response_timeout`.

The `apiTimeout` defaults to 60 seconds, to mimic the behavior present in OSP17.

Having different timeouts for HAProxy, Apache, and `rpc_response_timeout` is possible setting the HAProxy timeout in the `apiOverride`, the Apache timeout with `apiTimeout`, and setting `rpc_response_timeout` in the top level Manila `customServiceConfig`.

To be able to change the HAProxy value based on the `apiTimeout` with any update (and not just the first time) the code adds a custom annotation "api.manila.openstack.org/timeout" with the value that was initially set, this way flags it as being set by the manila-operator.