### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/manila/config/00-config.conf
+++ b/templates/manila/config/00-config.conf
@@ -45,6 +45,7 @@ user_domain_name = Default
 project_name = service
 {{- end }}
 interface = internal
+service_type = sharev2
 {{ if (index . "Region") -}}
 region_name = {{ .Region }}
 {{ end -}}


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)