### PR TITLE
Fix client IP logging in Manila API VirtualHost

### DIFF
--- a/templates/manila/config/10-manila_wsgi.conf
+++ b/templates/manila/config/10-manila_wsgi.conf
@@ -19,7 +19,9 @@
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog /dev/stdout combined
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
 
 {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1


### PR DESCRIPTION
The `VirtualHost` `CustomLog` directive was overriding the server-level dual-log setup, causing all requests to be logged with the OpenShift router IP instead of the real client IP from `X-Forwarded-For`.

Add `SetEnvIf` and dual `CustomLog` lines inside the `VirtualHost` block to match the `nova-operator` pattern.

Jira: [OSPRH-32107](https://redhat.atlassian.net/browse/OSPRH-32107)