### PR TITLE
Fix go.mod checksum mismatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20250408123225-0d9e9b82c41b
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20250408123225-0d9e9b82c41b
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-00010101000000-000000000000
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.0
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20250415060817-dc849adfa27e
 	k8s.io/api v0.29.15
 	k8s.io/apimachinery v0.29.15
 	k8s.io/client-go v0.29.15

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.202504081
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20250408123225-0d9e9b82c41b/go.mod h1:5+v92XC/PRATIiBrhNLEpJ+T4R9JpxBCgRP6QvbfwgE=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20250408123225-0d9e9b82c41b h1:wZLp/dRXbwgW1X0ZGly8RwZuw5cSnavzZg5E7Tn6RT4=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20250408123225-0d9e9b82c41b/go.mod h1:oKvVb28i6wwBR5uQO2B2KMzZnCFTPCUCj31c5Zvz2lo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.6.0 h1:dcSfC4ufrJve8A7jimLL1TtVVBsyGNrXpHCh2m2xDs0=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.6.0/go.mod h1:uW5rfxoe1Cj/4UJgCnhS875o0/jIwjjx078qY16cu0k=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20250415060817-dc849adfa27e h1:42PsCCv8ebk2tCw/ZiWsJJMhI4C3fmdUaatKSOJ0GXk=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20250415060817-dc849adfa27e/go.mod h1:ZgHSxZSgpgHg1FhKPnBm/cqxAJbVFbKiBkqQoRohn3Q=
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20241017142550-a3524acedd49 h1:/7SnnHfGCH/dwuZFNUx54zw4cnwv2w6hjONq16aoowM=
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20241017142550-a3524acedd49/go.mod h1:6Mq2N/KtNFW20L+PQC5qkeK8R8UGadmGBXL8HDY6lcg=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This patch fixes the following error:

```
verifying github.com/openstack-k8s-operators/mariadb-operator/api@v0.6.0: checksum mismatch
  downloaded: h1:fzGnHYRuBAehQTbiPVyjoNtC2eTd7mLVE3+52PUoQsI=
  go.sum:     h1:dcSfC4ufrJve8A7jimLL1TtVVBsyGNrXpHCh2m2xDs0=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum. The bits may have been replaced on the origin server, or an attacker may have intercepted the download attempt.
```

that prevents bumping the existing dependencies and blocks other patches.