### PR TITLE
Update Ceph backend samples

### DIFF
--- a/config/samples/backends/ceph-nfs/backend.yaml
+++ b/config/samples/backends/ceph-nfs/backend.yaml
@@ -41,10 +41,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/config/samples/backends/cephfs/backend.yaml
+++ b/config/samples/backends/cephfs/backend.yaml
@@ -44,10 +44,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/config/samples/backends/multibackend/backend.yaml
+++ b/config/samples/backends/multibackend/backend.yaml
@@ -80,10 +80,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/config/samples/layout/cephfs/cephfs.yaml
+++ b/config/samples/layout/cephfs/cephfs.yaml
@@ -30,10 +30,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/config/samples/layout/multibackend/multibackend.yaml
+++ b/config/samples/layout/multibackend/multibackend.yaml
@@ -45,10 +45,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/config/samples/layout/tls/tls.yaml
+++ b/config/samples/layout/tls/tls.yaml
@@ -37,10 +37,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/test/kuttl/tests/manila-tls/03-assert.yaml
+++ b/test/kuttl/tests/manila-tls/03-assert.yaml
@@ -23,10 +23,8 @@ spec:
       - share0
       volumes:
       - name: ceph
-        projected:
-          sources:
-          - secret:
-              name: ceph-conf-files
+        secret:
+          secretName: ceph-conf-files
     name: v1
     region: r1
   manilaAPI:
@@ -450,10 +448,8 @@ spec:
           secret:
             secretName: manila-config-data
         - name: ceph
-          projected:
-            sources:
-            - secret:
-                name: ceph-conf-files
+          secret:
+            secretName: ceph-conf-files
         - name: var-lib-manila
           hostPath:
             path: /var/lib/manila


### PR DESCRIPTION
Update `extraMounts` struct to to use the `secret` volume type instead of `projected`. The projected volume type is used when multiple sources, but with `Ceph` we usually document a single source.