### PR TITLE
Share cleanup job

### DIFF
--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -25,7 +25,8 @@ import (
 const (
 	// DbSyncHash hash
 	DbSyncHash = "dbsync"
-
+	// SvcCleanupHash hash
+	SvcCleanupHash = "servicecleanup"
 	// DeploymentHash hash used to detect changes
 	DeploymentHash = "deployment"
 )

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -374,6 +374,7 @@ func (r *ManilaReconciler) reconcileInit(
 		nil,
 		manila.DBSyncJobName,
 		manila.DBSyncCommand,
+		0, // no need to delay dbSync
 	)
 	dbSyncjob := job.NewJob(
 		jobDef,
@@ -799,6 +800,7 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 			ptr.To(manila.TTL),
 			fmt.Sprintf("%s-%s", manila.SvcCleanupJobName, hash[:manila.TruncateHash]),
 			manila.SvcCleanupCommand,
+			manila.ManilaServiceCleanupDelay,
 		)
 		shareCleanupJob := job.NewJob(
 			jobDef,

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -366,7 +366,13 @@ func (r *ManilaReconciler) reconcileInit(
 	// run manila db sync
 	//
 	dbSyncHash := instance.Status.Hash[manilav1beta1.DbSyncHash]
-	jobDef := manila.DbSyncJob(instance, serviceLabels, serviceAnnotations)
+	jobDef := manila.Job(
+		instance,
+		serviceLabels,
+		serviceAnnotations,
+		manila.DBSyncJobName,
+		manila.DBSyncCommand,
+	)
 	dbSyncjob := job.NewJob(
 		jobDef,
 		manilav1beta1.DbSyncHash,
@@ -778,11 +784,38 @@ func (r *ManilaReconciler) reconcileNormal(ctx context.Context, instance *manila
 	instance.Status.Conditions.MarkTrue(condition.CronJobReadyCondition, condition.CronJobReadyMessage)
 	// create CronJob - end
 
-	err = r.shareCleanup(ctx, instance)
+	cleanJob, err := r.shareCleanup(ctx, instance)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
+	if cleanJob {
+		jobDef := manila.Job(
+			instance,
+			serviceLabels,
+			serviceAnnotations,
+			manila.SvcCleanupJobName,
+			manila.SvcCleanupCommand,
+		)
+		svcCleanupHash := instance.Status.Hash[manilav1beta1.SvcCleanupHash]
+		shareCleanupJob := job.NewJob(
+			jobDef,
+			manilav1beta1.SvcCleanupHash,
+			instance.Spec.PreserveJobs,
+			manila.ShortDuration,
+			svcCleanupHash,
+		)
+		ctrlResult, err := shareCleanupJob.DoJob(
+			ctx,
+			helper,
+		)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, nil
+		}
+	}
 	r.Log.Info(fmt.Sprintf("Reconciled Service '%s' successfully", instance.Name))
 	// update the overall status condition if service is ready
 	if instance.IsReady() {
@@ -1216,15 +1249,16 @@ func (r *ManilaReconciler) checkManilaShareGeneration(
 func (r *ManilaReconciler) shareCleanup(
 	ctx context.Context,
 	instance *manilav1beta1.Manila,
-) error {
+) (bool, error) {
 	// Generate a list of share CRs
 	shares := &manilav1beta1.ManilaShareList{}
+	cleanJob := false
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),
 	}
 	if err := r.Client.List(ctx, shares, listOpts...); err != nil {
 		r.Log.Error(err, "Unable to retrieve Manila Share CRs %v")
-		return nil
+		return cleanJob, nil
 	}
 	for _, share := range shares.Items {
 		// Skip shares CRs that we don't own
@@ -1238,10 +1272,11 @@ func (r *ManilaReconciler) shareCleanup(
 			err := r.Client.Delete(ctx, &share)
 			if err != nil && !k8s_errors.IsNotFound(err) {
 				err = fmt.Errorf("Error cleaning up %s: %w", share.Name, err)
-				return err
+				return cleanJob, err
 			}
 			delete(instance.Status.ManilaSharesReadyCounts, share.ShareName())
+			cleanJob = true
 		}
 	}
-	return nil
+	return cleanJob, nil
 }

--- a/pkg/manila/const.go
+++ b/pkg/manila/const.go
@@ -79,8 +79,14 @@ const (
 	ShortDuration = time.Duration(5) * time.Second
 	// NormalDuration -
 	NormalDuration = time.Duration(10) * time.Second
-	//DBSyncCommand -
+	// DBSyncJobName -
+	DBSyncJobName = "db-sync"
+	// DBSyncCommand -
 	DBSyncCommand = "/usr/bin/manila-manage --config-dir /etc/manila/manila.conf.d db sync"
+	// SvcCleanupJobName -
+	SvcCleanupJobName = "service-cleanup"
+	// SvcCleanupCommand -
+	SvcCleanupCommand = "/usr/bin/manila-manage --config-dir /etc/manila/manila.conf.d service cleanup"
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/pkg/manila/const.go
+++ b/pkg/manila/const.go
@@ -87,6 +87,10 @@ const (
 	SvcCleanupJobName = "service-cleanup"
 	// SvcCleanupCommand -
 	SvcCleanupCommand = "/usr/bin/manila-manage --config-dir /etc/manila/manila.conf.d service cleanup"
+	// TruncateHash -
+	TruncateHash int = 8
+	// TTL -
+	TTL int32 = 5 * 60 // 5 minutes
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/pkg/manila/const.go
+++ b/pkg/manila/const.go
@@ -43,12 +43,13 @@ const (
 	ManilaUserID int64 = 42429
 	// ManilaGroupID -
 	ManilaGroupID int64 = 42429
-
 	// ManilaPublicPort -
 	ManilaPublicPort int32 = 8786
 	// ManilaInternalPort -
 	ManilaInternalPort int32 = 8786
-
+	// ManilaServiceCleanupDelay - Time in seconds that the ServiceCleanupJob
+	// needs to wait before executing the manila-manage command
+	ManilaServiceCleanupDelay int32 = 120
 	// ManilaExtraVolTypeUndefined can be used to label an extraMount which
 	// is not associated with a specific backend
 	ManilaExtraVolTypeUndefined storage.ExtraVolType = "Undefined"

--- a/pkg/manila/funcs.go
+++ b/pkg/manila/funcs.go
@@ -3,6 +3,7 @@ package manila
 import (
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,4 +55,14 @@ func GetPodAffinity(componentName string) *corev1.Affinity {
 		},
 		corev1.LabelHostname,
 	)
+}
+
+// SharesListHash - Given a list of share names passed as an array of strings,
+// it returns an hash that is currently used to build the job name
+func SharesListHash(shareNames []string) (string, error) {
+	hash, err := util.ObjectHash(shareNames)
+	if err != nil {
+		return hash, err
+	}
+	return hash, err
 }

--- a/pkg/manila/job.go
+++ b/pkg/manila/job.go
@@ -9,11 +9,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ManilaJob func
+// Job func
 func Job(
 	instance *manilav1.Manila,
 	labels map[string]string,
 	annotations map[string]string,
+	ttl *int32,
 	jobName string,
 	jobCommand string,
 ) *batchv1.Job {
@@ -82,7 +83,6 @@ func Job(
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			//Name:      instance.Name + "-db-sync",
 			Name:      fmt.Sprintf("%s-%s", instance.Name, jobName),
 			Namespace: instance.Namespace,
 			Labels:    labels,
@@ -113,6 +113,9 @@ func Job(
 			},
 		},
 	}
-
+	if ttl != nil {
+		// Setting TTL to delete the job after it has completed
+		job.Spec.TTLSecondsAfterFinished = ttl
+	}
 	return job
 }

--- a/pkg/manila/job.go
+++ b/pkg/manila/job.go
@@ -17,6 +17,7 @@ func Job(
 	ttl *int32,
 	jobName string,
 	jobCommand string,
+	delay int32,
 ) *batchv1.Job {
 	var config0644AccessMode int32 = 0644
 	// Unlike the individual manila services, DbSyncJob or a Job executing a
@@ -69,7 +70,8 @@ func Job(
 		},
 	}
 
-	args := []string{"-c", jobCommand}
+	delayCommand := fmt.Sprintf("sleep %d", delay)
+	args := []string{"-c", fmt.Sprintf("%s && %s", delayCommand, jobCommand)}
 
 	// add CA cert if defined
 	if instance.Spec.ManilaAPI.TLS.CaBundleSecretName != "" {


### PR DESCRIPTION
When a backend config is removed, the "service" database entry in manila needs to be adjusted to account for the removal. This patch introduces a Job that runs a manila-manage command every time a share is scaled down. The main job definition is now more flexible and we can pass a `TTL` in case we want to customize the time the job is kept.

Jira: https://issues.redhat.com/browse/OSPRH-6526
