### PR TITLE
Set APIDefaultTimeout default value through webhooks

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -33,6 +33,8 @@ const (
 	DBPurgeDefaultAge = 30
 	//DBPurgeDefaultSchedule is in crontab format, and the default runs the job once every day
 	DBPurgeDefaultSchedule = "1 0 * * *"
+	// APIDefaultTimeout indicates the default APITimeout for HAProxy and Apache, defaults to 60 seconds
+	APIDefaultTimeout = 60
 )
 
 // ManilaTemplate defines common input parameters used by all Manila services

--- a/api/v1beta1/manila_webhook.go
+++ b/api/v1beta1/manila_webhook.go
@@ -44,6 +44,7 @@ type ManilaDefaults struct {
 	ShareContainerImageURL     string
 	DBPurgeAge                 int
 	DBPurgeSchedule            string
+	APITimeout                 int
 }
 
 var manilaDefaults ManilaDefaults
@@ -61,6 +62,7 @@ func SetupDefaults() {
 		ShareContainerImageURL:     util.GetEnvVar("RELATED_IMAGE_MANILA_SHARE_IMAGE_URL_DEFAULT", ManilaShareContainerImage),
 		DBPurgeAge:                 DBPurgeDefaultAge,
 		DBPurgeSchedule:            DBPurgeDefaultSchedule,
+		APITimeout:                 APIDefaultTimeout,
 	}
 
 	manilalog.Info("Manila defaults initialized", "defaults", manilaDefaults)
@@ -108,6 +110,10 @@ func (spec *ManilaSpec) Default() {
 
 // Default - set defaults for this Manila spec base
 func (spec *ManilaSpecBase) Default() {
+
+	if spec.APITimeout == 0 {
+		spec.APITimeout = manilaDefaults.APITimeout
+	}
 
 	if spec.DBPurge.Age == 0 {
 		spec.DBPurge.Age = manilaDefaults.DBPurgeAge


### PR DESCRIPTION
Like we did for `CronJobs` and `ContainerImage`, this patch enforces the same default defined by `kubebuilder` to make sure we don't end up creating the `CR` with wrong values (e.g., `apiTimeout = 0`).