### PR TITLE
Add oslo_reports file_event_handler config option

### DIFF
--- a/templates/manila/config/00-config.conf
+++ b/templates/manila/config/00-config.conf
@@ -93,3 +93,6 @@ enforce_scope = true
 share_driver = manila.tests.share.drivers.dummy.DummyDriver
 share_backend_name = alpha
 driver_handles_share_servers = False
+
+[oslo_reports]
+file_event_handler=/var/lib/manila


### PR DESCRIPTION
`openstack-must-gather` is able to trigger `GMR` for many services. `Manila` is being added through [1], and, as done with `cinder`, this patch adds a default `file_event_handler` path to point to `/var/lib/manila` that we know is chowned to `manila:manila` by [3].

[1] https://github.com/openstack-k8s-operators/openstack-must-gather/pull/104
[2] https://github.com/openstack-k8s-operators/tcib/blob/main/container-images/kolla/base/uid_gid_manage.sh#L56

Jira: https://issues.redhat.com/browse/OSPRH-19720