### PR TITLE
Make share v1 endpoint optional

### DIFF
--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -31,6 +31,9 @@ const (
 	SvcCleanupHash = "servicecleanup"
 	// DeploymentHash hash used to detect changes
 	DeploymentHash = "deployment"
+	// ManilaV1Label - Label set as Annotation to tell whether manila registers
+	// share v1 endpoints or not
+	ManilaShareV1Label = "manila.openstack.org/sharev1"
 )
 
 // ManilaSpec defines the desired state of Manila

--- a/api/v1beta1/manila_types.go
+++ b/api/v1beta1/manila_types.go
@@ -31,8 +31,8 @@ const (
 	SvcCleanupHash = "servicecleanup"
 	// DeploymentHash hash used to detect changes
 	DeploymentHash = "deployment"
-	// ManilaV1Label - Label set as Annotation to tell whether manila registers
-	// share v1 endpoints or not
+	// ManilaShareV1Label - Label set as an Annotation to tell whether manila
+	// needs to register share v1 endpoints or not
 	ManilaShareV1Label = "manila.openstack.org/sharev1"
 )
 

--- a/api/v1beta1/manilaapi_types.go
+++ b/api/v1beta1/manilaapi_types.go
@@ -20,6 +20,7 @@ import (
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/annotations"
 
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,4 +176,20 @@ func (instance *ManilaAPI) GetLastAppliedTopology() *topologyv1.TopoRef {
 // SetLastAppliedTopology - Sets the LastAppliedTopology value in the Status
 func (instance *ManilaAPI) SetLastAppliedTopology(topologyRef *topologyv1.TopoRef) {
 	instance.Status.LastAppliedTopology = topologyRef
+}
+
+// IsShareV1Enabled - Returns false when sharev1 is explicitly disabled
+func (instance *ManilaAPI) IsShareV1Enabled() (bool, error) {
+	shareV1API, exists, err := annotations.GetBoolFromAnnotation(
+		instance.GetAnnotations(), ManilaShareV1Label)
+	if err != nil {
+		return true, err
+	}
+	// By default shareV1API is enabled to keep backward compatible with
+	// existing deployments.
+	// (Note) we can modify this if statement in 19 to reverse the behavior
+	if !exists {
+		return true, nil
+	}
+	return shareV1API, nil
 }

--- a/api/v1beta1/manilaapi_types.go
+++ b/api/v1beta1/manilaapi_types.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/openstack-k8s-operators/lib-common/modules/common/annotations"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/annotations"
 
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/manila_controller.go
+++ b/internal/controller/manila_controller.go
@@ -1198,8 +1198,9 @@ func (r *ManilaReconciler) createHashOfInputHashes(
 func (r *ManilaReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, instance *manilav1beta1.Manila) (*manilav1beta1.ManilaAPI, controllerutil.OperationResult, error) {
 	deployment := &manilav1beta1.ManilaAPI{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-api", instance.Name),
-			Namespace: instance.Namespace,
+			Name:        fmt.Sprintf("%s-api", instance.Name),
+			Namespace:   instance.Namespace,
+			Annotations: instance.GetAnnotations(),
 		},
 	}
 

--- a/internal/controller/manilaapi_controller.go
+++ b/internal/controller/manilaapi_controller.go
@@ -473,8 +473,8 @@ func (r *ManilaAPIReconciler) reconcileInit(
 		service.EndpointInternal: internalEndpointData,
 	}
 
-	apiEndpointsV1 := make(map[string]string)
 	apiEndpointsV2 := make(map[string]string)
+	apiEndpointsV1 := make(map[string]string)
 
 	for _, endpointType := range slices.Sorted(maps.Keys(data)) {
 		data := data[endpointType]
@@ -577,10 +577,7 @@ func (r *ManilaAPIReconciler) reconcileInit(
 			return ctrl.Result{}, err
 		}
 
-		// V1 (Deprected, non micro-versioned API endpoint, here for legacy users)
-		// will be removed when the upstream service (and dependencies) drop it
-		apiEndpointsV1[string(endpointType)], err = svc.GetAPIEndpoint(
-			svcOverride.EndpointURL, data.Protocol, "/v1/%(project_id)s")
+		v1Enabled, err := instance.IsShareV1Enabled()
 		if err != nil {
 			instance.Status.Conditions.MarkFalse(
 				condition.CreateServiceReadyCondition,
@@ -589,6 +586,22 @@ func (r *ManilaAPIReconciler) reconcileInit(
 				condition.CreateServiceReadyErrorMessage,
 				err.Error())
 			return ctrl.Result{}, err
+		}
+
+		if v1Enabled {
+			// V1 (Deprected, non micro-versioned API endpoint, here for legacy users)
+			// will be removed when the upstream service (and dependencies) drop it
+			apiEndpointsV1[string(endpointType)], err = svc.GetAPIEndpoint(
+				svcOverride.EndpointURL, data.Protocol, "/v1/%(project_id)s")
+			if err != nil {
+				instance.Status.Conditions.MarkFalse(
+					condition.CreateServiceReadyCondition,
+					condition.ErrorReason,
+					condition.SeverityWarning,
+					condition.CreateServiceReadyErrorMessage,
+					err.Error())
+				return ctrl.Result{}, err
+			}
 		}
 	}
 

--- a/internal/controller/manilaapi_controller.go
+++ b/internal/controller/manilaapi_controller.go
@@ -476,6 +476,19 @@ func (r *ManilaAPIReconciler) reconcileInit(
 	apiEndpointsV2 := make(map[string]string)
 	apiEndpointsV1 := make(map[string]string)
 
+	// Determine if sharev1 endpoints should be created
+	// based on the annotation and the logic behind
+	v1Enabled, err := instance.IsShareV1Enabled()
+	if err != nil {
+		instance.Status.Conditions.MarkFalse(
+			condition.CreateServiceReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.CreateServiceReadyErrorMessage,
+			err.Error())
+		return ctrl.Result{}, err
+	}
+
 	for _, endpointType := range slices.Sorted(maps.Keys(data)) {
 		data := data[endpointType]
 		endpointTypeStr := string(endpointType)
@@ -577,19 +590,8 @@ func (r *ManilaAPIReconciler) reconcileInit(
 			return ctrl.Result{}, err
 		}
 
-		v1Enabled, err := instance.IsShareV1Enabled()
-		if err != nil {
-			instance.Status.Conditions.MarkFalse(
-				condition.CreateServiceReadyCondition,
-				condition.ErrorReason,
-				condition.SeverityWarning,
-				condition.CreateServiceReadyErrorMessage,
-				err.Error())
-			return ctrl.Result{}, err
-		}
-
 		if v1Enabled {
-			// V1 (Deprected, non micro-versioned API endpoint, here for legacy users)
+			// V1 (Deprecated, non micro-versioned API endpoint, here for legacy users)
 			// will be removed when the upstream service (and dependencies) drop it
 			apiEndpointsV1[string(endpointType)], err = svc.GetAPIEndpoint(
 				svcOverride.EndpointURL, data.Protocol, "/v1/%(project_id)s")
@@ -605,6 +607,8 @@ func (r *ManilaAPIReconciler) reconcileInit(
 		}
 	}
 
+	// NOTE: when v1Enabled is false (sharev1 is disabled), apiEndpointsV1
+	// is not populated and the associated endpoint is not created.
 	apiEndpoints := map[string]map[string]string{
 		manila.ServiceNameV2: apiEndpointsV2,
 		manila.ServiceName:   apiEndpointsV1,
@@ -617,6 +621,11 @@ func (r *ManilaAPIReconciler) reconcileInit(
 	// create service and user in keystone - - https://docs.openstack.org/manila/ocata/adminref/quick_start.html
 	//
 	for _, ksSvc := range keystoneServices {
+		// if sharev1 is not enabled no need to create the associated
+		// "share" service
+		if ksSvc["name"] == manila.ServiceName && !v1Enabled {
+			continue
+		}
 		ksSvcSpec := keystonev1.KeystoneServiceSpec{
 			ServiceType:        ksSvc["type"],
 			ServiceName:        ksSvc["name"],

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -153,14 +153,15 @@ func GetManila(name types.NamespacedName) *manilav1.Manila {
 	return instance
 }
 
-func CreateManila(name types.NamespacedName, spec map[string]any) client.Object {
+func CreateManila(name types.NamespacedName, spec map[string]any, annotations map[string]string) client.Object {
 
 	raw := map[string]any{
 		"apiVersion": "manila.openstack.org/v1beta1",
 		"kind":       "Manila",
 		"metadata": map[string]any{
-			"name":      name.Name,
-			"namespace": name.Namespace,
+			"name":        name.Name,
+			"namespace":   name.Namespace,
+			"annotations": annotations,
 		},
 		"spec": spec,
 	}

--- a/test/functional/manila_controller_test.go
+++ b/test/functional/manila_controller_test.go
@@ -43,14 +43,16 @@ import (
 
 var _ = Describe("Manila controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
+	var annotations map[string]string
 
 	BeforeEach(func() {
 		memcachedSpec = infra.GetDefaultMemcachedSpec()
+		annotations = map[string]string{}
 	})
 
 	When("Manila CR instance is created", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 		})
 		It("initializes the status fields", func() {
 			Eventually(func(g Gomega) {
@@ -146,7 +148,7 @@ var _ = Describe("Manila controller", func() {
 	When("Manila DB is created", func() {
 		BeforeEach(func() {
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 			DeferCleanup(
 				mariadb.DeleteDBService,
 				mariadb.CreateDBService(
@@ -216,10 +218,10 @@ var _ = Describe("Manila controller", func() {
 				CreateManilaInvalidSecret(manilaName.Namespace, manilaTest.ManilaInvalidSecretName))
 			spec := GetManilaEmptySpec()
 			spec["secret"] = manilaTest.ManilaInvalidSecretName
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(
 				manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 			DeferCleanup(
 				mariadb.DeleteDBService,
 				mariadb.CreateDBService(
@@ -248,7 +250,7 @@ var _ = Describe("Manila controller", func() {
 	})
 	When("Both TransportURL secret and osp-secret are available", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(mariadb.DeleteDBService, mariadb.CreateDBService(
 				manilaTest.Instance.Namespace,
@@ -282,7 +284,7 @@ var _ = Describe("Manila controller", func() {
 		BeforeEach(func() {
 			// ManilaEmptySpec is used to provide a standard Manila CR where no
 			// field is customized
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetManilaEmptySpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetManilaEmptySpec(), annotations))
 		})
 		It("has the expected container image defaults", func() {
 			manilaDefault := GetManila(manilaTest.Instance)
@@ -296,7 +298,7 @@ var _ = Describe("Manila controller", func() {
 	When("All the Resources are ready", func() {
 		var keystoneAPIName types.NamespacedName
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(th.DeleteInstance, CreateManilaAPI(manilaTest.Instance, GetDefaultManilaAPISpec()))
 			DeferCleanup(th.DeleteInstance, CreateManilaScheduler(manilaTest.Instance, GetDefaultManilaSchedulerSpec()))
@@ -374,7 +376,7 @@ var _ = Describe("Manila controller", func() {
 	})
 	When("Manila CR instance is deleted", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -452,7 +454,7 @@ var _ = Describe("Manila controller", func() {
 					},
 				},
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -539,9 +541,49 @@ var _ = Describe("Manila controller", func() {
 			Expect(endpoints).To(HaveKeyWithValue("internal", "http://manila-internal."+manila.Namespace+".svc:8786/v2"))
 		})
 	})
+	When("Manila CR instance is created with sharev1: false annotation", func() {
+		BeforeEach(func() {
+			spec := GetDefaultManilaSpec()
+
+			// Explicitly disable sharev1 annotation before creating the Manila CR
+			annotations["manila.openstack.org/sharev1"] = "false"
+
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
+			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
+			DeferCleanup(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
+					manilaTest.Instance.Namespace,
+					GetManila(manilaTest.Instance).Spec.DatabaseInstance,
+					corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Port: 3306}},
+					},
+				),
+			)
+			infra.SimulateTransportURLReady(manilaTest.ManilaTransportURL)
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, manilaTest.MemcachedInstance, memcachedSpec))
+			infra.SimulateMemcachedReady(manilaTest.ManilaMemcached)
+			keystoneAPIName := keystone.CreateKeystoneAPI(manilaTest.Instance.Namespace)
+			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPIName)
+			mariadb.SimulateMariaDBDatabaseCompleted(manilaTest.ManilaDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(manilaTest.ManilaDatabaseAccount)
+			th.SimulateJobSuccess(manilaTest.ManilaDBSync)
+		})
+		It("Check the resulting endpoints (sharev1 disabled)", func() {
+			// Retrieve the generated resources
+			manilaCR := GetManila(manilaTest.Instance)
+			keystoneEndpoint := keystone.GetKeystoneEndpoint(types.NamespacedName{Namespace: manilaCR.Namespace, Name: manila.ServiceNameV2})
+			endpoints := keystoneEndpoint.Spec.Endpoints
+			// sharev1 service is not created, therefore there's no "manila" endpoint key (only manilav2)
+			Expect(endpoints).ToNot(HaveKey(manila.ServiceName))
+			// sharev2 service exists and has endpoints associated
+			Expect(endpoints).To(HaveKeyWithValue("public", "http://manila-public."+manilaCR.Namespace+".svc:8786/v2"))
+			Expect(endpoints).To(HaveKeyWithValue("internal", "http://manila-internal."+manilaCR.Namespace+".svc:8786/v2"))
+		})
+	})
 	When("A Manila with TLS is created", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetTLSManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetTLSManilaSpec(), annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(th.DeleteInstance, CreateManilaAPI(manilaTest.Instance, GetDefaultManilaAPISpec()))
 			DeferCleanup(th.DeleteInstance, CreateManilaScheduler(manilaTest.Instance, GetDefaultManilaSchedulerSpec()))
@@ -743,7 +785,7 @@ var _ = Describe("Manila controller", func() {
 			spec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -982,7 +1024,7 @@ var _ = Describe("Manila controller", func() {
 			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -1188,7 +1230,7 @@ var _ = Describe("Manila controller", func() {
 					},
 				},
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -1262,7 +1304,7 @@ var _ = Describe("Manila controller", func() {
 					},
 				},
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -1379,7 +1421,7 @@ var _ = Describe("Manila controller", func() {
 
 	When("Manila is created with quorum queues enabled in transport secret", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 			DeferCleanup(k8sClient.Delete, ctx, infra.CreateTransportURLSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName, true))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -1472,7 +1514,7 @@ var _ = Describe("Manila controller", func() {
 
 	When("Manila is created with quorum queues disabled in transport secret", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 			DeferCleanup(k8sClient.Delete, ctx, infra.CreateTransportURLSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName, false))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -1532,7 +1574,7 @@ var _ = Describe("Manila controller", func() {
 					},
 				},
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -1586,7 +1628,7 @@ var _ = Describe("Manila controller", func() {
 					},
 				},
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, rawSpec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.NotificationSecretName))
 			DeferCleanup(
@@ -1624,7 +1666,7 @@ var _ = Describe("Manila controller", func() {
 
 	When("Manila is created with default RabbitMQ config", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -1673,7 +1715,7 @@ var _ = Describe("Manila controller", func() {
 
 			spec := GetDefaultManilaSpec()
 			spec["databaseAccount"] = accountName.Name
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(th.DeleteInstance, CreateManilaAPI(manilaTest.Instance, GetDefaultManilaAPISpec()))
 			DeferCleanup(th.DeleteInstance, CreateManilaScheduler(manilaTest.Instance, GetDefaultManilaSchedulerSpec()))
@@ -1755,7 +1797,7 @@ var _ = Describe("Manila controller", func() {
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(manilaTest.Instance.Namespace))
 
 			spec := GetManilaSpecWithAC(acSecretName, servicePasswordSecret)
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(
 				mariadb.DeleteDBService,
 				mariadb.CreateDBService(
@@ -2026,9 +2068,11 @@ var _ = Describe("Manila Webhook", func() {
 
 var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
+	var annotations map[string]string
 
 	BeforeEach(func() {
 		memcachedSpec = infra.GetDefaultMemcachedSpec()
+		annotations = map[string]string{}
 	})
 
 	When("Manila is created with custom RabbitMQ vhost and user", func() {
@@ -2038,7 +2082,7 @@ var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 				"user":  "custom-user",
 				"vhost": "custom-vhost",
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -2068,7 +2112,7 @@ var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 
 	When("Manila is created with default RabbitMQ configuration", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec()))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetDefaultManilaSpec(), annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -2102,7 +2146,7 @@ var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 			spec["messagingBus"] = map[string]any{
 				"user": "custom-user-only",
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -2136,7 +2180,7 @@ var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 			spec["messagingBus"] = map[string]any{
 				"vhost": "custom-vhost-only",
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -2171,7 +2215,7 @@ var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 				"user":  "initial-user",
 				"vhost": "initial-vhost",
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,
@@ -2225,7 +2269,7 @@ var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 			spec["notificationsBus"] = map[string]any{
 				"cluster": "rabbitmq-notifications",
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, "rabbitmq-notifications-secret"))
 			DeferCleanup(
@@ -2282,7 +2326,7 @@ var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 				"user":    "notifications-user",
 				"vhost":   "notifications-vhost",
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, "rabbitmq-notifications-secret"))
 			DeferCleanup(
@@ -2337,7 +2381,7 @@ var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 			spec["notificationsBus"] = map[string]any{
 				"cluster": "rabbitmq-notifications",
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, "rabbitmq-notifications-secret"))
 			DeferCleanup(
@@ -2394,7 +2438,7 @@ var _ = Describe("Manila with RabbitMQ custom vhost and user", func() {
 				"user":    "notifications-user",
 				"vhost":   "notifications-vhost",
 			}
-			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec))
+			DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, spec, annotations))
 			DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
 			DeferCleanup(
 				mariadb.DeleteDBService,

--- a/test/functional/manilaapi_controller_test.go
+++ b/test/functional/manilaapi_controller_test.go
@@ -30,14 +30,16 @@ import (
 
 var _ = Describe("ManilaAPI controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
+	var annotations map[string]string
 
 	BeforeEach(func() {
+		annotations = map[string]string{}
 		memcachedSpec = infra.GetDefaultMemcachedSpec()
 		apiSpec := GetDefaultManilaAPISpec()
 		apiSpec["customServiceConfig"] = "foo=bar"
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, manilaTest.MemcachedInstance, memcachedSpec))
 		DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
-		DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetManilaSpec(apiSpec)))
+		DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetManilaSpec(apiSpec), annotations))
 		DeferCleanup(th.DeleteInstance, CreateManilaAPI(manilaTest.Instance, GetDefaultManilaAPISpec()))
 		DeferCleanup(
 			mariadb.DeleteDBService,

--- a/test/functional/manilascheduler_controller_test.go
+++ b/test/functional/manilascheduler_controller_test.go
@@ -30,14 +30,16 @@ import (
 
 var _ = Describe("ManilaScheduler controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
+	var annotations map[string]string
 
 	BeforeEach(func() {
 		memcachedSpec = infra.GetDefaultMemcachedSpec()
+		annotations = map[string]string{}
 		schedSpec := GetDefaultManilaSchedulerSpec()
 		schedSpec["customServiceConfig"] = "foo=bar"
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, manilaTest.MemcachedInstance, memcachedSpec))
 		DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
-		DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetManilaSpec(schedSpec)))
+		DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetManilaSpec(schedSpec), annotations))
 		DeferCleanup(th.DeleteInstance, CreateManilaScheduler(manilaTest.Instance, GetDefaultManilaSchedulerSpec()))
 		DeferCleanup(
 			mariadb.DeleteDBService,

--- a/test/functional/manilashare_controller_test.go
+++ b/test/functional/manilashare_controller_test.go
@@ -30,14 +30,16 @@ import (
 
 var _ = Describe("ManilaShare controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
+	var annotations map[string]string
 
 	BeforeEach(func() {
 		memcachedSpec = infra.GetDefaultMemcachedSpec()
+		annotations = map[string]string{}
 		shareSpec := GetDefaultManilaShareSpec()
 		shareSpec["customServiceConfig"] = "foo=bar"
 		DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, manilaTest.MemcachedInstance, memcachedSpec))
 		DeferCleanup(k8sClient.Delete, ctx, CreateManilaMessageBusSecret(manilaTest.Instance.Namespace, manilaTest.RabbitmqSecretName))
-		DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetManilaSpec(shareSpec)))
+		DeferCleanup(th.DeleteInstance, CreateManila(manilaTest.Instance, GetManilaSpec(shareSpec), annotations))
 		for _, share := range manilaTest.ManilaShares {
 			DeferCleanup(th.DeleteInstance, CreateManilaShare(share, GetDefaultManilaShareSpec()))
 		}


### PR DESCRIPTION
`v1` endpoints [are removed](https://review.opendev.org/q/topic:%22remove-v1%22+and+project:openstack/manila) from the latest manila version and not used anymore. For this reason we need to conditionally enable them based on the release. Older versions might have them enabled, and we need to preserve **brownfield** deployment for backward compatibility. However, **greenfield** deployments based on the latest version won't have them registered anymore. This patch adds a new annotation that can be used to drive the deployment and support both older and new deployment methods.

Note that by default the patch keep the existing behavior, and they are registered unless the `manila.openstack.org/sharev1: false` annotation is passed.
This will be typically done by the `openstack-operator` (and enabled in a follow up patch).

Jira: https://redhat.atlassian.net/browse/OSPRH-27947