### PR TITLE
Run manila services using manila user/group

### DIFF
--- a/pkg/manila/const.go
+++ b/pkg/manila/const.go
@@ -36,6 +36,14 @@ const (
 	// is to be generated, e.g. "manila_e5a4", "manila_78bc", etc
 	DatabaseUsernamePrefix = "manila"
 
+	// Manila's uid and gid magic numbers come from the 'manila-user' in
+	// https://github.com/openstack/kolla/blob/master/kolla/common/users.py
+
+	// ManilaUserID -
+	ManilaUserID int64 = 42429
+	// ManilaGroupID -
+	ManilaGroupID int64 = 42429
+
 	// ManilaPublicPort -
 	ManilaPublicPort int32 = 8786
 	// ManilaInternalPort -
@@ -71,6 +79,8 @@ const (
 	ShortDuration = time.Duration(5) * time.Second
 	// NormalDuration -
 	NormalDuration = time.Duration(10) * time.Second
+	//DBSyncCommand -
+	DBSyncCommand = "/usr/bin/manila-manage --config-dir /etc/manila/manila.conf.d db sync"
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/pkg/manila/cronjob.go
+++ b/pkg/manila/cronjob.go
@@ -112,7 +112,7 @@ func CronJob(
 									},
 									Args:            args,
 									VolumeMounts:    cronJobVolumeMounts,
-									SecurityContext: GetManilaSecurityContext(),
+									SecurityContext: manilaDefaultSecurityContext(),
 								},
 							},
 							Volumes:            cronJobVolume,

--- a/pkg/manila/dbsync.go
+++ b/pkg/manila/dbsync.go
@@ -8,11 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	//DBSyncCommand -
-	DBSyncCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
-)
-
 // DbSyncJob func
 func DbSyncJob(instance *manilav1.Manila, labels map[string]string, annotations map[string]string) *batchv1.Job {
 	var config0644AccessMode int32 = 0644
@@ -75,7 +70,6 @@ func DbSyncJob(instance *manilav1.Manila, labels map[string]string, annotations 
 		dbSyncMounts = append(dbSyncMounts, instance.Spec.ManilaAPI.TLS.CreateVolumeMounts(nil)...)
 	}
 
-	runAsUser := int64(0)
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["KOLLA_BOOTSTRAP"] = env.SetValue("TRUE")
@@ -100,13 +94,11 @@ func DbSyncJob(instance *manilav1.Manila, labels map[string]string, annotations 
 							Command: []string{
 								"/bin/bash",
 							},
-							Args:  args,
-							Image: instance.Spec.ManilaAPI.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
-							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: dbSyncMounts,
+							Args:            args,
+							Image:           instance.Spec.ManilaAPI.ContainerImage,
+							SecurityContext: manilaDefaultSecurityContext(),
+							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:    dbSyncMounts,
 						},
 					},
 					Volumes: dbSyncVolume,

--- a/pkg/manila/funcs.go
+++ b/pkg/manila/funcs.go
@@ -19,13 +19,13 @@ func GetOwningManilaName(instance client.Object) string {
 	return ""
 }
 
-// GetManilaSecurityContext - Returns the right set of SecurityContext that
+// manilaDefaultSecurityContext - Returns the right set of SecurityContext that
 // does not violate the k8s requirements
-func GetManilaSecurityContext() *corev1.SecurityContext {
+func manilaDefaultSecurityContext() *corev1.SecurityContext {
 	falseVal := false
 	trueVal := true
-	runAsUser := int64(42429)
-	runAsGroup := int64(42429)
+	runAsUser := ManilaUserID
+	runAsGroup := ManilaGroupID
 	return &corev1.SecurityContext{
 		RunAsUser:                &runAsUser,
 		RunAsGroup:               &runAsGroup,

--- a/pkg/manilaapi/statefulset.go
+++ b/pkg/manilaapi/statefulset.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// ServiceCommand -
-	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
+	ServiceCommand = "/usr/local/bin/kolla_start"
 )
 
 // StatefulSet func
@@ -37,7 +37,7 @@ func StatefulSet(
 	labels map[string]string,
 	annotations map[string]string,
 ) (*appsv1.StatefulSet, error) {
-	runAsUser := int64(0)
+	manilaUser := manila.ManilaUserID
 
 	livenessProbe := &corev1.Probe{
 		TimeoutSeconds:      10,
@@ -134,7 +134,7 @@ func StatefulSet(
 							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
+								RunAsUser: &manilaUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: []corev1.VolumeMount{GetLogVolumeMount()},
@@ -154,7 +154,7 @@ func StatefulSet(
 							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
+								RunAsUser: &manilaUser,
 							},
 							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:   volumeMounts,

--- a/pkg/manilascheduler/statefulset.go
+++ b/pkg/manilascheduler/statefulset.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// ServiceCommand -
-	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
+	ServiceCommand = "/usr/local/bin/kolla_start"
 )
 
 // StatefulSet func
@@ -35,11 +35,8 @@ func StatefulSet(
 	labels map[string]string,
 	annotations map[string]string,
 ) *appsv1.StatefulSet {
-	rootUser := int64(0)
-	// manila's uid and gid magic numbers come from the 'manila-user' in
-	// https://github.com/openstack/kolla/blob/master/kolla/common/users.py
-	manilaUser := int64(42429)
-	manilaGroup := int64(42429)
+	manilaUser := manila.ManilaUserID
+	manilaGroup := manila.ManilaGroupID
 
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
@@ -115,7 +112,7 @@ func StatefulSet(
 							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &rootUser,
+								RunAsUser: &manilaUser,
 							},
 							Env:           env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:  volumeMounts,

--- a/pkg/manilashare/statefulset.go
+++ b/pkg/manilashare/statefulset.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// ServiceCommand -
-	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
+	ServiceCommand = "/usr/local/bin/kolla_start"
 )
 
 // StatefulSet func
@@ -36,11 +36,9 @@ func StatefulSet(
 	annotations map[string]string,
 ) *appsv1.StatefulSet {
 	trueVar := true
-	rootUser := int64(0)
-	// Manila's uid and gid magic numbers come from the 'manila-user' in
-	// https://github.com/openstack/kolla/blob/master/kolla/common/users.py
-	manilaUser := int64(42429)
-	manilaGroup := int64(42429)
+
+	manilaUser := manila.ManilaUserID
+	manilaGroup := manila.ManilaGroupID
 
 	// TODO until we determine how to properly query for these
 	livenessProbe := &corev1.Probe{
@@ -129,7 +127,7 @@ func StatefulSet(
 							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser:  &rootUser,
+								RunAsUser:  &manilaUser,
 								Privileged: &trueVar,
 							},
 							Env:           env.MergeEnvs([]corev1.EnvVar{}, envVars),

--- a/templates/manila/config/db-sync-config.json
+++ b/templates/manila/config/db-sync-config.json
@@ -1,3 +1,0 @@
-{
-  "command": "/usr/bin/manila-manage --config-dir /etc/manila/manila.conf.d db sync"
-}

--- a/templates/manila/config/httpd.conf
+++ b/templates/manila/config/httpd.conf
@@ -19,6 +19,7 @@ LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-A
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
+ErrorLog /dev/stdout
 
 # XXX: To disable SSL
 #Include conf.d/*.conf

--- a/templates/manila/config/manila-api-config.json
+++ b/templates/manila/config/manila-api-config.json
@@ -16,13 +16,13 @@
     {
       "source": "/var/lib/config-data/default/ssl.conf",
       "dest": "/etc/httpd/conf.d/ssl.conf",
-      "owner": "root",
+      "owner": "manila",
       "perm": "0644"
     },
     {
       "source": "/var/lib/config-data/tls/certs/*",
       "dest": "/etc/pki/tls/certs/",
-      "owner": "root",
+      "owner": "manila",
       "perm": "0640",
       "optional": true,
       "merge": true
@@ -30,7 +30,7 @@
     {
       "source": "/var/lib/config-data/tls/private/*",
       "dest": "/etc/pki/tls/private/",
-      "owner": "root",
+      "owner": "manila",
       "perm": "0600",
       "optional": true,
       "merge": true
@@ -41,6 +41,11 @@
           "path": "/var/log/manila",
           "owner": "manila:apache",
           "recurse": true
+      },
+      {
+	  "path": "/etc/httpd/run",
+	  "owner": "manila:apache",
+	  "recurse": true
       }
   ]
 }

--- a/test/kuttl/tests/manila-tls/03-assert.yaml
+++ b/test/kuttl/tests/manila-tls/03-assert.yaml
@@ -264,7 +264,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        - /usr/local/bin/kolla_start
         command:
         - /usr/bin/dumb-init
         volumeMounts:
@@ -365,7 +365,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        - /usr/local/bin/kolla_start
         command:
         - /usr/bin/dumb-init
         volumeMounts:
@@ -488,7 +488,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        - /usr/local/bin/kolla_start
         command:
         - /usr/bin/dumb-init
         volumeMounts:


### PR DESCRIPTION
This patch represents an improvment of the existing code to make sure we run manila services using the manila user instead of root.

Jira: https://issues.redhat.com/browse/OSPRH-9115