### PR TITLE
Drop privileged from manila-share StatefulSet

### DIFF
--- a/internal/manila/volumes.go
+++ b/internal/manila/volumes.go
@@ -81,11 +81,6 @@ func GetVolumeMounts(extraVol []manilav1.ManilaExtraVolMounts, svc []storage.Pro
 			SubPath:   "my.cnf",
 			ReadOnly:  true,
 		},
-		/*{
-			Name:      "config-data-merged",
-			MountPath: "/var/lib/config-data/merged",
-			ReadOnly:  false,
-		},*/
 	}
 
 	for _, exv := range extraVol {

--- a/internal/manilashare/statefulset.go
+++ b/internal/manilashare/statefulset.go
@@ -39,7 +39,6 @@ func StatefulSet(
 	topology *topologyv1.Topology,
 	memcached *memcachedv1.Memcached,
 ) (*appsv1.StatefulSet, error) {
-	trueVar := true
 
 	manilaUser := manila.ManilaUserID
 	manilaGroup := manila.ManilaGroupID
@@ -133,7 +132,7 @@ func StatefulSet(
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  &manilaUser,
-								Privileged: &trueVar,
+								RunAsGroup: &manilaGroup,
 							},
 							Env:           env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:  volumeMounts,

--- a/internal/manilashare/volumes.go
+++ b/internal/manilashare/volumes.go
@@ -15,18 +15,8 @@ func GetVolumes(
 	propagationInstanceName string,
 ) []corev1.Volume {
 	var config0644AccessMode int32 = 0644
-	var dirOrCreate = corev1.HostPathDirectoryOrCreate
 
 	shareVolumes := []corev1.Volume{
-		{
-			Name: "var-lib-manila",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/lib/manila",
-					Type: &dirOrCreate,
-				},
-			},
-		},
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
@@ -53,9 +43,6 @@ func GetVolumeMounts(
 			Name:      "config-data-custom",
 			MountPath: "/etc/manila/manila.conf.d",
 			ReadOnly:  true,
-		}, {
-			Name:      "var-lib-manila",
-			MountPath: "/var/lib/manila",
 		},
 		{
 			Name:      "config-data",

--- a/test/functional/manila_controller_test.go
+++ b/test/functional/manila_controller_test.go
@@ -1268,13 +1268,13 @@ var _ = Describe("Manila controller", func() {
 			ss := th.GetStatefulSet(share)
 			// Check the resulting deployment fields
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
-			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(6))
+			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(5))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 			// Get the manila-share container
 			container := ss.Spec.Template.Spec.Containers[1]
 			// Fail if manila-share doesn't have the right number of
 			// VolumeMounts entries
-			Expect(container.VolumeMounts).To(HaveLen(8))
+			Expect(container.VolumeMounts).To(HaveLen(7))
 			// Inspect VolumeMounts and make sure we have the Ceph MountPath
 			// provided through extraMounts
 			th.AssertVolumeMountPathExists(ManilaCephExtraMountsSecretName,

--- a/test/functional/manilashare_controller_test.go
+++ b/test/functional/manilashare_controller_test.go
@@ -149,11 +149,11 @@ var _ = Describe("ManilaShare controller", func() {
 					ss := th.GetStatefulSet(share)
 					// Check the resulting deployment fields
 					Expect(int(*ss.Spec.Replicas)).To(Equal(1))
-					Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(5))
+					Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(4))
 					Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 					container := ss.Spec.Template.Spec.Containers[1]
-					Expect(container.VolumeMounts).To(HaveLen(7))
+					Expect(container.VolumeMounts).To(HaveLen(6))
 					Expect(container.Image).To(Equal(manilaTest.ContainerImage))
 
 					// the input hash is stored in the current manilaShare.Status

--- a/test/kuttl/tests/manila-tls/03-assert.yaml
+++ b/test/kuttl/tests/manila-tls/03-assert.yaml
@@ -380,8 +380,6 @@ spec:
         - mountPath: /etc/manila/manila.conf.d
           name: config-data-custom
           readOnly: true
-        - mountPath: /var/lib/manila
-          name: var-lib-manila
         - mountPath: /var/lib/kolla/config_files/config.json
           name: config-data
           readOnly: true
@@ -413,8 +411,6 @@ spec:
         - mountPath: /etc/manila/manila.conf.d
           name: config-data-custom
           readOnly: true
-        - mountPath: /var/lib/manila
-          name: var-lib-manila
         - mountPath: /var/lib/kolla/config_files/config.json
           name: config-data
           readOnly: true
@@ -436,9 +432,6 @@ spec:
         - name: ceph
           secret:
             secretName: ceph-conf-files
-        - name: var-lib-manila
-          hostPath:
-            path: /var/lib/manila
         - name: config-data-custom
           secret:
             secretName: manila-share-share0-config-data


### PR DESCRIPTION
Unlike some valid use cases for `glance` and `cinder`, we never require a `privileged` `Pod` for `manila-share`.
It can be always run using `Manila` `user` and `kolla` group, which is sufficient to distribute config files and start the service.

Jira: [OSPRH-32347](https://redhat.atlassian.net/browse/OSPRH-32347)