### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/manila_webhook.go
+++ b/api/v1beta1/manila_webhook.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -68,8 +67,6 @@ func SetupDefaults() {
 
 	manilalog.Info("Manila defaults initialized", "defaults", manilaDefaults)
 }
-
-var _ webhook.Defaulter = &Manila{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Manila) Default() {
@@ -187,8 +184,6 @@ func (spec *ManilaSpecBase) validateDeprecatedFieldsUpdate(old ManilaSpecBase, b
 	deprecatedFields := spec.getDeprecatedFields(&old)
 	return common_webhook.ValidateDeprecatedFieldsUpdate(deprecatedFields, basePath)
 }
-
-var _ webhook.Validator = &Manila{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Manila) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.