### PR TITLE
Add extraMounts functional tests

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -336,3 +336,37 @@ func GetCronJob(name types.NamespacedName) *batchv1.CronJob {
 	}, timeout, interval).Should(Succeed())
 	return cron
 }
+
+// GetExtraMounts - Utility function that simulates extraMounts pointing
+// to a Ceph secret
+func GetExtraMounts() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"name":   manilaTest.Instance.Name,
+			"region": "az0",
+			"extraVol": []map[string]interface{}{
+				{
+					"extraVolType": ManilaCephExtraMountsSecretName,
+					"propagation": []string{
+						"ManilaShare",
+					},
+					"volumes": []map[string]interface{}{
+						{
+							"name": ManilaCephExtraMountsSecretName,
+							"secret": map[string]interface{}{
+								"secretName": ManilaCephExtraMountsSecretName,
+							},
+						},
+					},
+					"mounts": []map[string]interface{}{
+						{
+							"name":      ManilaCephExtraMountsSecretName,
+							"mountPath": ManilaCephExtraMountsPath,
+							"readOnly":  true,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/test/functional/manila_test_data.go
+++ b/test/functional/manila_test_data.go
@@ -33,6 +33,10 @@ const (
 	InternalCertSecretName = "internal-tls-certs"
 	//CABundleSecretName -
 	CABundleSecretName = "combined-ca-bundle"
+	// ManilaCephExtraMountsPath -
+	ManilaCephExtraMountsPath = "/etc/ceph"
+	// ManilaCephExtraMountsSecretName -
+	ManilaCephExtraMountsSecretName = "ceph"
 )
 
 // ManilaTestData is the data structure used to provide input data to envTest


### PR DESCRIPTION
This change adds a functional test for the Manila `extraMounts`. It ensures we're able to validate the abstraction of `corev1.VolumeSource` struct introduced in `lib-common/storage` module.

Jira: https://issues.redhat.com/browse/OSPRH-11210