### PR TITLE
Remove localtime hostMount

### DIFF
--- a/pkg/manila/volumes.go
+++ b/pkg/manila/volumes.go
@@ -23,14 +23,6 @@ func GetVolumes(name string, extraVol []manilav1.ManilaExtraVolMounts, svc []sto
 			},
 		},
 		{
-			Name: "etc-localtime",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/localtime",
-				},
-			},
-		},
-		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
@@ -71,11 +63,6 @@ func GetVolumeMounts(extraVol []manilav1.ManilaExtraVolMounts, svc []storage.Pro
 		{
 			Name:      "etc-machine-id",
 			MountPath: "/etc/machine-id",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "etc-localtime",
-			MountPath: "/etc/localtime",
 			ReadOnly:  true,
 		},
 		{

--- a/test/functional/manila_controller_test.go
+++ b/test/functional/manila_controller_test.go
@@ -593,7 +593,7 @@ var _ = Describe("Manila controller", func() {
 			// Check the resulting deployment fieldsq
 			Expect(int(*d.Spec.Replicas)).To(Equal(1))
 
-			Expect(d.Spec.Template.Spec.Volumes).To(HaveLen(9))
+			Expect(d.Spec.Template.Spec.Volumes).To(HaveLen(8))
 			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 			// cert deployment volumes
@@ -1182,13 +1182,13 @@ var _ = Describe("Manila controller", func() {
 			ss := th.GetStatefulSet(share)
 			// Check the resulting deployment fields
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
-			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(7))
+			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(6))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 			// Get the manila-share container
 			container := ss.Spec.Template.Spec.Containers[1]
 			// Fail if manila-share doesn't have the right number of
 			// VolumeMounts entries
-			Expect(container.VolumeMounts).To(HaveLen(9))
+			Expect(container.VolumeMounts).To(HaveLen(8))
 			// Inspect VolumeMounts and make sure we have the Ceph MountPath
 			// provided through extraMounts
 			th.AssertVolumeMountPathExists(ManilaCephExtraMountsSecretName,

--- a/test/functional/manilaapi_controller_test.go
+++ b/test/functional/manilaapi_controller_test.go
@@ -133,11 +133,11 @@ var _ = Describe("ManilaAPI controller", func() {
 				ss := th.GetStatefulSet(manilaTest.ManilaAPI)
 				// Check the resulting deployment fields
 				Expect(int(*ss.Spec.Replicas)).To(Equal(1))
-				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(6))
+				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(5))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 				container := ss.Spec.Template.Spec.Containers[1]
-				Expect(container.VolumeMounts).To(HaveLen(8))
+				Expect(container.VolumeMounts).To(HaveLen(7))
 				Expect(container.Image).To(Equal(manilaTest.ContainerImage))
 				Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(8786)))
 				Expect(container.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(8786)))

--- a/test/functional/manilascheduler_controller_test.go
+++ b/test/functional/manilascheduler_controller_test.go
@@ -134,11 +134,11 @@ var _ = Describe("ManilaScheduler controller", func() {
 				ss := th.GetStatefulSet(manilaTest.ManilaScheduler)
 				// Check the resulting deployment fields
 				Expect(int(*ss.Spec.Replicas)).To(Equal(1))
-				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(5))
+				Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(4))
 				Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 				container := ss.Spec.Template.Spec.Containers[1]
-				Expect(container.VolumeMounts).To(HaveLen(7))
+				Expect(container.VolumeMounts).To(HaveLen(6))
 				Expect(container.Image).To(Equal(manilaTest.ContainerImage))
 			})
 			It("stored the input hash in the Status", func() {

--- a/test/functional/manilashare_controller_test.go
+++ b/test/functional/manilashare_controller_test.go
@@ -147,11 +147,11 @@ var _ = Describe("ManilaShare controller", func() {
 					ss := th.GetStatefulSet(share)
 					// Check the resulting deployment fields
 					Expect(int(*ss.Spec.Replicas)).To(Equal(1))
-					Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(6))
+					Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(5))
 					Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 					container := ss.Spec.Template.Spec.Containers[1]
-					Expect(container.VolumeMounts).To(HaveLen(8))
+					Expect(container.VolumeMounts).To(HaveLen(7))
 					Expect(container.Image).To(Equal(manilaTest.ContainerImage))
 
 					// the input hash is stored in the current manilaShare.Status

--- a/test/kuttl/tests/manila-tls/03-assert.yaml
+++ b/test/kuttl/tests/manila-tls/03-assert.yaml
@@ -269,9 +269,6 @@ spec:
         - mountPath: /etc/machine-id
           name: etc-machine-id
           readOnly: true
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /var/lib/config-data/default
           name: config-data
         - mountPath: /usr/local/bin/container-scripts
@@ -312,9 +309,6 @@ spec:
       - name: etc-machine-id
         hostPath:
           path: /etc/machine-id
-      - name: etc-localtime
-        hostPath:
-          path: /etc/localtime
       - name: scripts
         secret:
           secretName: manila-scripts
@@ -369,9 +363,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/machine-id
           name: etc-machine-id
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /var/lib/config-data/default
           name: config-data
           readOnly: true
@@ -405,9 +396,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/machine-id
           name: etc-machine-id
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /var/lib/config-data/default
           name: config-data
           readOnly: true
@@ -438,9 +426,6 @@ spec:
         - name: etc-machine-id
           hostPath:
             path: /etc/machine-id
-        - name: etc-localtime
-          hostPath:
-            path: /etc/localtime
         - name: scripts
           secret:
             secretName: manila-scripts
@@ -490,9 +475,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/machine-id
           name: etc-machine-id
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /var/lib/config-data/default
           name: config-data
           readOnly: true
@@ -522,9 +504,6 @@ spec:
         - mountPath: /etc/machine-id
           name: etc-machine-id
           readOnly: true
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /var/lib/config-data/default
           name: config-data
           readOnly: true
@@ -550,9 +529,6 @@ spec:
         - name: etc-machine-id
           hostPath:
             path: /etc/machine-id
-        - name: etc-localtime
-          hostPath:
-            path: /etc/localtime
         - name: scripts
           secret:
             secretName: manila-scripts


### PR DESCRIPTION
`Manila` `Pods` shouldn't inherit `/etc/localtime` from the worker node/host where the `Pod` is scheduled. Mounting that volume has several drawbacks, and one of them is having these `Pods` not aligned with the rest of the control plane other than establish a dependency with the underlying host. It results difficult to track requests in case of troubleshooting and as per [1] the current approach is not recommended.
Because there is no reason to modify `localtime` to match the underlying host, this patch fixes the bug by removing it.

Jira: https://issues.redhat.com/browse/OSPRH-17676

[1] https://access.redhat.com/solutions/5487331