### PR TITLE
Put zuul voting: false

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,3 +11,4 @@
         - manila-operator-tempest:
             dependencies:
               - openstack-k8s-operators-content-provider
+            voting: false


### PR DESCRIPTION
`Prow` is still our source of truth until `zuul` is stable enough, hence moving `zuul` to non voting until the switch is completed.