### PR TITLE
[OSPRH-20340] Improve consistency of condition severity usage

### DIFF
--- a/controllers/manila_common.go
+++ b/controllers/manila_common.go
@@ -114,11 +114,13 @@ func ensureNAD(
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, helper.GetBeforeObject().GetNamespace())
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				log.FromContext(ctx).Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				conditionUpdater.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return serviceAnnotations, manila.ResultRequeue, nil
@@ -173,11 +175,13 @@ func verifyServiceSecret(
 			err.Error()))
 		return res, err
 	} else if (res != ctrl.Result{}) {
+		// Since the service secret should have been manually created by the user and referenced in the spec,
+		// we treat this as a warning because it means that the service will not be able to start.
 		log.FromContext(ctx).Info(fmt.Sprintf("OpenStack secret %s not found", secretName))
 		conditionUpdater.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
+			condition.ErrorReason,
+			condition.SeverityWarning,
 			condition.InputReadyWaitingMessage))
 		return res, nil
 	}
@@ -205,11 +209,14 @@ func verifyConfigSecrets(
 		_, hash, err = secret.GetSecret(ctx, h, secretName, namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since config secrets should have been previously automatically created by the parent
+				// Manila CR and then referenced in this instance's spec, we treat this as a warning
+				// because it means that the service will not be able to start.
 				log.FromContext(ctx).Info(fmt.Sprintf("Secret %s not found", secretName))
 				conditionUpdater.Set(condition.FalseCondition(
 					condition.InputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.InputReadyWaitingMessage))
 				return manila.ResultRequeue, nil
 			}

--- a/controllers/manilaapi_controller.go
+++ b/controllers/manilaapi_controller.go
@@ -740,10 +740,12 @@ func (r *ManilaAPIReconciler) reconcileNormal(ctx context.Context, instance *man
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}

--- a/controllers/manilascheduler_controller.go
+++ b/controllers/manilascheduler_controller.go
@@ -423,10 +423,12 @@ func (r *ManilaSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, err.Error()))
 				return ctrl.Result{}, nil
 			}

--- a/controllers/manilashare_controller.go
+++ b/controllers/manilashare_controller.go
@@ -423,10 +423,12 @@ func (r *ManilaShareReconciler) reconcileNormal(ctx context.Context, instance *m
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, err.Error()))
 				return ctrl.Result{}, nil
 			}


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20340

Co-authored-by: Claude (Anthropic) claude@anthropic.com