### PR TITLE
Remove errorReason from tls input check functional test

### DIFF
--- a/test/functional/manila_controller_test.go
+++ b/test/functional/manila_controller_test.go
@@ -490,47 +490,39 @@ var _ = Describe("Manila controller", func() {
 		})
 
 		It("reports that the CA secret is missing", func() {
-			th.ExpectConditionWithDetails(
+			th.ExpectCondition(
 				manilaTest.ManilaAPI,
 				ConditionGetterFunc(ManilaAPIConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/combined-ca-bundle not found", namespace),
 			)
 
-			th.ExpectConditionWithDetails(
+			th.ExpectCondition(
 				manilaTest.ManilaScheduler,
 				ConditionGetterFunc(ManilaSchedulerConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/combined-ca-bundle not found", namespace),
 			)
 		})
 
 		It("reports that the internal cert secret is missing", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(manilaTest.CABundleSecret))
-			th.ExpectConditionWithDetails(
+			th.ExpectCondition(
 				manilaTest.ManilaAPI,
 				ConditionGetterFunc(ManilaAPIConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/internal-tls-certs not found", namespace),
 			)
 		})
 
 		It("reports that the public cert secret is missing", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(manilaTest.CABundleSecret))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(manilaTest.InternalCertSecret))
-			th.ExpectConditionWithDetails(
+			th.ExpectCondition(
 				manilaTest.ManilaAPI,
 				ConditionGetterFunc(ManilaAPIConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/public-tls-certs not found", namespace),
 			)
 		})
 


### PR DESCRIPTION
We're not really interested in the `ErrorReason` as we depends on what is provided by `lib-common`. However, We still want to match the resulting condition boolean.
This patch removes the `TLSInput` `error message` so we don't fail if something changes in `lib-common`.