### PR TITLE
Include ssl.conf in httpd configuration

### DIFF
--- a/templates/manila/config/httpd.conf
+++ b/templates/manila/config/httpd.conf
@@ -21,7 +21,4 @@ CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 ErrorLog /dev/stdout
 
-# XXX: To disable SSL
-#Include conf.d/*.conf
-# If above include is commented include at least the manila wsgi file
-Include conf.d/10-manila_wsgi.conf
+Include conf.d/*.conf


### PR DESCRIPTION
The `ssl.conf` rendered by `lib-common` was placed by `kolla` into `conf.d/` but never loaded because the Include `conf.d/*.conf` directive was commented out. This left global `SSL` hardening settings (cipher suite, protocol restrictions, session cache) at `mod_ssl` defaults instead of the operator-managed values.

Replace the explicit Include of `10-manila_wsgi.conf` with the `conf.d` wildcard so both `ssl.conf` and the `wsgi vhost` config are loaded.

Jira: https://redhat.atlassian.net/browse/OSPRH-34153