### PR TITLE
Fix api log file increases indefinitely

### DIFF
--- a/pkg/manilaapi/statefulset.go
+++ b/pkg/manilaapi/statefulset.go
@@ -128,10 +128,9 @@ func StatefulSet(
 							Args: []string{
 								"--single-child",
 								"--",
-								"/usr/bin/tail",
-								"-n+1",
-								"-F",
-								LogFile,
+								"/bin/sh",
+								"-c",
+								"/usr/bin/tail -n+1 -F " + LogFile + " 2>/dev/null",
 							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{

--- a/templates/manilaapi/config/01-config.conf
+++ b/templates/manilaapi/config/01-config.conf
@@ -1,2 +1,5 @@
 [DEFAULT]
 log_file = {{ .LogFile }}
+log_rotation_type = size
+max_logfile_count = 1
+max_logfile_size_mb = 20

--- a/test/kuttl/tests/manila-tls/03-assert.yaml
+++ b/test/kuttl/tests/manila-tls/03-assert.yaml
@@ -253,10 +253,9 @@ spec:
       - args:
         - --single-child
         - --
-        - /usr/bin/tail
-        - -n+1
-        - -F
-        - /var/log/manila/manila-api.log
+        - /bin/sh
+        - -c
+        - /usr/bin/tail -n+1 -F /var/log/manila/manila-api.log 2>/dev/null
         volumeMounts:
         - name: logs
           mountPath: /var/log/manila


### PR DESCRIPTION
The manila-api pod uses a file between the manila-api service and a sidecar to pass the manila logs from the service to the stdout.

With the current code it will grow forever, which makes no sense, since the stdout from the pod itself is already being stored, under /var/log/pods and/or in a centralized logging service.

This patch makes the oslo.log service rotate the log file once it reaches 20MB in size.

Other projects like nova and glance set the limit to 50MB and they keep 5 rotated files, but I think that keeping rotated files is useless here and 50MB seems a bit much.

Unfortunately we need to at least keep 1 copy, or oslo.log will not do the right thing if set to 0.

We also need to redirect errors in the sidecar container that tails the log to /dev/null to prevent tail error messages whenever the file gets rotated.