### PR TITLE
Fix the JUnitXML reporting

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -16,8 +16,9 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
-reportFormat: XML
-reportName: kuttl-test-manila
+reportFormat: xml
+reportName: kuttl-report-manila
+reportGranularity: test
 namespace: manila-kuttl-tests
 timeout: 180
 parallel: 1

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -5,6 +5,15 @@
     attempts: 1
     required-projects:
       - github.com/openstack-k8s-operators/manila-operator
+    irrelevant-files: &ir_files
+      - .*/*.md
+      - ^\..*$
+      - ^LICENSE$
+      - ^OWNERS$
+      - ^OWNERS_ALIASES$
+      - ^PROJECT$
+      - ^README.md$
+      - tests?\/functional
     vars:
       cifmw_kuttl_tests_env_vars:
         CEPH_HOSTNETWORK: true


### PR DESCRIPTION
- fix the type (it is 'xml' lowercase, not uppercase);
- tune the name a bit to highlight it is a report;
- add the new reportGranularity parameter which will be supported by kuttl 1.20 and will restore the pre-1.17 JUnitXML format (granularity by test case, instead of by step).

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2598
Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/973