### PR TITLE
Ensure nodeSelector logic is consistent for all operators

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -67,7 +67,7 @@ type ManilaServiceTemplate struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
 	// any global NodeSelector settings within the Manila CR.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="# add your customization here"

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -111,7 +111,7 @@ type ManilaSpecBase struct {
 	// NodeSelector to target subset of worker nodes running this service. Setting
 	// NodeSelector here acts as a default value and can be overridden by service
 	// specific NodeSelector Settings.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// DBPurge parameters -

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -512,9 +512,13 @@ func (in *ManilaServiceTemplate) DeepCopyInto(out *ManilaServiceTemplate) {
 	*out = *in
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.CustomServiceConfigSecrets != nil {
@@ -744,9 +748,13 @@ func (in *ManilaSpecBase) DeepCopyInto(out *ManilaSpecBase) {
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	out.DBPurge = in.DBPurge

--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -977,12 +977,13 @@ func (r *ManilaReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, inst
 		ServiceAccount:     instance.RbacResourceName(),
 	}
 
+	if apiSpec.NodeSelector == nil {
+		apiSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = apiSpec
 
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
@@ -1014,12 +1015,12 @@ func (r *ManilaReconciler) schedulerDeploymentCreateOrUpdate(ctx context.Context
 		TLS:                     instance.Spec.ManilaAPI.TLS.Ca,
 	}
 
+	if schedulerSpec.NodeSelector == nil {
+		schedulerSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = schedulerSpec
-
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
@@ -1061,12 +1062,12 @@ func (r *ManilaReconciler) shareDeploymentCreateOrUpdate(
 		TLS:                 instance.Spec.ManilaAPI.TLS.Ca,
 	}
 
+	if shareSpec.NodeSelector == nil {
+		shareSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = shareSpec
-
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)

--- a/pkg/manila/cronjob.go
+++ b/pkg/manila/cronjob.go
@@ -124,8 +124,9 @@ func CronJob(
 			},
 		},
 	}
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+
+	if instance.Spec.NodeSelector != nil {
+		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return cronjob

--- a/pkg/manila/job.go
+++ b/pkg/manila/job.go
@@ -2,6 +2,7 @@ package manila
 
 import (
 	"fmt"
+
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	manilav1 "github.com/openstack-k8s-operators/manila-operator/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -118,6 +119,9 @@ func Job(
 	if ttl != nil {
 		// Setting TTL to delete the job after it has completed
 		job.Spec.TTLSecondsAfterFinished = ttl
+	}
+	if instance.Spec.NodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 	return job
 }

--- a/pkg/manilaapi/statefulset.go
+++ b/pkg/manilaapi/statefulset.go
@@ -163,12 +163,15 @@ func StatefulSet(
 							LivenessProbe:  livenessProbe,
 						},
 					},
-					Affinity:     manila.GetPodAffinity(ComponentName),
-					NodeSelector: instance.Spec.NodeSelector,
-					Volumes:      volumes,
+					Affinity: manila.GetPodAffinity(ComponentName),
+					Volumes:  volumes,
 				},
 			},
 		},
+	}
+
+	if instance.Spec.NodeSelector != nil {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return statefulset, nil

--- a/pkg/manilascheduler/statefulset.go
+++ b/pkg/manilascheduler/statefulset.go
@@ -131,12 +131,15 @@ func StatefulSet(
 							VolumeMounts: volumeMounts,
 						},
 					},
-					Affinity:     manila.GetPodAffinity(ComponentName),
-					NodeSelector: instance.Spec.NodeSelector,
-					Volumes:      volumes,
+					Affinity: manila.GetPodAffinity(ComponentName),
+					Volumes:  volumes,
 				},
 			},
 		},
+	}
+
+	if instance.Spec.NodeSelector != nil {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return statefulset

--- a/pkg/manilashare/statefulset.go
+++ b/pkg/manilashare/statefulset.go
@@ -149,12 +149,15 @@ func StatefulSet(
 							VolumeMounts: volumeMounts,
 						},
 					},
-					Affinity:     manila.GetPodAffinity(ComponentName),
-					NodeSelector: instance.Spec.NodeSelector,
-					Volumes:      volumes,
+					Affinity: manila.GetPodAffinity(ComponentName),
+					Volumes:  volumes,
 				},
 			},
 		},
+	}
+
+	if instance.Spec.NodeSelector != nil {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return statefulset

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -73,7 +73,9 @@ func GetDefaultManilaSpec() map[string]interface{} {
 		"secret":           SecretName,
 		"manilaAPI":        GetDefaultManilaAPISpec(),
 		"manilaScheduler":  GetDefaultManilaSchedulerSpec(),
-		"manilaShare":      GetDefaultManilaShareSpec(),
+		"manilaShares": map[string]interface{}{
+			"share0": GetDefaultManilaShareSpec(),
+		},
 	}
 }
 


### PR DESCRIPTION
nodeSelectors are not currently applied consistently across all operators.

Some do not support nodeSelectors at all - will be implemented in this series of pull requests.
Some do not apply them to every pod (jobs/cronjobs esp) - will be resolved in this series of pull requests.
Some do not apply a node selector update correctly, only when not initially set.
Some support nodeSelectors but do not inherit the default nodeSelector from the OpenstackControlPlane CR.

Jira: [OSPRH-10734](https://issues.redhat.com//browse/OSPRH-10734)