### PR TITLE
Add cronJob envTests

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/onsi/gomega" //revive:disable:dot-imports
 	"golang.org/x/exp/maps"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -324,4 +325,12 @@ func ManilaShareNotExists(name types.NamespacedName) {
 		err := k8sClient.Get(ctx, name, instance)
 		g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue())
 	}, timeout, interval).Should(Succeed())
+}
+
+func GetCronJob(name types.NamespacedName) *batchv1.CronJob {
+	cron := &batchv1.CronJob{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, cron)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return cron
 }

--- a/test/functional/manila_test_data.go
+++ b/test/functional/manila_test_data.go
@@ -69,6 +69,7 @@ type ManilaTestData struct {
 	CABundleSecret              types.NamespacedName
 	InternalCertSecret          types.NamespacedName
 	PublicCertSecret            types.NamespacedName
+	DBPurgeCronJob              types.NamespacedName
 }
 
 // GetManilaTestData is a function that initialize the ManilaTestData
@@ -190,6 +191,10 @@ func GetManilaTestData(manilaName types.NamespacedName) ManilaTestData {
 		PublicCertSecret: types.NamespacedName{
 			Namespace: manilaName.Namespace,
 			Name:      PublicCertSecretName,
+		},
+		DBPurgeCronJob: types.NamespacedName{
+			Namespace: manilaName.Namespace,
+			Name:      fmt.Sprintf("%s-db-purge", manilaName.Name),
 		},
 	}
 }


### PR DESCRIPTION
This patch improves the existing `envTests` to include `cronJob` verification and update. It shows how an update in the `Manila` top level CR is reflected in an update to the `CronJob` schedule.