### PR TITLE
Use GetDefaultMemcachedSpec test helper from infra-operator

### DIFF
--- a/test/functional/manila_controller_test.go
+++ b/test/functional/manila_controller_test.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
@@ -43,11 +42,7 @@ var _ = Describe("Manila controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
 
 	BeforeEach(func() {
-		memcachedSpec = memcachedv1.MemcachedSpec{
-			MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
-				Replicas: ptr.To[int32](3),
-			},
-		}
+		memcachedSpec = infra.GetDefaultMemcachedSpec()
 	})
 
 	When("Manila CR instance is created", func() {
@@ -1201,11 +1196,7 @@ var _ = Describe("Manila controller", func() {
 		// needs to make it all the way to the end where the mariadb finalizers
 		// are removed from unused accounts since that's part of what we are testing
 		SetupCR: func(accountName types.NamespacedName) {
-			memcachedSpec = memcachedv1.MemcachedSpec{
-				MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
-					Replicas: ptr.To[int32](3),
-				},
-			}
+			memcachedSpec = infra.GetDefaultMemcachedSpec()
 
 			spec := GetDefaultManilaSpec()
 			spec["databaseAccount"] = accountName.Name

--- a/test/functional/manilaapi_controller_test.go
+++ b/test/functional/manilaapi_controller_test.go
@@ -26,18 +26,13 @@ import (
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("ManilaAPI controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
 
 	BeforeEach(func() {
-		memcachedSpec = memcachedv1.MemcachedSpec{
-			MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
-				Replicas: ptr.To[int32](3),
-			},
-		}
+		memcachedSpec = infra.GetDefaultMemcachedSpec()
 		apiSpec := GetDefaultManilaAPISpec()
 		apiSpec["customServiceConfig"] = "foo=bar"
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, manilaTest.MemcachedInstance, memcachedSpec))

--- a/test/functional/manilascheduler_controller_test.go
+++ b/test/functional/manilascheduler_controller_test.go
@@ -26,18 +26,13 @@ import (
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("ManilaScheduler controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
 
 	BeforeEach(func() {
-		memcachedSpec = memcachedv1.MemcachedSpec{
-			MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
-				Replicas: ptr.To[int32](3),
-			},
-		}
+		memcachedSpec = infra.GetDefaultMemcachedSpec()
 		schedSpec := GetDefaultManilaSchedulerSpec()
 		schedSpec["customServiceConfig"] = "foo=bar"
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, manilaTest.MemcachedInstance, memcachedSpec))

--- a/test/functional/manilashare_controller_test.go
+++ b/test/functional/manilashare_controller_test.go
@@ -26,18 +26,13 @@ import (
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("ManilaShare controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
 
 	BeforeEach(func() {
-		memcachedSpec = memcachedv1.MemcachedSpec{
-			MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
-				Replicas: ptr.To[int32](3),
-			},
-		}
+		memcachedSpec = infra.GetDefaultMemcachedSpec()
 		shareSpec := GetDefaultManilaShareSpec()
 		shareSpec["customServiceConfig"] = "foo=bar"
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, manilaTest.MemcachedInstance, memcachedSpec))


### PR DESCRIPTION
This change uses GetDefaultMemcachedSpec test helper from infra-operator to reduce code duplication.