### PR TITLE
Add ensureNAD common function

### DIFF
--- a/api/v1beta1/manila_webhook.go
+++ b/api/v1beta1/manila_webhook.go
@@ -248,12 +248,12 @@ func (spec *ManilaSpecCore) SetDefaultRouteAnnotations(annotations map[string]st
 	valHAProxy, okHAProxy := annotations[haProxyAnno]
 
 	// Human operator set the HAProxy timeout manually
-	if (!okManila && okHAProxy) {
+	if !okManila && okHAProxy {
 		return
 	}
 
 	// Human operator modified the HAProxy timeout manually without removing the Manila flag
-	if (okManila && okHAProxy && valManila != valHAProxy) {
+	if okManila && okHAProxy && valManila != valHAProxy {
 		delete(annotations, manilaAnno)
 		return
 	}

--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -786,44 +786,11 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 	}
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 
-	//
-	// TODO check when/if Init, Update, or Upgrade should/could be skipped
-	//
-
-	// networks to attach to
-	for _, netAtt := range instance.Spec.NetworkAttachments {
-		_, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
-		if err != nil {
-			if k8s_errors.IsNotFound(err) {
-				r.Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
-				instance.Status.Conditions.Set(condition.FalseCondition(
-					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
-					condition.NetworkAttachmentsReadyWaitingMessage,
-					netAtt))
-				return manila.ResultRequeue, nil
-			}
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.NetworkAttachmentsReadyCondition,
-				condition.ErrorReason,
-				condition.SeverityWarning,
-				condition.NetworkAttachmentsReadyErrorMessage,
-				err.Error()))
-			return ctrl.Result{}, err
-		}
-	}
-
-	serviceAnnotations, err := nad.CreateNetworksAnnotation(instance.Namespace, instance.Spec.NetworkAttachments)
+	var serviceAnnotations map[string]string
+	// Ensure NAD annotations are generated
+	serviceAnnotations, ctrlResult, err = ensureNAD(ctx, &instance.Status.Conditions, instance.Spec.NetworkAttachments, helper)
 	if err != nil {
-		err := fmt.Errorf("failed create network annotation from %s: %w", instance.Spec.NetworkAttachments, err)
-		instance.Status.Conditions.MarkFalse(
-			condition.NetworkAttachmentsReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.NetworkAttachmentsReadyErrorMessage,
-			err)
-		return ctrl.Result{}, err
+		return ctrlResult, err
 	}
 
 	// Handle service init

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -335,10 +335,8 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 		manila.NormalDuration,
 		&configVars,
 	)
-	if err != nil {
+	if (err != nil || ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
 	}
 
 	//
@@ -453,44 +451,11 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 
-	//
-	// TODO check when/if Init, Update, or Upgrade should/could be skipped
-	//
-
-	// networks to attach to
-	for _, netAtt := range instance.Spec.NetworkAttachments {
-		_, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
-		if err != nil {
-			if k8s_errors.IsNotFound(err) {
-				r.Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
-				instance.Status.Conditions.Set(condition.FalseCondition(
-					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
-					condition.NetworkAttachmentsReadyWaitingMessage,
-					netAtt))
-				return manila.ResultRequeue, nil
-			}
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.NetworkAttachmentsReadyCondition,
-				condition.ErrorReason,
-				condition.SeverityWarning,
-				condition.NetworkAttachmentsReadyErrorMessage,
-				err.Error()))
-			return ctrl.Result{}, err
-		}
-	}
-
-	serviceAnnotations, err := nad.CreateNetworksAnnotation(instance.Namespace, instance.Spec.NetworkAttachments)
+	var serviceAnnotations map[string]string
+	// Ensure NAD annotations are generated
+	serviceAnnotations, ctrlResult, err = ensureNAD(ctx, &instance.Status.Conditions, instance.Spec.NetworkAttachments, helper)
 	if err != nil {
-		err := fmt.Errorf("failed create network annotation from %s: %w", instance.Spec.NetworkAttachments, err)
-		instance.Status.Conditions.MarkFalse(
-			condition.NetworkAttachmentsReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.NetworkAttachmentsReadyErrorMessage,
-			err)
-		return ctrl.Result{}, err
+		return ctrlResult, err
 	}
 
 	//


### PR DESCRIPTION
This patch improves the work started with `verifyServiceSecret` and introduces an `ensureNAD` function that is common to all the `Manila` controllers. In addition, the compound form is extended to all the `verifyServiceSecret` function calls.