### PR TITLE
Do not use strings.TrimPrefix to get ShareName

### DIFF
--- a/pkg/manila/volumes.go
+++ b/pkg/manila/volumes.go
@@ -48,12 +48,6 @@ func GetVolumes(name string, extraVol []manilav1.ManilaExtraVolMounts, svc []sto
 				},
 			},
 		},
-		/*{
-			Name: "config-data-merged",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
-			},
-		},*/
 	}
 
 	for _, exv := range extraVol {

--- a/pkg/manilashare/statefulset.go
+++ b/pkg/manilashare/statefulset.go
@@ -81,11 +81,13 @@ func StatefulSet(
 	volumes := GetVolumes(
 		manila.GetOwningManilaName(instance),
 		instance.Name,
-		instance.Spec.ExtraMounts)
+		instance.Spec.ExtraMounts,
+		instance.ShareName(),
+	)
 
 	volumeMounts := GetVolumeMounts(
-		instance.Name,
 		instance.Spec.ExtraMounts,
+		instance.ShareName(),
 	)
 
 	// Add the CA bundle

--- a/pkg/manilashare/volumes.go
+++ b/pkg/manilashare/volumes.go
@@ -5,11 +5,15 @@ import (
 	manilav1 "github.com/openstack-k8s-operators/manila-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/manila-operator/pkg/manila"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 // GetVolumes -
-func GetVolumes(parentName string, name string, extraVol []manilav1.ManilaExtraVolMounts) []corev1.Volume {
+func GetVolumes(
+	parentName string,
+	name string,
+	extraVol []manilav1.ManilaExtraVolMounts,
+	propagationInstanceName string,
+) []corev1.Volume {
 	var config0644AccessMode int32 = 0644
 	var dirOrCreate = corev1.HostPathDirectoryOrCreate
 
@@ -35,12 +39,15 @@ func GetVolumes(parentName string, name string, extraVol []manilav1.ManilaExtraV
 	}
 
 	// Set the propagation levels for ManilaShare, including the backend name
-	propagation := append(manila.ManilaSharePropagation, storage.PropagationType(strings.TrimPrefix(name, "manila-share-")))
+	propagation := append(manila.ManilaSharePropagation, storage.PropagationType(propagationInstanceName))
 	return append(manila.GetVolumes(parentName, extraVol, propagation), shareVolumes...)
 }
 
 // GetVolumeMounts - Manila Share VolumeMounts
-func GetVolumeMounts(name string, extraVol []manilav1.ManilaExtraVolMounts) []corev1.VolumeMount {
+func GetVolumeMounts(
+	extraVol []manilav1.ManilaExtraVolMounts,
+	propagationInstanceName string,
+) []corev1.VolumeMount {
 	shareVolumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "config-data-custom",
@@ -59,6 +66,6 @@ func GetVolumeMounts(name string, extraVol []manilav1.ManilaExtraVolMounts) []co
 	}
 
 	// Set the propagation levels for ManilaShare, including the backend name
-	propagation := append(manila.ManilaSharePropagation, storage.PropagationType(strings.TrimPrefix(name, "manila-share-")))
+	propagation := append(manila.ManilaSharePropagation, storage.PropagationType(propagationInstanceName))
 	return append(manila.GetVolumeMounts(extraVol, propagation), shareVolumeMounts...)
 }


### PR DESCRIPTION
As done with Cinder as part of [1], and to make Manila consistent with that work, this patch removes the need of using `strings.TrimPrefix` and instead relies on the `ShareName()` function that returns the instance name stored as label in every `manilaShare` instance.

[1] https://github.com/openstack-k8s-operators/cinder-operator/pull/463