### PR TITLE
Align and remove omitempty from databaseInstance

### DIFF
--- a/api/bases/manila.openstack.org_manilas.yaml
+++ b/api/bases/manila.openstack.org_manilas.yaml
@@ -1780,6 +1780,7 @@ spec:
                     type: string
                 type: object
             required:
+            - databaseInstance
             - manilaAPI
             - manilaScheduler
             - memcachedInstance

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -74,7 +74,7 @@ type ManilaSpecBase struct {
 	// MariaDB instance name
 	// Right now required by the maridb-operator to get the credentials from the instance to create the DB
 	// Might not be required in future
-	DatabaseInstance string `json:"databaseInstance,omitempty"`
+	DatabaseInstance string `json:"databaseInstance"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=rabbitmq

--- a/config/crd/bases/manila.openstack.org_manilas.yaml
+++ b/config/crd/bases/manila.openstack.org_manilas.yaml
@@ -1780,6 +1780,7 @@ spec:
                     type: string
                 type: object
             required:
+            - databaseInstance
             - manilaAPI
             - manilaScheduler
             - memcachedInstance


### PR DESCRIPTION
For adoption testing a ctlplane with disabled manila gets applied:

~~~
  manila:
    enabled: false
    template:
      manilaAPI: {}
      manilaScheduler: {}
      manilaShares: {}
~~~

This fails with because the manila databaseInstance parameter has omitempty specified:

~~~
$ oc apply -f ./test_deployment.yaml
The OpenStackControlPlane "openstack" is invalid:
* spec.manila.template.databaseInstance: Required value
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation ~~~

This aligns the databaseInstance parameter and removes the omitempty like it is speficied in all other service operators.