### PR TITLE
Move to VerifySecret when checking the ctlplane secret

### DIFF
--- a/controllers/manila_common.go
+++ b/controllers/manila_common.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
+	"k8s.io/apimachinery/pkg/types"
+	"time"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/manila-operator/pkg/manila"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type conditionUpdater interface {
+	Set(c *condition.Condition)
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+}
+
+// getServiceSecret - ensures that the Secret object exists and the expected
+// fields are in the Secret. It also sets a hash of the values of the expected
+// fields passed as input.
+func getServiceSecret(
+	ctx context.Context,
+	secretName types.NamespacedName,
+	expectedFields []string,
+	reader client.Reader,
+	conditionUpdater conditionUpdater,
+	requeueTimeout time.Duration,
+	envVars *map[string]env.Setter,
+) (ctrl.Result, error) {
+
+	hash, res, err := secret.VerifySecret(ctx, secretName, expectedFields, reader, requeueTimeout)
+	if err != nil {
+		conditionUpdater.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.InputReadyErrorMessage,
+			err.Error()))
+		return res, err
+	} else if (res != ctrl.Result{}) {
+		log.FromContext(ctx).Info(fmt.Sprintf("OpenStack secret %s not found", secretName))
+		conditionUpdater.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.InputReadyWaitingMessage))
+		return res, nil
+	}
+	(*envVars)[secretName.Name] = env.SetValue(hash)
+	return ctrl.Result{}, nil
+}
+
+// getConfigSecret - get the specified secret, and add its hash to envVars
+func getConfigSecret(
+	ctx context.Context,
+	h *helper.Helper,
+	conditionUpdater conditionUpdater,
+	secretName string,
+	namespace string,
+	envVars *map[string]env.Setter,
+) (ctrl.Result, error) {
+	secret, hash, err := secret.GetSecret(ctx, h, secretName, namespace)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			log.FromContext(ctx).Info(fmt.Sprintf("Secret %s not found", secretName))
+			conditionUpdater.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				condition.InputReadyWaitingMessage))
+			return manila.ResultRequeue, nil
+		}
+		conditionUpdater.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.InputReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+
+	// Add a prefix to the var name to avoid accidental collision with other non-secret
+	// vars. The secret names themselves will be unique.
+	(*envVars)["secret-"+secret.Name] = env.SetValue(hash)
+
+	return ctrl.Result{}, nil
+}

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -510,7 +510,7 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
 
-	result, err := getServiceSecret(
+	result, err := verifyServiceSecret(
 		ctx,
 		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
 		[]string{

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
@@ -508,27 +509,23 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
-	ospSecret, hash, err := secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			r.Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return manila.ResultRequeue, nil
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-	configVars[ospSecret.Name] = env.SetValue(hash)
 
+	result, err := getServiceSecret(
+		ctx,
+		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
+		[]string{
+			instance.Spec.PasswordSelectors.Service,
+		},
+		helper.GetClient(),
+		&instance.Status.Conditions,
+		manila.NormalDuration,
+		&configVars,
+	)
+	if err != nil {
+		return result, err
+	} else if (result != ctrl.Result{}) {
+		return result, nil
+	}
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 	// run check OpenStack secret - end
 

--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -638,31 +638,49 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
-	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configVars)
-	if err != nil {
+
+	ctrlResult, err := getServiceSecret(
+		ctx,
+		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
+		[]string{
+			instance.Spec.PasswordSelectors.Service,
+		},
+		helper.GetClient(),
+		&instance.Status.Conditions,
+		manila.NormalDuration,
+		&configVars,
+	)
+	if (err != nil || ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
 
 	//
+	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
+	//
+
+	ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, instance.Spec.TransportURLSecret, instance.Namespace, &configVars)
+	if (err != nil || ctrlResult != ctrl.Result{}) {
+		return ctrlResult, err
+	}
+	//
 	// check for required service secrets
 	//
 	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
-		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configVars)
-		if err != nil {
+		ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, secretName, instance.Namespace, &configVars)
+		if (err != nil || ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
 		}
 	}
 
 	parentManilaName := manila.GetOwningManilaName(instance)
-
 	parentSecrets := []string{
 		fmt.Sprintf("%s-scripts", parentManilaName),     // ScriptsSecret
 		fmt.Sprintf("%s-config-data", parentManilaName), // ConfigSecret
 	}
 
 	for _, parentSecret := range parentSecrets {
-		ctrlResult, err = r.getSecret(ctx, helper, instance, parentSecret, &configVars)
-		if err != nil {
+		ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, parentSecret, instance.Namespace, &configVars)
+		if (err != nil || ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
 		}
 	}
@@ -921,41 +939,6 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 	if instance.IsReady() {
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 	}
-	return ctrl.Result{}, nil
-}
-
-// getSecret - get the specified secret, and add its hash to envVars
-func (r *ManilaAPIReconciler) getSecret(
-	ctx context.Context,
-	h *helper.Helper,
-	instance *manilav1beta1.ManilaAPI,
-	secretName string,
-	envVars *map[string]env.Setter,
-) (ctrl.Result, error) {
-	secret, hash, err := secret.GetSecret(ctx, h, secretName, instance.Namespace)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			r.Log.Info(fmt.Sprintf("Secret %s not found", secretName))
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return manila.ResultRequeue, nil
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-
-	// Add a prefix to the var name to avoid accidental collision with other non-secret
-	// vars. The secret names themselves will be unique.
-	(*envVars)["secret-"+secret.Name] = env.SetValue(hash)
-
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -639,7 +639,7 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
 
-	ctrlResult, err := getServiceSecret(
+	ctrlResult, err := verifyServiceSecret(
 		ctx,
 		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
 		[]string{
@@ -658,31 +658,25 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
 
-	ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, instance.Spec.TransportURLSecret, instance.Namespace, &configVars)
-	if (err != nil || ctrlResult != ctrl.Result{}) {
-		return ctrlResult, err
-	}
-	//
-	// check for required service secrets
-	//
-	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
-		ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, secretName, instance.Namespace, &configVars)
-		if (err != nil || ctrlResult != ctrl.Result{}) {
-			return ctrlResult, err
-		}
-	}
-
 	parentManilaName := manila.GetOwningManilaName(instance)
-	parentSecrets := []string{
+	secretNames := []string{
+		instance.Spec.TransportURLSecret,                // TransportURLSecret
 		fmt.Sprintf("%s-scripts", parentManilaName),     // ScriptsSecret
 		fmt.Sprintf("%s-config-data", parentManilaName), // ConfigSecret
 	}
+	// Append CustomServiceConfigSecrets that should be checked
+	secretNames = append(secretNames, instance.Spec.CustomServiceConfigSecrets...)
 
-	for _, parentSecret := range parentSecrets {
-		ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, parentSecret, instance.Namespace, &configVars)
-		if (err != nil || ctrlResult != ctrl.Result{}) {
-			return ctrlResult, err
-		}
+	ctrlResult, err = verifyConfigSecrets(
+		ctx,
+		helper,
+		&instance.Status.Conditions,
+		secretNames,
+		instance.Namespace,
+		&configVars,
+	)
+	if (err != nil || ctrlResult != ctrl.Result{}) {
+		return ctrlResult, err
 	}
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -323,15 +323,30 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
-	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.Secret, &configVars)
+
+	ctrlResult, err := getServiceSecret(
+		ctx,
+		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
+		[]string{
+			instance.Spec.PasswordSelectors.Service,
+		},
+		helper.GetClient(),
+		&instance.Status.Conditions,
+		manila.NormalDuration,
+		&configVars,
+	)
 	if err != nil {
 		return ctrlResult, err
+	} else if (ctrlResult != ctrl.Result{}) {
+		return ctrlResult, nil
 	}
+
 	//
 	// check for required TransportURL secret holding transport URL string
 	//
-	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configVars)
-	if err != nil {
+
+	ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, instance.Spec.TransportURLSecret, instance.Namespace, &configVars)
+	if (err != nil || ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
 
@@ -339,8 +354,8 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	// check for required service secrets
 	//
 	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
-		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configVars)
-		if err != nil {
+		ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, secretName, instance.Namespace, &configVars)
+		if (err != nil || ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
 		}
 	}
@@ -352,8 +367,8 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 
 	for _, parentSecret := range parentSecrets {
-		ctrlResult, err = r.getSecret(ctx, helper, instance, parentSecret, &configVars)
-		if err != nil {
+		ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, parentSecret, instance.Namespace, &configVars)
+		if (err != nil || ctrlResult != ctrl.Result{}) {
 			return ctrlResult, err
 		}
 	}
@@ -576,41 +591,6 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	if instance.IsReady() {
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 	}
-	return ctrl.Result{}, nil
-}
-
-// getSecret - get the specified secret, and add its hash to envVars
-func (r *ManilaSchedulerReconciler) getSecret(
-	ctx context.Context,
-	h *helper.Helper,
-	instance *manilav1beta1.ManilaScheduler,
-	secretName string,
-	envVars *map[string]env.Setter,
-) (ctrl.Result, error) {
-	secret, hash, err := secret.GetSecret(ctx, h, secretName, instance.Namespace)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			r.Log.Info(fmt.Sprintf("Secret %s not found", secretName))
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return manila.ResultRequeue, nil
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-
-	// Add a prefix to the var name to avoid accidental collision with other non-secret
-	// vars. The secret names themselves will be unique.
-	(*envVars)["secret-"+secret.Name] = env.SetValue(hash)
-
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -324,7 +324,7 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
 
-	ctrlResult, err := getServiceSecret(
+	ctrlResult, err := verifyServiceSecret(
 		ctx,
 		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
 		[]string{
@@ -342,35 +342,29 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 
 	//
-	// check for required TransportURL secret holding transport URL string
-	//
-
-	ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, instance.Spec.TransportURLSecret, instance.Namespace, &configVars)
-	if (err != nil || ctrlResult != ctrl.Result{}) {
-		return ctrlResult, err
-	}
-
-	//
 	// check for required service secrets
 	//
-	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
-		ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, secretName, instance.Namespace, &configVars)
-		if (err != nil || ctrlResult != ctrl.Result{}) {
-			return ctrlResult, err
-		}
-	}
 
 	parentManilaName := manila.GetOwningManilaName(instance)
-	parentSecrets := []string{
-		fmt.Sprintf("%s-scripts", parentManilaName),     // ScriptsConfigMap
-		fmt.Sprintf("%s-config-data", parentManilaName), // ConfigMap
+	secretNames := []string{
+		instance.Spec.TransportURLSecret,                // TransportURLSecret
+		fmt.Sprintf("%s-scripts", parentManilaName),     // ScriptsSecret
+		fmt.Sprintf("%s-config-data", parentManilaName), // ConfigSecret
 	}
 
-	for _, parentSecret := range parentSecrets {
-		ctrlResult, err = getConfigSecret(ctx, helper, &instance.Status.Conditions, parentSecret, instance.Namespace, &configVars)
-		if (err != nil || ctrlResult != ctrl.Result{}) {
-			return ctrlResult, err
-		}
+	// Append CustomServiceConfigSecrets that should be checked
+	secretNames = append(secretNames, instance.Spec.CustomServiceConfigSecrets...)
+
+	ctrlResult, err = verifyConfigSecrets(
+		ctx,
+		helper,
+		&instance.Status.Conditions,
+		secretNames,
+		instance.Namespace,
+		&configVars,
+	)
+	if (err != nil || ctrlResult != ctrl.Result{}) {
+		return ctrlResult, err
 	}
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 


### PR DESCRIPTION
Currently we get the provided `osp_secret` and we build the hash of the entire secret.
If an unrelated field is added or changed, this cause a rollout of new manila `Pods`, resulting in an entire service restart in all its components (API, Scheduler and Share services are terminated and recreated).

This change does two main things:
1. replace the `GetSecret` call to `VerifySecret` where possible
2. build a common function that is called by all controllers (top level, `manilaAPI`, `manilaScheduler`, `manilaShare`) to verify the control plane secret exists and has the expected fields

By having a common file for all controllers we are able to also start some code deduplication (that will continue in follow up patches as it's out of scope).

Jira: https://issues.redhat.com/browse/OSPRH-8290