### PR TITLE
Add runAsNonRoot annotation to the kube-rbac-proxy

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -12,6 +12,7 @@ spec:
       - name: kube-rbac-proxy
         securityContext:
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
           capabilities:
             drop:
               - "ALL"


### PR DESCRIPTION
A static analysis (SAST) has detected potential
bug(s) or issue(s) within the manila-operator:

Error: SIGMA.container_running_as_root (CWE-269):
unpacked_remote_sources/app/config/default/manager_auth_proxy_patch.yaml:14: Sigma main event: The Kubernetes container is allowed to run as the root user. This may allow attackers to gain the root privileges of the host when the container is compromised.
unpacked_remote_sources/app/config/default/manager_auth_proxy_patch.yaml:14: remediation: Explicitly set the `securityContext.runAsNonRoot` value to `true` to prevent the container from running as a root-level user.

kube-rbac-proxy does run rootless by default [1][2]; however, this annotation shouldn't hurt in case the underlying container image changes in the future.

Jira: OSPRH-9115
[1] https://github.com/brancz/kube-rbac-proxy/blob/b76470f11760731a6ddb6977cd11ac25929ed0a0/Dockerfile#L9C6-L9C11
[2] https://github.com/operator-framework/operator-sdk/pull/4498

(cherry picked from commit 6c1ed08a7fec16c8cd6aa3210cd241b73a33ebf4)