### PR TITLE
Do not update status when reconciler exits due to panic

### DIFF
--- a/controllers/manila_controller.go
+++ b/controllers/manila_controller.go
@@ -157,6 +157,11 @@ func (r *ManilaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -157,6 +157,11 @@ func (r *ManilaAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -136,6 +136,11 @@ func (r *ManilaSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
 			instance.Status.Conditions.Set(

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -137,6 +137,11 @@ func (r *ManilaShareReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {


### PR DESCRIPTION
Currently we use deferred call to always update the status field when Reconcile call exits, which seems correct for any other error except Reconciler exits due to panic.

This change adds a call to recover function and try to handle panic and logs error.

Closes: [OSPRH-16933](https://issues.redhat.com//browse/OSPRH-16933)