### PR TITLE
Add ManilaShare instance name as label

### DIFF
--- a/api/v1beta1/manilashare_types.go
+++ b/api/v1beta1/manilashare_types.go
@@ -25,6 +25,11 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	// ShareNameLabel - Label used to identify the manila-share name / backend
+	ShareNameLabel = "share-name"
+)
+
 // ManilaShareTemplate defines the input parameter for the ManilaShare service
 type ManilaShareTemplate struct {
 
@@ -132,4 +137,10 @@ func init() {
 // IsReady - returns true if service is ready to serve requests
 func (instance ManilaShare) IsReady() bool {
 	return instance.Status.ReadyCount == *instance.Spec.Replicas
+}
+
+// ShareName - returns the name used to identify the ManilaShare
+func (instance ManilaShare) ShareName() string {
+	// The information is stored as a label
+	return instance.Labels[ShareNameLabel]
 }

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -738,7 +738,7 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 	// Deploy ManilaShare
 	var shareCondition *condition.Condition
 	for name, share := range instance.Spec.ManilaShares {
-		manilaShare, op, err := r.shareDeploymentCreateOrUpdate(ctx, instance, name, share)
+		manilaShare, op, err := r.shareDeploymentCreateOrUpdate(ctx, instance, name, share, serviceLabels)
 		if err != nil {
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				manilav1beta1.ManilaShareReadyCondition,
@@ -1031,11 +1031,21 @@ func (r *ManilaReconciler) schedulerDeploymentCreateOrUpdate(ctx context.Context
 	return deployment, op, err
 }
 
-func (r *ManilaReconciler) shareDeploymentCreateOrUpdate(ctx context.Context, instance *manilav1beta1.Manila, name string, share manilav1beta1.ManilaShareTemplate) (*manilav1beta1.ManilaShare, controllerutil.OperationResult, error) {
+func (r *ManilaReconciler) shareDeploymentCreateOrUpdate(
+	ctx context.Context,
+	instance *manilav1beta1.Manila,
+	name string,
+	share manilav1beta1.ManilaShareTemplate,
+	serviceLabels map[string]string,
+) (*manilav1beta1.ManilaShare, controllerutil.OperationResult, error) {
+
+	// Add the ShareName to the ManilaShare instance as a label
+	serviceLabels[manilav1beta1.ShareNameLabel] = name
 	deployment := &manilav1beta1.ManilaShare{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-share-%s", instance.Name, name),
 			Namespace: instance.Namespace,
+			Labels:    serviceLabels,
 		},
 	}
 

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -406,8 +406,9 @@ func (r *ManilaShareReconciler) reconcileNormal(ctx context.Context, instance *m
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
 
 	serviceLabels := map[string]string{
-		common.AppSelector:       manila.ServiceName,
-		common.ComponentSelector: manilashare.ComponentName,
+		common.AppSelector:           manila.ServiceName,
+		common.ComponentSelector:     manilashare.ComponentName,
+		manilav1beta1.ShareNameLabel: instance.ShareName(),
 	}
 	//
 	// create service Secrets for manila-share service


### PR DESCRIPTION
As done for `Glance`, where we might be more than one API with arbitrary names (the same applies to `Cinder`), it's easier to store and retrieve the `ManilaShare` `instanceName` from the `Label`, instead of hardcoding part of the pod name in a string. This way the code is more solid and we have to reduce the amount of string manipulation.